### PR TITLE
[chore] 도메인 엔티티 및 mapper 추가

### DIFF
--- a/src/main/java/konkuk/thip/book/adapter/out/mapper/BookMapper.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/mapper/BookMapper.java
@@ -1,8 +1,39 @@
 package konkuk.thip.book.adapter.out.mapper;
 
+import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.domain.Book;
 import org.springframework.stereotype.Component;
 
 @Component
 public class BookMapper {
 
+    public BookJpaEntity toJpaEntity(Book book) {
+        return BookJpaEntity.builder()
+                .title(book.getTitle())
+                .isbn(book.getIsbn())
+                .authorName(book.getAuthorName())
+                .bestSeller(book.isBestSeller())
+                .publisher(book.getPublisher())
+                .imageUrl(book.getImageUrl())
+                .pageCount(book.getPageCount())
+                .description(book.getDescription())
+                .build();
+    }
+
+    public Book toDomainEntity(BookJpaEntity bookJpaEntity) {
+        return Book.builder()
+                .id(bookJpaEntity.getBookId())
+                .title(bookJpaEntity.getTitle())
+                .isbn(bookJpaEntity.getIsbn())
+                .authorName(bookJpaEntity.getAuthorName())
+                .bestSeller(bookJpaEntity.isBestSeller())
+                .publisher(bookJpaEntity.getPublisher())
+                .imageUrl(bookJpaEntity.getImageUrl())
+                .pageCount(bookJpaEntity.getPageCount())
+                .description(bookJpaEntity.getDescription())
+                .createdAt(bookJpaEntity.getCreatedAt())
+                .modifiedAt(bookJpaEntity.getModifiedAt())
+                .status(bookJpaEntity.getStatus())
+                .build();
+    }
 }

--- a/src/main/java/konkuk/thip/book/adapter/out/mapper/CategoryMapper.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/mapper/CategoryMapper.java
@@ -1,0 +1,28 @@
+package konkuk.thip.book.adapter.out.mapper;
+
+import konkuk.thip.book.adapter.out.jpa.CategoryJpaEntity;
+import konkuk.thip.book.domain.Category;
+import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CategoryMapper {
+
+    public CategoryJpaEntity toJpaEntity(Category category, AliasJpaEntity aliasJpaEntity) {
+        return CategoryJpaEntity.builder()
+                .value(category.getValue())
+                .aliasForCategoryJpaEntity(aliasJpaEntity)
+                .build();
+    }
+
+    public Category toDomainEntity(CategoryJpaEntity categoryJpaEntity) {
+        return Category.builder()
+                .id(categoryJpaEntity.getCategoryId())
+                .value(categoryJpaEntity.getValue())
+                .aliasId(categoryJpaEntity.getAliasForCategoryJpaEntity().getAliasId())
+                .createdAt(categoryJpaEntity.getCreatedAt())
+                .modifiedAt(categoryJpaEntity.getModifiedAt())
+                .status(categoryJpaEntity.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/konkuk/thip/book/adapter/out/persistence/CategoryJpaRepository.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/persistence/CategoryJpaRepository.java
@@ -1,0 +1,7 @@
+package konkuk.thip.book.adapter.out.persistence;
+
+import konkuk.thip.book.adapter.out.jpa.CategoryJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryJpaRepository extends JpaRepository<CategoryJpaEntity, Long> {
+}

--- a/src/main/java/konkuk/thip/book/domain/Book.java
+++ b/src/main/java/konkuk/thip/book/domain/Book.java
@@ -1,14 +1,29 @@
 package konkuk.thip.book.domain;
 
-import lombok.Builder;
+import konkuk.thip.common.entity.BaseDomainEntity;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 
 @Getter
-@Builder
-public class Book {
+@SuperBuilder
+public class Book extends BaseDomainEntity {
 
-    /**
-     * 도메인 엔티티 -> 비즈니스 로직 수행
-     */
+    private Long id;
+
+    private String title;
+
+    private String isbn;
+
+    private String authorName;
+
+    private boolean bestSeller;
+
+    private String publisher;
+
+    private String imageUrl;
+
+    private Integer pageCount;
+
+    private String description;
 
 }

--- a/src/main/java/konkuk/thip/book/domain/Category.java
+++ b/src/main/java/konkuk/thip/book/domain/Category.java
@@ -1,0 +1,16 @@
+package konkuk.thip.book.domain;
+
+import konkuk.thip.common.entity.BaseDomainEntity;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class Category extends BaseDomainEntity {
+
+    private Long id;
+
+    private String value;
+
+    private Long aliasId;
+}

--- a/src/main/java/konkuk/thip/comment/adapter/out/mapper/CommentLikeMapper.java
+++ b/src/main/java/konkuk/thip/comment/adapter/out/mapper/CommentLikeMapper.java
@@ -1,0 +1,29 @@
+package konkuk.thip.comment.adapter.out.mapper;
+
+import konkuk.thip.comment.adapter.out.jpa.CommentJpaEntity;
+import konkuk.thip.comment.adapter.out.jpa.CommentLikeJpaEntity;
+import konkuk.thip.comment.domain.CommentLike;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CommentLikeMapper {
+
+    public CommentLikeJpaEntity toJpaEntity(UserJpaEntity userJpaEntity, CommentJpaEntity commentJpaEntity){
+        return CommentLikeJpaEntity.builder()
+                .userJpaEntity(userJpaEntity)
+                .commentJpaEntity(commentJpaEntity)
+                .build();
+    }
+
+    public CommentLike toDomainEntity(CommentLikeJpaEntity commentLikeJpaEntity){
+        return CommentLike.builder()
+                .id(commentLikeJpaEntity.getLikeId())
+                .userId(commentLikeJpaEntity.getUserJpaEntity().getUserId())
+                .targetCommentId(commentLikeJpaEntity.getCommentJpaEntity().getCommentId())
+                .createdAt(commentLikeJpaEntity.getCreatedAt())
+                .modifiedAt(commentLikeJpaEntity.getModifiedAt())
+                .status(commentLikeJpaEntity.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/konkuk/thip/comment/adapter/out/mapper/CommentMapper.java
+++ b/src/main/java/konkuk/thip/comment/adapter/out/mapper/CommentMapper.java
@@ -1,8 +1,35 @@
 package konkuk.thip.comment.adapter.out.mapper;
 
+import konkuk.thip.comment.adapter.out.jpa.CommentJpaEntity;
+import konkuk.thip.comment.domain.Comment;
+import konkuk.thip.room.adapter.out.jpa.PostJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CommentMapper {
 
+    public CommentJpaEntity toJpaEntity(Comment comment, PostJpaEntity postJpaEntity, UserJpaEntity userJpaEntity, CommentJpaEntity commentJpaEntity) {
+        return CommentJpaEntity.builder()
+                .content(comment.getContent())
+                .reportCount(comment.getReportCount())
+                .postJpaEntity(postJpaEntity)
+                .userJpaEntity(userJpaEntity)
+                .parent(commentJpaEntity)
+                .build();
+    }
+
+    public Comment toDomainEntity(CommentJpaEntity commentJpaEntity) {
+        return Comment.builder()
+                .id(commentJpaEntity.getCommentId())
+                .content(commentJpaEntity.getContent())
+                .reportCount(commentJpaEntity.getReportCount())
+                .targetPostId(commentJpaEntity.getPostJpaEntity().getPostId())
+                .creatorId(commentJpaEntity.getUserJpaEntity().getUserId())
+                .parentCommentId(commentJpaEntity.getParent().getCommentId())
+                .createdAt(commentJpaEntity.getCreatedAt())
+                .modifiedAt(commentJpaEntity.getModifiedAt())
+                .status(commentJpaEntity.getStatus())
+                .build();
+    }
 }

--- a/src/main/java/konkuk/thip/comment/adapter/out/mapper/CommentMapper.java
+++ b/src/main/java/konkuk/thip/comment/adapter/out/mapper/CommentMapper.java
@@ -26,7 +26,7 @@ public class CommentMapper {
                 .reportCount(commentJpaEntity.getReportCount())
                 .targetPostId(commentJpaEntity.getPostJpaEntity().getPostId())
                 .creatorId(commentJpaEntity.getUserJpaEntity().getUserId())
-                .parentCommentId(commentJpaEntity.getParent().getCommentId())
+                .parentCommentId(commentJpaEntity.getParent() != null ? commentJpaEntity.getParent().getCommentId() : null)
                 .createdAt(commentJpaEntity.getCreatedAt())
                 .modifiedAt(commentJpaEntity.getModifiedAt())
                 .status(commentJpaEntity.getStatus())

--- a/src/main/java/konkuk/thip/comment/domain/Comment.java
+++ b/src/main/java/konkuk/thip/comment/domain/Comment.java
@@ -1,14 +1,23 @@
 package konkuk.thip.comment.domain;
 
-import lombok.Builder;
+import konkuk.thip.common.entity.BaseDomainEntity;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 
 @Getter
-@Builder
-public class Comment {
+@SuperBuilder
+public class Comment extends BaseDomainEntity {
 
-    /**
-     * 도메인 엔티티 -> 비즈니스 로직 수행
-     */
+    private Long id;
+
+    private String content;
+
+    private int reportCount;
+
+    private Long targetPostId;
+
+    private Long creatorId;
+
+    private Long parentCommentId;
 
 }

--- a/src/main/java/konkuk/thip/comment/domain/CommentLike.java
+++ b/src/main/java/konkuk/thip/comment/domain/CommentLike.java
@@ -1,0 +1,16 @@
+package konkuk.thip.comment.domain;
+
+import konkuk.thip.common.entity.BaseDomainEntity;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class CommentLike extends BaseDomainEntity {
+
+    private Long id;
+
+    private Long userId;
+
+    private Long targetCommentId;
+}

--- a/src/main/java/konkuk/thip/common/entity/BaseDomainEntity.java
+++ b/src/main/java/konkuk/thip/common/entity/BaseDomainEntity.java
@@ -1,0 +1,17 @@
+package konkuk.thip.common.entity;
+
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@Getter
+@SuperBuilder
+public class BaseDomainEntity {
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime modifiedAt;
+
+    private StatusType status;
+}

--- a/src/main/java/konkuk/thip/common/entity/BaseJpaEntity.java
+++ b/src/main/java/konkuk/thip/common/entity/BaseJpaEntity.java
@@ -37,5 +37,5 @@ public abstract class BaseJpaEntity {
     @Setter
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private JpaEntityStatus status = JpaEntityStatus.ACTIVE;
+    private StatusType status = StatusType.ACTIVE;
 }

--- a/src/main/java/konkuk/thip/common/entity/StatusType.java
+++ b/src/main/java/konkuk/thip/common/entity/StatusType.java
@@ -1,5 +1,5 @@
 package konkuk.thip.common.entity;
 
-public enum JpaEntityStatus {
+public enum StatusType {
     ACTIVE, INACTIVE, EXPIRED
 }

--- a/src/main/java/konkuk/thip/feed/adapter/out/jpa/FeedJpaEntity.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/jpa/FeedJpaEntity.java
@@ -20,19 +20,15 @@ public class FeedJpaEntity extends PostJpaEntity {
     @Column(name = "report_count", nullable = false)
     private int reportCount = 0;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id")
-    private PostJpaEntity postJpaEntity;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_id", nullable = false)
     private BookJpaEntity bookJpaEntity;
 
     @Builder
-    public FeedJpaEntity(String content, UserJpaEntity userJpaEntity, Boolean isPublic, BookJpaEntity bookJpaEntity) {
+    public FeedJpaEntity(String content, UserJpaEntity userJpaEntity, Boolean isPublic, int reportCount, BookJpaEntity bookJpaEntity) {
         super(content, userJpaEntity);
         this.isPublic = isPublic;
-        this.reportCount = 0; // Default 값
+        this.reportCount = reportCount;
         this.bookJpaEntity = bookJpaEntity;
     }
 }

--- a/src/main/java/konkuk/thip/feed/adapter/out/mapper/FeedMapper.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/mapper/FeedMapper.java
@@ -1,8 +1,35 @@
 package konkuk.thip.feed.adapter.out.mapper;
 
+import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.feed.adapter.out.jpa.FeedJpaEntity;
+import konkuk.thip.feed.domain.Feed;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import org.springframework.stereotype.Component;
 
 @Component
 public class FeedMapper {
 
+    public FeedJpaEntity toJpaEntity(Feed feed, UserJpaEntity userJpaEntity, BookJpaEntity bookJpaEntity) {
+        return FeedJpaEntity.builder()
+                .content(feed.getContent())
+                .userJpaEntity(userJpaEntity)
+                .isPublic(feed.getIsPublic())
+                .reportCount(feed.getReportCount())
+                .bookJpaEntity(bookJpaEntity)
+                .build();
+    }
+
+    public Feed toDomainEntity(FeedJpaEntity feedJpaEntity) {
+        return Feed.builder()
+                .id(feedJpaEntity.getPostId())
+                .content(feedJpaEntity.getContent())
+                .creatorId(feedJpaEntity.getUserJpaEntity().getUserId())
+                .isPublic(feedJpaEntity.getIsPublic())
+                .reportCount(feedJpaEntity.getReportCount())
+                .targetBookId(feedJpaEntity.getBookJpaEntity().getBookId())
+                .createdAt(feedJpaEntity.getCreatedAt())
+                .modifiedAt(feedJpaEntity.getModifiedAt())
+                .status(feedJpaEntity.getStatus())
+                .build();
+    }
 }

--- a/src/main/java/konkuk/thip/feed/adapter/out/mapper/TagMapper.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/mapper/TagMapper.java
@@ -1,0 +1,31 @@
+package konkuk.thip.feed.adapter.out.mapper;
+
+import konkuk.thip.book.adapter.out.jpa.CategoryJpaEntity;
+import konkuk.thip.feed.adapter.out.jpa.TagJpaEntity;
+import konkuk.thip.feed.domain.Tag;
+import konkuk.thip.room.adapter.out.jpa.PostJpaEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TagMapper {
+
+    public TagJpaEntity toJpaEntity(Tag tag, PostJpaEntity postJpaEntity, CategoryJpaEntity categoryJpaEntity) {
+        return TagJpaEntity.builder()
+                .value(tag.getValue())
+                .postJpaEntity(postJpaEntity)
+                .categoryJpaEntity(categoryJpaEntity)
+                .build();
+    }
+
+    public Tag toDomainEntity(TagJpaEntity tagJpaEntity) {
+        return Tag.builder()
+                .id(tagJpaEntity.getTagId())
+                .value(tagJpaEntity.getValue())
+                .targetPostId(tagJpaEntity.getPostJpaEntity().getPostId())
+                .categoryId(tagJpaEntity.getCategoryJpaEntity().getCategoryId())
+                .createdAt(tagJpaEntity.getCreatedAt())
+                .modifiedAt(tagJpaEntity.getModifiedAt())
+                .status(tagJpaEntity.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/konkuk/thip/feed/domain/Feed.java
+++ b/src/main/java/konkuk/thip/feed/domain/Feed.java
@@ -1,14 +1,23 @@
 package konkuk.thip.feed.domain;
 
-import lombok.Builder;
+import konkuk.thip.common.entity.BaseDomainEntity;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 
 @Getter
-@Builder
-public class Feed {
+@SuperBuilder
+public class Feed extends BaseDomainEntity {
 
-    /**
-     * 도메인 엔티티 -> 비즈니스 로직 수행
-     */
+    private Long id;
+
+    private String content;
+
+    private Long creatorId;
+
+    private Boolean isPublic;
+
+    private int reportCount;
+
+    private Long targetBookId;
 
 }

--- a/src/main/java/konkuk/thip/feed/domain/Tag.java
+++ b/src/main/java/konkuk/thip/feed/domain/Tag.java
@@ -1,0 +1,18 @@
+package konkuk.thip.feed.domain;
+
+import konkuk.thip.common.entity.BaseDomainEntity;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class Tag extends BaseDomainEntity {
+
+    private Long id;
+
+    private String value;
+
+    private Long targetPostId;
+
+    private Long categoryId;
+}

--- a/src/main/java/konkuk/thip/room/adapter/out/jpa/PostJpaEntity.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/jpa/PostJpaEntity.java
@@ -11,7 +11,6 @@ import lombok.*;
 @Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn(name = "dtype")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public abstract class PostJpaEntity extends BaseJpaEntity {
 
     @Id

--- a/src/main/java/konkuk/thip/room/adapter/out/jpa/RecordJpaEntity.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/jpa/RecordJpaEntity.java
@@ -4,13 +4,13 @@ import jakarta.persistence.*;
 import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import lombok.*;
 
-
 @Entity
 @Table(name = "records")
 @DiscriminatorValue("RECORD")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RecordJpaEntity extends PostJpaEntity {
+
     private Integer page;
 
     @Column(name = "is_overview",nullable = false)
@@ -27,5 +27,6 @@ public class RecordJpaEntity extends PostJpaEntity {
         this.isOverview = isOverview;
         this.roomJpaEntity = roomJpaEntity;
     }
+
 }
 

--- a/src/main/java/konkuk/thip/room/adapter/out/jpa/RoomJpaEntity.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/jpa/RoomJpaEntity.java
@@ -2,6 +2,7 @@ package konkuk.thip.room.adapter.out.jpa;
 
 import jakarta.persistence.*;
 import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.adapter.out.jpa.CategoryJpaEntity;
 import konkuk.thip.common.entity.BaseJpaEntity;
 import lombok.*;
 
@@ -48,4 +49,7 @@ public class RoomJpaEntity extends BaseJpaEntity {
     @JoinColumn(name = "book_id")
     private BookJpaEntity bookJpaEntity;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private CategoryJpaEntity categoryJpaEntity;
 }

--- a/src/main/java/konkuk/thip/room/adapter/out/mapper/ContentMapper.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/mapper/ContentMapper.java
@@ -1,0 +1,28 @@
+package konkuk.thip.room.adapter.out.mapper;
+
+import konkuk.thip.room.adapter.out.jpa.ContentJpaEntity;
+import konkuk.thip.room.adapter.out.jpa.PostJpaEntity;
+import konkuk.thip.room.domain.Content;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ContentMapper {
+
+    public ContentJpaEntity toJpaEntity(Content content, PostJpaEntity postJpaEntity) {
+        return ContentJpaEntity.builder()
+                .contentUrl(content.getContentUrl())
+                .postJpaEntity(postJpaEntity)
+                .build();
+    }
+
+    public Content toDomainEntity(ContentJpaEntity contentJpaEntity) {
+        return Content.builder()
+                .id(contentJpaEntity.getContentId())
+                .contentUrl(contentJpaEntity.getContentUrl())
+                .targetPostId(contentJpaEntity.getPostJpaEntity().getPostId())
+                .createdAt(contentJpaEntity.getCreatedAt())
+                .modifiedAt(contentJpaEntity.getModifiedAt())
+                .status(contentJpaEntity.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/konkuk/thip/room/adapter/out/mapper/PostLikeMapper.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/mapper/PostLikeMapper.java
@@ -1,0 +1,29 @@
+package konkuk.thip.room.adapter.out.mapper;
+
+import konkuk.thip.room.adapter.out.jpa.PostJpaEntity;
+import konkuk.thip.room.adapter.out.jpa.PostLikeJpaEntity;
+import konkuk.thip.room.domain.PostLike;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostLikeMapper {
+
+    public PostLikeJpaEntity toJpaEntity(PostJpaEntity postJpaEntity, UserJpaEntity userJpaEntity) {
+        return PostLikeJpaEntity.builder()
+                .postJpaEntity(postJpaEntity)
+                .userJpaEntity(userJpaEntity)
+                .build();
+    }
+
+    public PostLike toDomainEntity(PostLikeJpaEntity postLikeJpaEntity) {
+        return PostLike.builder()
+                .id(postLikeJpaEntity.getLikeId())
+                .targetPostId(postLikeJpaEntity.getPostJpaEntity().getPostId())
+                .userId(postLikeJpaEntity.getUserJpaEntity().getUserId())
+                .createdAt(postLikeJpaEntity.getCreatedAt())
+                .modifiedAt(postLikeJpaEntity.getModifiedAt())
+                .status(postLikeJpaEntity.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/konkuk/thip/room/adapter/out/mapper/RecordMapper.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/mapper/RecordMapper.java
@@ -1,0 +1,35 @@
+package konkuk.thip.room.adapter.out.mapper;
+
+import konkuk.thip.room.adapter.out.jpa.RecordJpaEntity;
+import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
+import konkuk.thip.room.domain.Record;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RecordMapper {
+
+    public RecordJpaEntity toJpaEntity(Record record, UserJpaEntity userJpaEntity, RoomJpaEntity roomJpaEntity) {
+        return RecordJpaEntity.builder()
+                .content(record.getContent())
+                .userJpaEntity(userJpaEntity)
+                .page(record.getPage())
+                .isOverview(record.isOverview())
+                .roomJpaEntity(roomJpaEntity)
+                .build();
+    }
+
+    public Record toDomainEntity(RecordJpaEntity recordJpaEntity) {
+        return Record.builder()
+                .id(recordJpaEntity.getPostId())
+                .content(recordJpaEntity.getContent())
+                .creatorId(recordJpaEntity.getUserJpaEntity().getUserId())
+                .page(recordJpaEntity.getPage())
+                .isOverview(recordJpaEntity.isOverview())
+                .roomId(recordJpaEntity.getRoomJpaEntity().getRoomId())
+                .createdAt(recordJpaEntity.getCreatedAt())
+                .modifiedAt(recordJpaEntity.getModifiedAt())
+                .status(recordJpaEntity.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/konkuk/thip/room/adapter/out/mapper/RoomMapper.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/mapper/RoomMapper.java
@@ -1,8 +1,42 @@
 package konkuk.thip.room.adapter.out.mapper;
 
+import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
+import konkuk.thip.room.domain.Room;
 import org.springframework.stereotype.Component;
 
 @Component
 public class RoomMapper {
 
+    public RoomJpaEntity roomJpaEntity(Room room, BookJpaEntity bookJpaEntity) {
+        return RoomJpaEntity.builder()
+                .title(room.getTitle())
+                .description(room.getDescription())
+                .isPublic(room.isPublic())
+                .password(room.getPassword())
+                .roomPercentage(room.getRoomPercentage())
+                .startDate(room.getStartDate())
+                .endDate(room.getEndDate())
+                .recruitCount(room.getRecruitCount())
+                .bookJpaEntity(bookJpaEntity)
+                .build();
+    }
+
+    public Room toDomainEntity(RoomJpaEntity roomJpaEntity) {
+        return Room.builder()
+                .id(roomJpaEntity.getRoomId())
+                .title(roomJpaEntity.getTitle())
+                .description(roomJpaEntity.getDescription())
+                .isPublic(roomJpaEntity.isPublic())
+                .password(roomJpaEntity.getPassword())
+                .roomPercentage(roomJpaEntity.getRoomPercentage())
+                .startDate(roomJpaEntity.getStartDate())
+                .endDate(roomJpaEntity.getEndDate())
+                .recruitCount(roomJpaEntity.getRecruitCount())
+                .bookId(roomJpaEntity.getBookJpaEntity().getBookId())
+                .createdAt(roomJpaEntity.getCreatedAt())
+                .modifiedAt(roomJpaEntity.getModifiedAt())
+                .status(roomJpaEntity.getStatus())
+                .build();
+    }
 }

--- a/src/main/java/konkuk/thip/room/adapter/out/mapper/RoomMapper.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/mapper/RoomMapper.java
@@ -1,6 +1,7 @@
 package konkuk.thip.room.adapter.out.mapper;
 
 import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.adapter.out.jpa.CategoryJpaEntity;
 import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
 import konkuk.thip.room.domain.Room;
 import org.springframework.stereotype.Component;
@@ -8,7 +9,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class RoomMapper {
 
-    public RoomJpaEntity roomJpaEntity(Room room, BookJpaEntity bookJpaEntity) {
+    public RoomJpaEntity roomJpaEntity(Room room, BookJpaEntity bookJpaEntity, CategoryJpaEntity categoryJpaEntity) {
         return RoomJpaEntity.builder()
                 .title(room.getTitle())
                 .description(room.getDescription())
@@ -19,6 +20,7 @@ public class RoomMapper {
                 .endDate(room.getEndDate())
                 .recruitCount(room.getRecruitCount())
                 .bookJpaEntity(bookJpaEntity)
+                .categoryJpaEntity(categoryJpaEntity)
                 .build();
     }
 
@@ -34,6 +36,7 @@ public class RoomMapper {
                 .endDate(roomJpaEntity.getEndDate())
                 .recruitCount(roomJpaEntity.getRecruitCount())
                 .bookId(roomJpaEntity.getBookJpaEntity().getBookId())
+                .categoryId(roomJpaEntity.getCategoryJpaEntity().getCategoryId())
                 .createdAt(roomJpaEntity.getCreatedAt())
                 .modifiedAt(roomJpaEntity.getModifiedAt())
                 .status(roomJpaEntity.getStatus())

--- a/src/main/java/konkuk/thip/room/adapter/out/mapper/VoteItemMapper.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/mapper/VoteItemMapper.java
@@ -1,0 +1,30 @@
+package konkuk.thip.room.adapter.out.mapper;
+
+import konkuk.thip.room.adapter.out.jpa.VoteItemJpaEntity;
+import konkuk.thip.room.adapter.out.jpa.VoteJpaEntity;
+import konkuk.thip.room.domain.VoteItem;
+import org.springframework.stereotype.Component;
+
+@Component
+public class VoteItemMapper {
+
+    public VoteItemJpaEntity toJpaEntity(VoteItem voteItem, VoteJpaEntity voteJpaEntity) {
+        return VoteItemJpaEntity.builder()
+                .itemName(voteItem.getItemName())
+                .count(voteItem.getCount())
+                .voteJpaEntity(voteJpaEntity)
+                .build();
+    }
+
+    public VoteItem toDomainEntity(VoteItemJpaEntity voteItemJpaEntity) {
+        return VoteItem.builder()
+                .id(voteItemJpaEntity.getVoteItemId())
+                .itemName(voteItemJpaEntity.getItemName())
+                .count(voteItemJpaEntity.getCount())
+                .voteId(voteItemJpaEntity.getVoteJpaEntity().getPostId())
+                .createdAt(voteItemJpaEntity.getCreatedAt())
+                .modifiedAt(voteItemJpaEntity.getModifiedAt())
+                .status(voteItemJpaEntity.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/konkuk/thip/room/adapter/out/mapper/VoteMapper.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/mapper/VoteMapper.java
@@ -1,0 +1,35 @@
+package konkuk.thip.room.adapter.out.mapper;
+
+import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
+import konkuk.thip.room.adapter.out.jpa.VoteJpaEntity;
+import konkuk.thip.room.domain.Vote;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class VoteMapper {
+
+    public VoteJpaEntity toJpaEntity(Vote vote, UserJpaEntity userJpaEntity, RoomJpaEntity roomJpaEntity) {
+        return VoteJpaEntity.builder()
+                .content(vote.getContent())
+                .userJpaEntity(userJpaEntity)
+                .page(vote.getPage())
+                .isOverview(vote.isOverview())
+                .roomJpaEntity(roomJpaEntity)
+                .build();
+    }
+
+    public Vote toDomainEntity(VoteJpaEntity voteJpaEntity) {
+        return Vote.builder()
+                .id(voteJpaEntity.getPostId())
+                .content(voteJpaEntity.getContent())
+                .creatorId(voteJpaEntity.getUserJpaEntity().getUserId())
+                .page(voteJpaEntity.getPage())
+                .isOverview(voteJpaEntity.isOverview())
+                .roomId(voteJpaEntity.getRoomJpaEntity().getRoomId())
+                .createdAt(voteJpaEntity.getCreatedAt())
+                .modifiedAt(voteJpaEntity.getModifiedAt())
+                .status(voteJpaEntity.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/konkuk/thip/room/domain/Content.java
+++ b/src/main/java/konkuk/thip/room/domain/Content.java
@@ -1,0 +1,16 @@
+package konkuk.thip.room.domain;
+
+import konkuk.thip.common.entity.BaseDomainEntity;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class Content extends BaseDomainEntity {
+
+    private Long id;
+
+    private String contentUrl;
+
+    private Long targetPostId;
+}

--- a/src/main/java/konkuk/thip/room/domain/PostLike.java
+++ b/src/main/java/konkuk/thip/room/domain/PostLike.java
@@ -1,0 +1,16 @@
+package konkuk.thip.room.domain;
+
+import konkuk.thip.common.entity.BaseDomainEntity;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class PostLike extends BaseDomainEntity {
+
+    private Long id;
+
+    private Long targetPostId;
+
+    private Long userId;
+}

--- a/src/main/java/konkuk/thip/room/domain/Record.java
+++ b/src/main/java/konkuk/thip/room/domain/Record.java
@@ -1,0 +1,22 @@
+package konkuk.thip.room.domain;
+
+import konkuk.thip.common.entity.BaseDomainEntity;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class Record extends BaseDomainEntity {
+
+    private Long id;
+
+    private String content;
+
+    private Long creatorId;
+
+    private Integer page;
+
+    private boolean isOverview;
+
+    private Long roomId;
+}

--- a/src/main/java/konkuk/thip/room/domain/Room.java
+++ b/src/main/java/konkuk/thip/room/domain/Room.java
@@ -1,14 +1,33 @@
 package konkuk.thip.room.domain;
 
-import lombok.Builder;
+import konkuk.thip.common.entity.BaseDomainEntity;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDate;
 
 @Getter
-@Builder
-public class Room {
+@SuperBuilder
+public class Room extends BaseDomainEntity {
 
-    /**
-     * 도메인 엔티티 -> 비즈니스 로직 수행
-     */
+    private Long id;
+
+    private String title;
+
+    private String description;
+
+    private boolean isPublic;
+
+    private Integer password;
+
+    private double roomPercentage;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    private int recruitCount;
+
+    private Long bookId;
 
 }

--- a/src/main/java/konkuk/thip/room/domain/Room.java
+++ b/src/main/java/konkuk/thip/room/domain/Room.java
@@ -30,4 +30,5 @@ public class Room extends BaseDomainEntity {
 
     private Long bookId;
 
+    private Long categoryId;
 }

--- a/src/main/java/konkuk/thip/room/domain/Vote.java
+++ b/src/main/java/konkuk/thip/room/domain/Vote.java
@@ -1,0 +1,22 @@
+package konkuk.thip.room.domain;
+
+import konkuk.thip.common.entity.BaseDomainEntity;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class Vote extends BaseDomainEntity {
+
+    private Long id;
+
+    private String content;
+
+    private Long creatorId;
+
+    private Integer page;
+
+    private boolean isOverview;
+
+    private Long roomId;
+}

--- a/src/main/java/konkuk/thip/room/domain/VoteItem.java
+++ b/src/main/java/konkuk/thip/room/domain/VoteItem.java
@@ -1,0 +1,18 @@
+package konkuk.thip.room.domain;
+
+import konkuk.thip.common.entity.BaseDomainEntity;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class VoteItem extends BaseDomainEntity {
+
+    private Long id;
+
+    private String itemName;
+
+    private int count;
+
+    private Long voteId;
+}

--- a/src/main/java/konkuk/thip/user/adapter/out/jpa/FollowingJpaEntity.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/jpa/FollowingJpaEntity.java
@@ -15,7 +15,7 @@ public class FollowingJpaEntity extends BaseJpaEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "following_id")
-    private Long following_id;
+    private Long followingId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/konkuk/thip/user/adapter/out/mapper/AliasMapper.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/mapper/AliasMapper.java
@@ -1,0 +1,25 @@
+package konkuk.thip.user.adapter.out.mapper;
+
+import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
+import konkuk.thip.user.domain.Alias;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AliasMapper {
+
+    public AliasJpaEntity toJpaEntity(Alias alias) {
+        return AliasJpaEntity.builder()
+                .value(alias.getValue())
+                .build();
+    }
+
+    public Alias toDomainEntity(AliasJpaEntity aliasJpaEntity) {
+        return Alias.builder()
+                .id(aliasJpaEntity.getAliasId())
+                .value(aliasJpaEntity.getValue())
+                .createdAt(aliasJpaEntity.getCreatedAt())
+                .modifiedAt(aliasJpaEntity.getModifiedAt())
+                .status(aliasJpaEntity.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/konkuk/thip/user/adapter/out/mapper/AttendanceCheckMapper.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/mapper/AttendanceCheckMapper.java
@@ -1,0 +1,32 @@
+package konkuk.thip.user.adapter.out.mapper;
+
+import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.AttendanceCheckJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.domain.AttendanceCheck;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AttendanceCheckMapper {
+
+    public AttendanceCheckJpaEntity toJpaEntity(AttendanceCheck attendanceCheck, RoomJpaEntity roomJpaEntity, UserJpaEntity userJpaEntity) {
+        return AttendanceCheckJpaEntity.builder()
+                .todayComment(attendanceCheck.getTodayComment())
+                .roomJpaEntity(roomJpaEntity)
+                .userJpaEntity(userJpaEntity)
+                .build();
+    }
+
+    public AttendanceCheck toDomainEntity(AttendanceCheckJpaEntity attendanceCheckJpaEntity) {
+        return AttendanceCheck.builder()
+                .id(attendanceCheckJpaEntity.getAttendanceCheckId())
+                .todayComment(attendanceCheckJpaEntity.getTodayComment())
+                .roomId(attendanceCheckJpaEntity.getRoomJpaEntity().getRoomId())
+                .creatorId(attendanceCheckJpaEntity.getUserJpaEntity().getUserId())
+                .createdAt(attendanceCheckJpaEntity.getCreatedAt())
+                .modifiedAt(attendanceCheckJpaEntity.getModifiedAt())
+                .status(attendanceCheckJpaEntity.getStatus())
+                .build();
+    }
+
+}

--- a/src/main/java/konkuk/thip/user/adapter/out/mapper/FollowingMapper.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/mapper/FollowingMapper.java
@@ -1,0 +1,28 @@
+package konkuk.thip.user.adapter.out.mapper;
+
+import konkuk.thip.user.adapter.out.jpa.FollowingJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.domain.Following;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FollowingMapper {
+
+    public FollowingJpaEntity toJpaEntity(UserJpaEntity userJpaEntity, UserJpaEntity followingUserJpaEntity) {
+        return FollowingJpaEntity.builder()
+                .userJpaEntity(userJpaEntity)
+                .followingUserJpaEntity(followingUserJpaEntity)
+                .build();
+    }
+
+    public Following toDomainEntity(FollowingJpaEntity followingJpaEntity) {
+        return Following.builder()
+                .id(followingJpaEntity.getFollowingId())
+                .userId(followingJpaEntity.getUserJpaEntity().getUserId())
+                .followingUserId(followingJpaEntity.getFollowingUserJpaEntity().getUserId())
+                .createdAt(followingJpaEntity.getCreatedAt())
+                .modifiedAt(followingJpaEntity.getModifiedAt())
+                .status(followingJpaEntity.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/konkuk/thip/user/adapter/out/mapper/NotificationMapper.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/mapper/NotificationMapper.java
@@ -1,0 +1,32 @@
+package konkuk.thip.user.adapter.out.mapper;
+
+import konkuk.thip.user.adapter.out.jpa.NotificationJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.domain.Notification;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NotificationMapper {
+
+    public NotificationJpaEntity toJpaEntity(Notification notification, UserJpaEntity userJpaEntity) {
+        return NotificationJpaEntity.builder()
+                .title(notification.getTitle())
+                .content(notification.getContent())
+                .isChecked(notification.isChecked())
+                .userJpaEntity(userJpaEntity)
+                .build();
+    }
+
+    public Notification toDomainEntity(NotificationJpaEntity notificationJpaEntity) {
+        return Notification.builder()
+                .id(notificationJpaEntity.getNotificationId())
+                .title(notificationJpaEntity.getTitle())
+                .content(notificationJpaEntity.getContent())
+                .isChecked(notificationJpaEntity.isChecked())
+                .targetUserId(notificationJpaEntity.getUserJpaEntity().getUserId())
+                .createdAt(notificationJpaEntity.getCreatedAt())
+                .modifiedAt(notificationJpaEntity.getModifiedAt())
+                .status(notificationJpaEntity.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/konkuk/thip/user/adapter/out/mapper/RecentSearchMapper.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/mapper/RecentSearchMapper.java
@@ -1,0 +1,31 @@
+package konkuk.thip.user.adapter.out.mapper;
+
+import konkuk.thip.user.adapter.out.jpa.RecentSearchJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.SearchType;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.domain.RecentSearch;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RecentSearchMapper {
+
+    public RecentSearchJpaEntity toJpaEntity(RecentSearch recentSearch, UserJpaEntity userJpaEntity) {
+        return RecentSearchJpaEntity.builder()
+                .searchTerm(recentSearch.getSearchTerm())
+                .type(SearchType.from(recentSearch.getType()))
+                .userJpaEntity(userJpaEntity)
+                .build();
+    }
+
+    public RecentSearch toDomainEntity(RecentSearchJpaEntity recentSearchJpaEntity) {
+        return RecentSearch.builder()
+                .id(recentSearchJpaEntity.getRecentSearchId())
+                .searchTerm(recentSearchJpaEntity.getSearchTerm())
+                .type(recentSearchJpaEntity.getType().getSearchType())
+                .userId(recentSearchJpaEntity.getUserJpaEntity().getUserId())
+                .createdAt(recentSearchJpaEntity.getCreatedAt())
+                .modifiedAt(recentSearchJpaEntity.getModifiedAt())
+                .status(recentSearchJpaEntity.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/konkuk/thip/user/adapter/out/mapper/SavedBookMapper.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/mapper/SavedBookMapper.java
@@ -1,0 +1,29 @@
+package konkuk.thip.user.adapter.out.mapper;
+
+import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.SavedBookJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.domain.SavedBook;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SavedBookMapper {
+
+    public SavedBookJpaEntity toJpaEntity(UserJpaEntity userJpaEntity, BookJpaEntity bookJpaEntity) {
+        return SavedBookJpaEntity.builder()
+                .userJpaEntity(userJpaEntity)
+                .bookJpaEntity(bookJpaEntity)
+                .build();
+    }
+
+    public SavedBook toDomainEntity(SavedBookJpaEntity savedBookJpaEntity) {
+        return SavedBook.builder()
+                .id(savedBookJpaEntity.getSavedId())
+                .userId(savedBookJpaEntity.getUserJpaEntity().getUserId())
+                .bookId(savedBookJpaEntity.getBookJpaEntity().getBookId())
+                .createdAt(savedBookJpaEntity.getCreatedAt())
+                .modifiedAt(savedBookJpaEntity.getModifiedAt())
+                .status(savedBookJpaEntity.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/konkuk/thip/user/adapter/out/mapper/SavedFeedMapper.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/mapper/SavedFeedMapper.java
@@ -1,0 +1,29 @@
+package konkuk.thip.user.adapter.out.mapper;
+
+import konkuk.thip.feed.adapter.out.jpa.FeedJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.SavedFeedJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.domain.SavedFeed;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SavedFeedMapper {
+
+    public SavedFeedJpaEntity toJpaEntity(UserJpaEntity userJpaEntity, FeedJpaEntity feedJpaEntity) {
+        return SavedFeedJpaEntity.builder()
+                .userJpaEntity(userJpaEntity)
+                .feedJpaEntity(feedJpaEntity)
+                .build();
+    }
+
+    public SavedFeed toDomainEntity(SavedFeedJpaEntity savedFeedJpaEntity) {
+        return SavedFeed.builder()
+                .id(savedFeedJpaEntity.getSavedId())
+                .userId(savedFeedJpaEntity.getUserJpaEntity().getUserId())
+                .feedId(savedFeedJpaEntity.getFeedJpaEntity().getPostId())
+                .createdAt(savedFeedJpaEntity.getCreatedAt())
+                .modifiedAt(savedFeedJpaEntity.getModifiedAt())
+                .status(savedFeedJpaEntity.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/konkuk/thip/user/adapter/out/mapper/UserMapper.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/mapper/UserMapper.java
@@ -1,8 +1,33 @@
 package konkuk.thip.user.adapter.out.mapper;
 
+import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserRole;
+import konkuk.thip.user.domain.User;
 import org.springframework.stereotype.Component;
 
 @Component
 public class UserMapper {
 
+    public UserJpaEntity toJpaEntity(User user, AliasJpaEntity aliasJpaEntity) {
+        return UserJpaEntity.builder()
+                .nickname(user.getNickname())
+                .imageUrl(user.getImageUrl())
+                .role(UserRole.from(user.getUserRole()))
+                .aliasForUserJpaEntity(aliasJpaEntity)
+                .build();
+    }
+
+    public User toDomainEntity(UserJpaEntity userJpaEntity) {
+        return User.builder()
+                .id(userJpaEntity.getUserId())
+                .nickname(userJpaEntity.getNickname())
+                .imageUrl(userJpaEntity.getImageUrl())
+                .userRole(userJpaEntity.getRole().getType())
+                .aliasId(userJpaEntity.getAliasForUserJpaEntity().getAliasId())
+                .createdAt(userJpaEntity.getCreatedAt())
+                .modifiedAt(userJpaEntity.getModifiedAt())
+                .status(userJpaEntity.getStatus())
+                .build();
+    }
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/mapper/UserRoomMapper.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/mapper/UserRoomMapper.java
@@ -1,0 +1,36 @@
+package konkuk.thip.user.adapter.out.mapper;
+
+import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserRoomJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserRoomRole;
+import konkuk.thip.user.domain.UserRoom;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserRoomMapper {
+
+    public UserRoomJpaEntity toJpaEntity(UserRoom userRoom, UserJpaEntity userJpaEntity, RoomJpaEntity roomJpaEntity) {
+        return UserRoomJpaEntity.builder()
+                .currentPage(userRoom.getCurrentPage())
+                .userPercentage(userRoom.getUserPercentage())
+                .userRoomRole(UserRoomRole.from(userRoom.getUserRoomRole()))
+                .userJpaEntity(userJpaEntity)
+                .roomJpaEntity(roomJpaEntity)
+                .build();
+    }
+
+    public UserRoom toDomainEntity(UserRoomJpaEntity userRoomJpaEntity) {
+        return UserRoom.builder()
+                .id(userRoomJpaEntity.getUserRoomId())
+                .currentPage(userRoomJpaEntity.getCurrentPage())
+                .userPercentage(userRoomJpaEntity.getUserPercentage())
+                .userRoomRole(userRoomJpaEntity.getUserRoomRole().getType())
+                .userId(userRoomJpaEntity.getUserJpaEntity().getUserId())
+                .roomId(userRoomJpaEntity.getRoomJpaEntity().getRoomId())
+                .createdAt(userRoomJpaEntity.getCreatedAt())
+                .modifiedAt(userRoomJpaEntity.getModifiedAt())
+                .status(userRoomJpaEntity.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/konkuk/thip/user/adapter/out/mapper/UserVoteMapper.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/mapper/UserVoteMapper.java
@@ -1,0 +1,29 @@
+package konkuk.thip.user.adapter.out.mapper;
+
+import konkuk.thip.room.adapter.out.jpa.VoteItemJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserVoteJpaEntity;
+import konkuk.thip.user.domain.UserVote;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserVoteMapper {
+
+    public UserVoteJpaEntity toJpaEntity(UserJpaEntity userJpaEntity, VoteItemJpaEntity voteItemJpaEntity) {
+        return UserVoteJpaEntity.builder()
+                .userJpaEntity(userJpaEntity)
+                .voteItemJpaEntity(voteItemJpaEntity)
+                .build();
+    }
+
+    public UserVote toDomainEntity(UserVoteJpaEntity userVoteJpaEntity) {
+        return UserVote.builder()
+                .id(userVoteJpaEntity.getUserVoteId())
+                .userId(userVoteJpaEntity.getUserJpaEntity().getUserId())
+                .voteItemId(userVoteJpaEntity.getVoteItemJpaEntity().getVoteItemId())
+                .createdAt(userVoteJpaEntity.getCreatedAt())
+                .modifiedAt(userVoteJpaEntity.getModifiedAt())
+                .status(userVoteJpaEntity.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/konkuk/thip/user/domain/Alias.java
+++ b/src/main/java/konkuk/thip/user/domain/Alias.java
@@ -1,0 +1,14 @@
+package konkuk.thip.user.domain;
+
+import konkuk.thip.common.entity.BaseDomainEntity;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class Alias extends BaseDomainEntity {
+
+    private Long id;
+
+    private String value;
+}

--- a/src/main/java/konkuk/thip/user/domain/AttendanceCheck.java
+++ b/src/main/java/konkuk/thip/user/domain/AttendanceCheck.java
@@ -1,0 +1,18 @@
+package konkuk.thip.user.domain;
+
+import konkuk.thip.common.entity.BaseDomainEntity;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class AttendanceCheck extends BaseDomainEntity {
+
+    private Long id;
+
+    private String todayComment;
+
+    private Long roomId;
+
+    private Long creatorId;
+}

--- a/src/main/java/konkuk/thip/user/domain/Following.java
+++ b/src/main/java/konkuk/thip/user/domain/Following.java
@@ -1,0 +1,16 @@
+package konkuk.thip.user.domain;
+
+import konkuk.thip.common.entity.BaseDomainEntity;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class Following extends BaseDomainEntity {
+
+    private Long id;
+
+    private Long userId;
+
+    private Long followingUserId;
+}

--- a/src/main/java/konkuk/thip/user/domain/Notification.java
+++ b/src/main/java/konkuk/thip/user/domain/Notification.java
@@ -1,0 +1,20 @@
+package konkuk.thip.user.domain;
+
+import konkuk.thip.common.entity.BaseDomainEntity;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class Notification extends BaseDomainEntity {
+
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    private boolean isChecked;
+
+    private Long targetUserId;
+}

--- a/src/main/java/konkuk/thip/user/domain/RecentSearch.java
+++ b/src/main/java/konkuk/thip/user/domain/RecentSearch.java
@@ -1,0 +1,18 @@
+package konkuk.thip.user.domain;
+
+import konkuk.thip.common.entity.BaseDomainEntity;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class RecentSearch extends BaseDomainEntity {
+
+    private Long id;
+
+    private String searchTerm;
+
+    private String type;
+
+    private Long userId;
+}

--- a/src/main/java/konkuk/thip/user/domain/SavedBook.java
+++ b/src/main/java/konkuk/thip/user/domain/SavedBook.java
@@ -1,0 +1,16 @@
+package konkuk.thip.user.domain;
+
+import konkuk.thip.common.entity.BaseDomainEntity;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class SavedBook extends BaseDomainEntity {
+
+    private Long id;
+
+    private Long userId;
+
+    private Long bookId;
+}

--- a/src/main/java/konkuk/thip/user/domain/SavedFeed.java
+++ b/src/main/java/konkuk/thip/user/domain/SavedFeed.java
@@ -1,0 +1,16 @@
+package konkuk.thip.user.domain;
+
+import konkuk.thip.common.entity.BaseDomainEntity;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class SavedFeed extends BaseDomainEntity {
+
+    private Long id;
+
+    private Long userId;
+
+    private Long feedId;
+}

--- a/src/main/java/konkuk/thip/user/domain/User.java
+++ b/src/main/java/konkuk/thip/user/domain/User.java
@@ -1,14 +1,21 @@
 package konkuk.thip.user.domain;
 
-import lombok.Builder;
+import konkuk.thip.common.entity.BaseDomainEntity;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 
 @Getter
-@Builder
-public class User {
+@SuperBuilder
+public class User extends BaseDomainEntity {
 
-    /**
-     * 도메인 엔티티 -> 비즈니스 로직 수행
-     */
+    private Long id;
+
+    private String nickname;
+
+    private String imageUrl;
+
+    private String userRole;
+
+    private Long aliasId;
 
 }

--- a/src/main/java/konkuk/thip/user/domain/UserRoom.java
+++ b/src/main/java/konkuk/thip/user/domain/UserRoom.java
@@ -1,0 +1,22 @@
+package konkuk.thip.user.domain;
+
+import konkuk.thip.common.entity.BaseDomainEntity;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class UserRoom extends BaseDomainEntity {
+
+    private Long id;
+
+    private int currentPage;
+
+    private double userPercentage;
+
+    private String userRoomRole;
+
+    private Long userId;
+
+    private Long roomId;
+}

--- a/src/main/java/konkuk/thip/user/domain/UserVote.java
+++ b/src/main/java/konkuk/thip/user/domain/UserVote.java
@@ -1,0 +1,16 @@
+package konkuk.thip.user.domain;
+
+import konkuk.thip.common.entity.BaseDomainEntity;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class UserVote extends BaseDomainEntity {
+
+    private Long id;
+
+    private Long userId;
+
+    private Long voteItemId;
+}

--- a/src/test/java/konkuk/thip/domain/room/adapter/out/jpa/RecordJpaEntityTest.java
+++ b/src/test/java/konkuk/thip/domain/room/adapter/out/jpa/RecordJpaEntityTest.java
@@ -2,7 +2,9 @@ package konkuk.thip.domain.room.adapter.out.jpa;
 
 import jakarta.persistence.EntityManager;
 import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.adapter.out.jpa.CategoryJpaEntity;
 import konkuk.thip.book.adapter.out.persistence.BookJpaRepository;
+import konkuk.thip.book.adapter.out.persistence.CategoryJpaRepository;
 import konkuk.thip.room.adapter.out.jpa.RecordJpaEntity;
 import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
 import konkuk.thip.room.adapter.out.persistence.RecordJpaRepository;
@@ -44,6 +46,9 @@ class RecordJpaEntityTest {
     @Autowired
     private RecordJpaRepository recordRepository;
 
+    @Autowired
+    private CategoryJpaRepository categoryRepository;
+
     private UserJpaEntity createUser() {
         AliasJpaEntity alias = AliasJpaEntity.builder().value("익명1").build();
         aliasRepository.save(alias);
@@ -70,7 +75,7 @@ class RecordJpaEntityTest {
                 .build());
     }
 
-    private RoomJpaEntity createRoom(BookJpaEntity book) {
+    private RoomJpaEntity createRoom(BookJpaEntity book, CategoryJpaEntity category) {
         return roomRepository.save(RoomJpaEntity.builder()
                 .title("방이름")
                 .description("설명")
@@ -79,14 +84,25 @@ class RecordJpaEntityTest {
                 .endDate(LocalDate.now().plusDays(5))
                 .recruitCount(3)
                 .bookJpaEntity(book)
+                .categoryJpaEntity(category)
                 .build());
+    }
+
+    private CategoryJpaEntity createCategory() {
+        AliasJpaEntity alias = AliasJpaEntity.builder().value("익명1").build();
+        aliasRepository.save(alias);
+
+        return categoryRepository.save(CategoryJpaEntity.builder()
+                        .value("카테고리1")
+                        .aliasForCategoryJpaEntity(alias)
+                        .build());
     }
 
     @Test
     @DisplayName("RecordJpaEntity 저장 및 조회 테스트")
     void saveAndFindRecord() {
         UserJpaEntity user = createUser();
-        RoomJpaEntity room = createRoom(createBook());
+        RoomJpaEntity room = createRoom(createBook(), createCategory());
 
         RecordJpaEntity record = RecordJpaEntity.builder()
                 .content("기록 내용")

--- a/src/test/java/konkuk/thip/domain/room/adapter/out/jpa/RoomJpaEntityTest.java
+++ b/src/test/java/konkuk/thip/domain/room/adapter/out/jpa/RoomJpaEntityTest.java
@@ -3,9 +3,13 @@ package konkuk.thip.domain.room.adapter.out.jpa;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.adapter.out.jpa.CategoryJpaEntity;
 import konkuk.thip.book.adapter.out.persistence.BookJpaRepository;
+import konkuk.thip.book.adapter.out.persistence.CategoryJpaRepository;
 import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
 import konkuk.thip.room.adapter.out.persistence.RoomJpaRepository;
+import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
+import konkuk.thip.user.adapter.out.persistence.AliasJpaRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +26,12 @@ class RoomJpaEntityTest {
 
     @Autowired
     private BookJpaRepository bookRepository;
+
+    @Autowired
+    private AliasJpaRepository aliasRepository;
+
+    @Autowired
+    private CategoryJpaRepository categoryRepository;
 
     @Autowired
     private RoomJpaRepository roomRepository;
@@ -43,6 +53,19 @@ class RoomJpaEntityTest {
 
         bookRepository.save(book);
 
+        AliasJpaEntity alias = AliasJpaEntity.builder()
+                .value("칭호1")
+                .build();
+
+        aliasRepository.save(alias);
+
+        CategoryJpaEntity category = CategoryJpaEntity.builder()
+                .value("카테고리1")
+                .aliasForCategoryJpaEntity(alias)
+                .build();
+
+        categoryRepository.save(category);
+
         RoomJpaEntity room = RoomJpaEntity.builder()
                 .title("테스트 방")
                 .description("테스트 방 설명")
@@ -51,6 +74,7 @@ class RoomJpaEntityTest {
                 .endDate(LocalDate.of(2025, 6, 30))
                 .recruitCount(5)
                 .bookJpaEntity(book)
+                .categoryJpaEntity(category)
                 .build();
 
         //when

--- a/src/test/java/konkuk/thip/domain/room/adapter/out/jpa/VoteJpaEntityTest.java
+++ b/src/test/java/konkuk/thip/domain/room/adapter/out/jpa/VoteJpaEntityTest.java
@@ -3,7 +3,9 @@ package konkuk.thip.domain.room.adapter.out.jpa;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.adapter.out.jpa.CategoryJpaEntity;
 import konkuk.thip.book.adapter.out.persistence.BookJpaRepository;
+import konkuk.thip.book.adapter.out.persistence.CategoryJpaRepository;
 import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
 import konkuk.thip.room.adapter.out.jpa.VoteJpaEntity;
 import konkuk.thip.room.adapter.out.persistence.RoomJpaRepository;
@@ -45,6 +47,9 @@ class VoteJpaEntityTest {
     @Autowired
     private VoteJpaRepository voteRepository;
 
+    @Autowired
+    private CategoryJpaRepository categoryRepository;
+
     private UserJpaEntity createUser() {
         AliasJpaEntity alias = AliasJpaEntity.builder().value("익명1").build();
         aliasRepository.save(alias);
@@ -71,7 +76,7 @@ class VoteJpaEntityTest {
                 .build());
     }
 
-    private RoomJpaEntity createRoom(BookJpaEntity book) {
+    private RoomJpaEntity createRoom(BookJpaEntity book, CategoryJpaEntity category) {
         return roomRepository.save(RoomJpaEntity.builder()
                 .title("방이름")
                 .description("설명")
@@ -80,6 +85,17 @@ class VoteJpaEntityTest {
                 .endDate(LocalDate.now().plusDays(5))
                 .recruitCount(3)
                 .bookJpaEntity(book)
+                .categoryJpaEntity(category)
+                .build());
+    }
+
+    private CategoryJpaEntity createCategory() {
+        AliasJpaEntity alias = AliasJpaEntity.builder().value("익명1").build();
+        aliasRepository.save(alias);
+
+        return categoryRepository.save(CategoryJpaEntity.builder()
+                .value("카테고리1")
+                .aliasForCategoryJpaEntity(alias)
                 .build());
     }
 
@@ -87,7 +103,7 @@ class VoteJpaEntityTest {
     @DisplayName("VoteJpaEntity 저장 및 조회 테스트")
     void saveAndFindVote() {
         UserJpaEntity user = createUser();
-        RoomJpaEntity room = createRoom(createBook());
+        RoomJpaEntity room = createRoom(createBook(), createCategory());
 
         VoteJpaEntity vote = VoteJpaEntity.builder()
                 .content("투표 내용")


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #20 

## 📝 작업 내용
모든 jpa entity (PostJpaEntity 제외) 와 1대1로 대응되는 도메인 엔티티 및 mapper 클래스들을 추가하였습니다

- 모든 도메인 엔티티들이 가지는 속성값들을 포함하는 BaseDomainEntity 를 정의하고, 모든 도메인 엔티티들이 BaseDomainEntity를 상속받도록 수정하였습니다
- mapper 에서 도메인 엔티티 객체를 생성하면서 BaseDomainEntity의 속성값들도 초기화할 수 있도록 @SuperBuilder 를 도입하였습니다
(ref : https://velog.io/@dmsqo1403/SuperBuilder-%EB%9E%80)
- PostJpaEntity + {FeedJpaEntity, RecordJpaEntity, VoteJpaEntity} <-> {Feed, Record, Vote} 로 매핑되도록 도메인 엔티티와 mapper 클래스를 구현하였습니다
- 도메인 엔티티를 최대한 외부 의존성 없이 순수하게 유지하기 위해, jpa 엔티티의 enum 타입의 attribute 들을 모두 String 타입으로 정의하였습니다

## 📸 스크린샷

## 💬 리뷰 요구사항


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **신규 기능**
  - 다양한 도메인 엔티티(책, 카테고리, 댓글, 댓글 좋아요, 피드, 태그, 콘텐츠, 투표, 투표 항목, 방, 게시글 좋아요, 기록, 사용자, 알리아스, 출석 체크, 팔로잉, 알림, 최근 검색, 저장된 책 및 피드, 사용자 방, 사용자 투표 등)와 매퍼 클래스가 대거 추가되었습니다.
  - 각 엔티티에 생성일, 수정일, 상태 등 공통 필드가 포함된 공통 베이스 엔티티 상속 구조와 Lombok의 상속 지원 빌더 패턴이 적용되었습니다.
  - 도메인과 JPA 엔티티 간 변환을 위한 매핑 기능이 추가되어 데이터 변환 및 관리가 용이해졌습니다.
  - 방(Room)과 관련하여 카테고리 정보가 연동되도록 기능이 확장되었습니다.
  - 일부 JPA 엔티티 생성자 및 필드가 개선되어 명확성과 유연성이 향상되었습니다.

- **버그 수정**
  - 일부 필드명 및 타입이 일관성 있게 정정되었습니다(예: 상태 타입 변경, 필드명 camelCase 표준화 등).

- **리팩터링**
  - 기존 엔티티들이 공통 베이스 엔티티를 상속하는 구조로 개선되어 코드 일관성과 재사용성이 향상되었습니다.
  - 일부 JPA 엔티티의 생성자 및 필드 구조가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->