### PR TITLE
[feat] 방 검색 api 개발

### DIFF
--- a/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
@@ -68,6 +68,7 @@ public enum ErrorCode implements ResponseCode {
      */
     ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, 100000, "존재하지 않는 ROOM 입니다."),
     INVALID_ROOM_CREATE(HttpStatus.BAD_REQUEST, 100001, "유효하지 않은 ROOM 생성 요청 입니다."),
+    INVALID_ROOM_SEARCH_SORT(HttpStatus.BAD_REQUEST, 100002, "방 검색 시 정렬 조건이 잘못되었습니다."),
 
     /**
      * 110000 : vote error

--- a/src/main/java/konkuk/thip/common/util/DateUtilsss.java
+++ b/src/main/java/konkuk/thip/common/util/DateUtilsss.java
@@ -1,0 +1,31 @@
+package konkuk.thip.common.util;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class DateUtilsss {
+
+    public static String formatAfterTime(LocalDate date) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime dateTime = date.atStartOfDay();
+        Duration d = Duration.between(now, dateTime);
+
+        if (d.isNegative() || d.isZero()) {
+            return "??";
+        }
+
+        long days = d.toDays();
+        if (days > 0) {
+            return days + "일 뒤 ";
+        }
+
+        long hours = d.toHours();
+        if (hours > 0) {
+            return hours + "시간 뒤 ";
+        }
+
+        long minutes = d.toMinutes();
+        return minutes + "분 뒤 ";
+    }
+}

--- a/src/main/java/konkuk/thip/room/adapter/in/web/RoomQueryController.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/RoomQueryController.java
@@ -1,10 +1,26 @@
 package konkuk.thip.room.adapter.in.web;
 
+import konkuk.thip.common.dto.BaseResponse;
+import konkuk.thip.room.adapter.in.web.response.RoomSearchResponse;
+import konkuk.thip.room.application.port.in.RoomSearchUseCase;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 public class RoomQueryController {
 
+    private final RoomSearchUseCase roomSearchUseCase;
+
+    @GetMapping("/rooms/search")
+    public BaseResponse<RoomSearchResponse> searchRooms(
+            @RequestParam(value = "keyword", required = false, defaultValue = "") final String keyword,
+            @RequestParam(value = "category", required = false, defaultValue = "") final String category,
+            @RequestParam("sort") final String sort,
+            @RequestParam("page") final int page
+    ) {
+        return BaseResponse.ok(roomSearchUseCase.searchRoom(keyword, category, sort, page));
+    }
 }

--- a/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomSearchResponse.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomSearchResponse.java
@@ -1,0 +1,22 @@
+package konkuk.thip.room.adapter.in.web.response;
+
+import java.util.List;
+
+public record RoomSearchResponse(
+        List<RoomSearchResult> roomList,
+        int page,       // 현재 페이지
+        int size,       // 현재 페이지에 포함된 데이터 수
+        boolean last,
+        boolean first
+) {
+
+    public record RoomSearchResult(
+            Long roomId,
+            String bookImageUrl,
+            String roomName,
+            int memberCount,
+            int recruitCount,
+            String deadlineDate,
+            String category
+    ) {}
+}

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/CategoryName.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/CategoryName.java
@@ -1,0 +1,32 @@
+package konkuk.thip.room.adapter.out.persistence;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum CategoryName {
+
+    /**
+     * DB에 저장되어 있는 모든 카테고리들의 이름
+     * TODO : DB에서 value를 통해 카테고리를 조회하는것보다 id로 조회하는게 성능상 좋으니, id 값도 같이 보관 ??
+     */
+    SCIENCE_IT("과학/IT"),
+    Literature("문학"),
+    ART("예술"),
+    SOCIAL_SCIENCE("사회과확"),
+    HUMANITY("인문학");
+
+    private final String value;
+
+    public static CategoryName from(String value) {
+        return Arrays.stream(CategoryName.values())
+                .filter(categoryName -> categoryName.getValue().equals(value))
+                .findFirst()
+                .orElseThrow(
+                        () -> new IllegalArgumentException("현재 카테고리 이름 : " + value)
+                );
+    }
+}

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomJpaRepository.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomJpaRepository.java
@@ -5,6 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
 
-public interface RoomJpaRepository extends JpaRepository<RoomJpaEntity, Long> {
+public interface RoomJpaRepository extends JpaRepository<RoomJpaEntity, Long>, RoomQueryRepository {
+
     int countByBookJpaEntity_BookIdAndStartDateAfter(Long bookId, LocalDate currentDate);
+
+
 }

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomQueryPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomQueryPersistenceAdapter.java
@@ -1,8 +1,11 @@
 package konkuk.thip.room.adapter.out.persistence;
 
+import konkuk.thip.room.adapter.in.web.response.RoomSearchResponse;
 import konkuk.thip.room.adapter.out.mapper.RoomMapper;
 import konkuk.thip.room.application.port.out.RoomQueryPort;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -17,5 +20,10 @@ public class RoomQueryPersistenceAdapter implements RoomQueryPort {
     @Override
     public int countRecruitingRoomsByBookAndStartDateAfter(Long bookId, LocalDate currentDate) {
         return roomJpaRepository.countByBookJpaEntity_BookIdAndStartDateAfter(bookId, currentDate);
+    }
+
+    @Override
+    public Page<RoomSearchResponse.RoomSearchResult> searchRoom(String keyword, String category, Pageable pageable) {
+        return roomJpaRepository.searchRoom(keyword, category, pageable);
     }
 }

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomQueryRepository.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomQueryRepository.java
@@ -1,0 +1,10 @@
+package konkuk.thip.room.adapter.out.persistence;
+
+import konkuk.thip.room.adapter.in.web.response.RoomSearchResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface RoomQueryRepository {
+
+    Page<RoomSearchResponse.RoomSearchResult> searchRoom(String keyword, String category, Pageable pageable);
+}

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomQueryRepositoryImpl.java
@@ -1,0 +1,140 @@
+package konkuk.thip.room.adapter.out.persistence;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import konkuk.thip.book.adapter.out.jpa.QBookJpaEntity;
+import konkuk.thip.common.util.DateUtilsss;
+import konkuk.thip.room.adapter.in.web.response.RoomSearchResponse;
+import konkuk.thip.room.adapter.out.jpa.QRoomJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.QUserRoomJpaEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class RoomQueryRepositoryImpl implements RoomQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QRoomJpaEntity room = QRoomJpaEntity.roomJpaEntity;
+    private final QBookJpaEntity book = QBookJpaEntity.bookJpaEntity;
+    private final QUserRoomJpaEntity userRoom = QUserRoomJpaEntity.userRoomJpaEntity;
+
+    @Override
+    public Page<RoomSearchResponse.RoomSearchResult> searchRoom(String keyword, String category, Pageable pageable) {
+        // 1. 검색 조건(where) 조립 : 방이름 or 첵제목에 keyword 포함, category 필터 적용, 멤버 모집중인(= 활동 시작전인) 방만 검색
+        BooleanBuilder where = new BooleanBuilder();
+        // keyword 필터 (빈 문자열이면 생략)
+        if (keyword != null && !keyword.isBlank()) {
+            where.and(room.title.containsIgnoreCase(keyword).or(book.title.containsIgnoreCase(keyword)));
+        }
+        // category 필터 (빈 문자열이면 생략)
+        if (category != null && !category.isBlank()) {
+            where.and(room.categoryJpaEntity.value.eq(category));
+        }
+        // 모집중인 방만
+        where.and(room.startDate.after(LocalDate.now()));
+
+        // 2. 페이징된 content 조회
+        // 우선순위 표현식 : keyword가 방 제목에 매칭되면 1, 아니면 0
+        NumberExpression<Integer> priorityExpr = new CaseBuilder()
+                .when(room.title.containsIgnoreCase(keyword)).then(1)
+                .otherwise(0);
+
+        NumberExpression<Long> memberCountExpr = userRoom.userRoomId.count();       // 방 별 멤버수 표현식
+
+        List<Tuple> tuples = queryFactory
+                .select(
+                        room.roomId,
+                        book.imageUrl,
+                        room.title,
+                        memberCountExpr,
+                        room.recruitCount,
+                        room.startDate,
+                        room.categoryJpaEntity.value
+                )
+                .from(room)
+                .join(room.bookJpaEntity, book)
+                .leftJoin(userRoom).on(userRoom.roomJpaEntity.eq(room))
+                .where(where)
+                .groupBy(
+                        room.roomId,
+                        book.imageUrl,
+                        room.title,
+                        room.recruitCount,
+                        room.startDate,
+                        room.categoryJpaEntity.value
+                )
+                .orderBy(
+                        // 1차 정렬 : 설정된 정렬 조건, 2차 정렬 : 방이름으로 방 검색 > 책제목으로 방 검색
+                        toOrderSpecifier(pageable.getSort(), room, memberCountExpr),
+                        priorityExpr.desc()
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        // TODO : 추후에 오프셋 페이징이 아니라, 키셋 페이징 기법 도입 검토
+
+        // 3. Tuple → DTO 매핑
+        List<RoomSearchResponse.RoomSearchResult> content = tuples.stream()
+                .map(t -> new RoomSearchResponse.RoomSearchResult(
+                        t.get(room.roomId),
+                        t.get(book.imageUrl),
+                        t.get(room.title),
+                        // 참여자 수를 int로 캐스팅
+                        t.get(memberCountExpr).intValue(),
+                        t.get(room.recruitCount),
+                        // 모집마감일 까지 남은 시간 포맷
+                        DateUtilsss.formatAfterTime(t.get(room.startDate)),
+                        t.get(room.categoryJpaEntity.value)
+                ))
+                .toList();
+
+        // 4. 전체 개수 조회 (페이징 정보 계산용)
+        Long totalCount = queryFactory
+                .select(room.count())
+                .from(room)
+                .join(room.bookJpaEntity, book)
+                .where(where)
+                .fetchOne();
+        long total = (totalCount != null) ? totalCount : 0L;
+
+        // 5. PageImpl 생성하여 반환
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    /**
+     * 지원하는 정렬 키에 대해, 미리 정의된 Q 필드를 반환합니다.
+     * sort가 없으면 '마감 임박순' 으로 기본 처리합니다.
+     */
+    private OrderSpecifier<?> toOrderSpecifier(Sort sort, QRoomJpaEntity room, NumberExpression<Long> memberCountExpr) {
+        // sort 파라미터가 없으면 기본 마감 임박순
+        if (sort.isUnsorted()) {
+            return room.startDate.asc();
+        }
+
+        // 클라이언트가 보낸 첫 번째 sort 키를 꺼냅니다.
+        String key = sort.stream().findFirst().get().getProperty();
+
+        switch (key) {
+            case "memberCount":
+                // user_rooms 테이블에서 현재 참여자 수 집계 → 내림차순
+                return new OrderSpecifier<>(Order.DESC, memberCountExpr);
+            case "deadLine":
+            default:
+                // deadLine: 마감 임박순 = startDate 빠른 순서대로(오름차순)
+                return room.startDate.asc();
+        }
+    }
+}

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomSearchSortParam.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomSearchSortParam.java
@@ -1,0 +1,26 @@
+package konkuk.thip.room.adapter.out.persistence;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum RoomSearchSortParam {
+
+    DEADLINE("deadline"),
+    MEMBER_COUNT("memberCount"),
+    RECOMMEND("인플루언서, 작가 추천");      // 개발 미정
+
+    private final String value;
+
+    public static RoomSearchSortParam from(String value) {
+        return Arrays.stream(RoomSearchSortParam.values())
+                .filter(param -> param.getValue().equals(value))
+                .findFirst()
+                .orElseThrow(
+                        () -> new IllegalArgumentException("현재 정렬 조건 param : " + value)
+                );
+    }
+}

--- a/src/main/java/konkuk/thip/room/application/port/in/RoomSearchUseCase.java
+++ b/src/main/java/konkuk/thip/room/application/port/in/RoomSearchUseCase.java
@@ -1,0 +1,8 @@
+package konkuk.thip.room.application.port.in;
+
+import konkuk.thip.room.adapter.in.web.response.RoomSearchResponse;
+
+public interface RoomSearchUseCase {
+
+    RoomSearchResponse searchRoom(String keyword, String category, String sort, int page);
+}

--- a/src/main/java/konkuk/thip/room/application/port/out/RoomQueryPort.java
+++ b/src/main/java/konkuk/thip/room/application/port/out/RoomQueryPort.java
@@ -1,7 +1,13 @@
 package konkuk.thip.room.application.port.out;
 
+import konkuk.thip.room.adapter.in.web.response.RoomSearchResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import java.time.LocalDate;
 
 public interface RoomQueryPort {
     int countRecruitingRoomsByBookAndStartDateAfter(Long bookId, LocalDate currentDate);
+
+    Page<RoomSearchResponse.RoomSearchResult> searchRoom(String keyword, String category, Pageable pageable);
 }

--- a/src/main/java/konkuk/thip/room/application/service/RoomSearchService.java
+++ b/src/main/java/konkuk/thip/room/application/service/RoomSearchService.java
@@ -1,0 +1,84 @@
+package konkuk.thip.room.application.service;
+
+import konkuk.thip.common.exception.BusinessException;
+import konkuk.thip.room.adapter.in.web.response.RoomSearchResponse;
+import konkuk.thip.room.adapter.out.persistence.CategoryName;
+import konkuk.thip.room.adapter.out.persistence.RoomSearchSortParam;
+import konkuk.thip.room.application.port.in.RoomSearchUseCase;
+import konkuk.thip.room.application.port.out.RoomQueryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import static konkuk.thip.common.exception.code.ErrorCode.CATEGORY_NOT_FOUND;
+import static konkuk.thip.common.exception.code.ErrorCode.INVALID_ROOM_SEARCH_SORT;
+
+@Service
+@RequiredArgsConstructor
+public class RoomSearchService implements RoomSearchUseCase {
+
+    private static final int DEFAULT_PAGE_SIZE = 10;
+
+    private final RoomQueryPort roomQueryPort;
+
+    @Override
+    public RoomSearchResponse searchRoom(String keyword, String category, String sort, int page) {
+        // 1. validation
+        String sortVal = validateSort(sort);
+        String categoryVal = validateCategory(category);
+
+        // 2. Pageable 생성
+        int pageIndex = page > 0 ? page - 1 : 0;
+        Pageable pageable = PageRequest.of(pageIndex, DEFAULT_PAGE_SIZE, buildSort(sortVal));
+
+        // 3. 방 검색
+        Page<RoomSearchResponse.RoomSearchResult> result = roomQueryPort.searchRoom(keyword, categoryVal, pageable);
+
+        // 4. response 구성
+        return new RoomSearchResponse(
+                result.getContent(),
+                page,
+                result.getNumberOfElements(),
+                result.isLast(),
+                result.isFirst());
+    }
+
+    private String validateSort(String sort) {
+        try {
+            return RoomSearchSortParam.from(sort).getValue();
+        } catch (IllegalArgumentException ex) {
+            throw new BusinessException(INVALID_ROOM_SEARCH_SORT, ex);
+        }
+    }
+
+    private String validateCategory(String category) {
+        if (category == null || category.isEmpty()) {
+            return "";
+        }
+        try {
+            CategoryName cat = CategoryName.from(category);
+            return cat.getValue();
+        } catch (IllegalArgumentException ex) {
+            throw new BusinessException(CATEGORY_NOT_FOUND, ex);
+        }
+    }
+
+    /**
+     * 정렬 키에 따른 Sort 객체 생성
+     */
+    private Sort buildSort(String sortVal) {
+        if (sortVal.equals(RoomSearchSortParam.MEMBER_COUNT.getValue())) {
+            // 인기순: 참여자 수 내림차순
+            return Sort.by(Sort.Direction.DESC, RoomSearchSortParam.MEMBER_COUNT.getValue());
+        }
+        if (sortVal.equals(RoomSearchSortParam.RECOMMEND.getValue())) {
+            // TODO: 추후 추천 로직 구현 시 반영
+            return Sort.unsorted();
+        }
+        // default: 마감 임박순(deadLine) = 시작일 빠른 순서대로 오름차순
+        return Sort.by(Sort.Direction.ASC, RoomSearchSortParam.DEADLINE.getValue());
+    }
+}

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomSearchApiTest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomSearchApiTest.java
@@ -1,0 +1,366 @@
+package konkuk.thip.room.adapter.in.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.adapter.out.persistence.BookJpaRepository;
+import konkuk.thip.room.adapter.out.jpa.CategoryJpaEntity;
+import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
+import konkuk.thip.room.adapter.out.persistence.CategoryJpaRepository;
+import konkuk.thip.room.adapter.out.persistence.RoomJpaRepository;
+import konkuk.thip.user.adapter.out.jpa.*;
+import konkuk.thip.user.adapter.out.persistence.AliasJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.UserJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.UserRoomJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.is;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("[통합] 방 검색 api 통합 테스트")
+class RoomSearchApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private AliasJpaRepository aliasJpaRepository;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private CategoryJpaRepository categoryJpaRepository;
+
+    @Autowired
+    private BookJpaRepository bookJpaRepository;
+
+    @Autowired
+    private RoomJpaRepository roomJpaRepository;
+
+    @Autowired
+    private UserRoomJpaRepository userRoomJpaRepository;
+
+    @AfterEach
+    void tearDown() {
+        userRoomJpaRepository.deleteAll();
+        roomJpaRepository.deleteAll();
+        bookJpaRepository.deleteAll();
+        userJpaRepository.deleteAll();
+        categoryJpaRepository.deleteAll();
+        aliasJpaRepository.deleteAll();
+    }
+
+    private RoomJpaEntity saveRoom(String categoryValue, String bookTitle, String isbn, String roomName, LocalDate startDate, int recruitCount) {
+        AliasJpaEntity alias = aliasJpaRepository.save(AliasJpaEntity.builder()
+                .value("소설-칭호")
+                .color("blue")
+                .imageUrl("http://image.url")
+                .build());
+
+        BookJpaEntity book = bookJpaRepository.save(BookJpaEntity.builder()
+                .title(bookTitle)
+                .isbn(isbn)
+                .authorName("한강")
+                .bestSeller(false)
+                .publisher("문학동네")
+                .imageUrl("https://image1.jpg")
+                .pageCount(300)
+                .description("한강의 소설")
+                .build());
+
+        CategoryJpaEntity category = categoryJpaRepository.save(CategoryJpaEntity.builder()
+                .value(categoryValue)
+                .aliasForCategoryJpaEntity(alias)
+                .build());
+
+        return roomJpaRepository.save(RoomJpaEntity.builder()
+                .title(roomName)
+                .description("한강 작품 읽기 모임")
+                .isPublic(true)
+                .roomPercentage(0.0)
+                .startDate(startDate)
+                .endDate(LocalDate.now().plusDays(30))
+                .recruitCount(recruitCount)
+                .bookJpaEntity(book)
+                .categoryJpaEntity(category)
+                .build());
+    }
+
+    private void saveUsersToRoom(RoomJpaEntity roomJpaEntity, int count) {
+        AliasJpaEntity alias = aliasJpaRepository.save(AliasJpaEntity.builder()
+                .value("소설-칭호")
+                .color("blue")
+                .imageUrl("http://image.url")
+                .build());
+
+        // User 리스트 생성 및 저장
+        List<UserJpaEntity> users = IntStream.rangeClosed(1, count)
+                .mapToObj(i -> UserJpaEntity.builder()
+                        .nickname("user" + i)
+                        .imageUrl("http://image")
+                        .oauth2Id("oauth2Id")
+                        .role(UserRole.USER)
+                        .aliasForUserJpaEntity(alias)
+                        .build())
+                .toList();
+
+        List<UserJpaEntity> savedUsers = userJpaRepository.saveAll(users);
+
+        // UserRoom 매핑 리스트 생성 및 저장
+        List<UserRoomJpaEntity> mappings = savedUsers.stream()
+                .map(user -> UserRoomJpaEntity.builder()
+                        .userJpaEntity(user)
+                        .roomJpaEntity(roomJpaEntity)
+                        .userRoomRole(UserRoomRole.MEMBER)
+                        .build())
+                .toList();
+
+        userRoomJpaRepository.saveAll(mappings);
+    }
+
+    @Test
+    @DisplayName("keyword = [과학], 카테고리 선택 X, 정렬 = [마감임박순] 일 경우, 방이름 or 책제목에 '과학'이 포함된 방 검색 결과가 마감임박순으로 반환된다.")
+    void search_keyword_and_sort_deadline() throws Exception {
+        //given
+        RoomJpaEntity science_room_1 = saveRoom("과학/IT", "과학-책", "isbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1), 10);
+        saveUsersToRoom(science_room_1, 4);
+
+        RoomJpaEntity science_room_2 = saveRoom("과학/IT", "과학-책", "isbn2", "방이름입니다", LocalDate.now().plusDays(1), 10);
+        saveUsersToRoom(science_room_2, 5);
+
+        RoomJpaEntity science_room_3 = saveRoom("과학/IT", "과학-책", "isbn3", "무슨방일까요??", LocalDate.now().plusDays(5), 8);
+        saveUsersToRoom(science_room_3, 2);
+
+        RoomJpaEntity science_room_4 = saveRoom("과학/IT", "과학-책", "isbn4", "과학-방-5일뒤-활동시작", LocalDate.now().plusDays(5), 8);
+        saveUsersToRoom(science_room_4, 1);
+
+        RoomJpaEntity room_3 = saveRoom("문학", "문학-책", "isbn5", "방제목에-과학-포함된-문학방", LocalDate.now().plusDays(10), 8);
+        saveUsersToRoom(room_3, 6);
+
+        RoomJpaEntity recruit_expired_room_4 = saveRoom("과학/IT", "과학-책", "isbn6", "모집기한-지난-과학방", LocalDate.now().minusDays(1), 8);
+        saveUsersToRoom(recruit_expired_room_4, 6);
+
+        //when
+        ResultActions result = mockMvc.perform(get("/rooms/search")
+                .requestAttr("userId", 1L)
+                .param("keyword", "과학")
+                .param("sort", "deadline")
+                .param("page", "1"));
+
+        //then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.roomList", hasSize(5)))     // 결과 리스트 크기 확인
+                .andExpect(jsonPath("$.data.page", is(1)))      // 페이징 정보 검증
+                .andExpect(jsonPath("$.data.size", is(5)))
+                .andExpect(jsonPath("$.data.first", is(true)))
+                .andExpect(jsonPath("$.data.last", is(true)))
+                /**
+                 * roomList 검증 : 정렬 순서, 방 검색 결과 검증
+                 * <정렬 순서>
+                 * 1. 정렬 조건
+                 * 2. 정렬 조건이 같을 경우, 방이름에 keyword가 포함된 검색결과가 책제목에 keyword가 포함된 검색결과보다 우선순위가 더 높다
+                 */
+                .andExpect(jsonPath("$.data.roomList[0].roomName", is("과학-방-1일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[1].roomName", is("방이름입니다")))
+                .andExpect(jsonPath("$.data.roomList[2].roomName", is("과학-방-5일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[3].roomName", is("무슨방일까요??")))
+                .andExpect(jsonPath("$.data.roomList[4].roomName", is("방제목에-과학-포함된-문학방")));
+    }
+
+    @Test
+    @DisplayName("keyword = [과학], 카테고리 선택 X, 정렬 = [인기순] 일 경우, 방이름 or 책제목에 '과학'이 포함된 방 검색 결과가 인기순(= 현재까지 모집된 인원 많은 순)으로 반환된다.")
+    void search_keyword_and_sort_member_count() throws Exception {
+        //given
+        RoomJpaEntity science_room_1 = saveRoom("과학/IT", "과학-책", "isbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1), 10);
+        saveUsersToRoom(science_room_1, 4);
+
+        RoomJpaEntity science_room_2 = saveRoom("과학/IT", "과학-책", "isbn2", "방이름입니다", LocalDate.now().plusDays(1), 10);
+        saveUsersToRoom(science_room_2, 5);
+
+        RoomJpaEntity science_room_3 = saveRoom("과학/IT", "과학-책", "isbn3", "무슨방일까요??", LocalDate.now().plusDays(5), 8);
+        saveUsersToRoom(science_room_3, 2);
+
+        RoomJpaEntity science_room_4 = saveRoom("과학/IT", "과학-책", "isbn4", "과학-방-5일뒤-활동시작", LocalDate.now().plusDays(5), 8);
+        saveUsersToRoom(science_room_4, 1);
+
+        RoomJpaEntity room_3 = saveRoom("문학", "문학-책", "isbn5", "방제목에-과학-포함된-문학방", LocalDate.now().plusDays(10), 8);
+        saveUsersToRoom(room_3, 6);
+
+        RoomJpaEntity recruit_expired_room_4 = saveRoom("과학/IT", "과학-책", "isbn6", "모집기한-지난-과학방", LocalDate.now().minusDays(1), 8);
+        saveUsersToRoom(recruit_expired_room_4, 6);
+
+        //when
+        ResultActions result = mockMvc.perform(get("/rooms/search")
+                .requestAttr("userId", 1L)
+                .param("keyword", "과학")
+                .param("sort", "memberCount")
+                .param("page", "1"));
+
+        //then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.roomList", hasSize(5)))     // 결과 리스트 크기 확인
+                .andExpect(jsonPath("$.data.page", is(1)))      // 페이징 정보 검증
+                .andExpect(jsonPath("$.data.size", is(5)))
+                .andExpect(jsonPath("$.data.first", is(true)))
+                .andExpect(jsonPath("$.data.last", is(true)))
+                /**
+                 * roomList 검증 : 정렬 순서, 방 검색 결과 검증
+                 * <정렬 순서>
+                 * 1. 정렬 조건
+                 * 2. 정렬 조건이 같을 경우, 방이름에 keyword가 포함된 검색결과가 책제목에 keyword가 포함된 검색결과보다 우선순위가 더 높다
+                 */
+                .andExpect(jsonPath("$.data.roomList[0].roomName", is("방제목에-과학-포함된-문학방")))
+                .andExpect(jsonPath("$.data.roomList[0].memberCount", is(6)))
+
+                .andExpect(jsonPath("$.data.roomList[1].roomName", is("방이름입니다")))
+                .andExpect(jsonPath("$.data.roomList[1].memberCount", is(5)))
+
+                .andExpect(jsonPath("$.data.roomList[2].roomName", is("과학-방-1일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[2].memberCount", is(4)))
+
+                .andExpect(jsonPath("$.data.roomList[3].roomName", is("무슨방일까요??")))
+                .andExpect(jsonPath("$.data.roomList[3].memberCount", is(2)))
+
+                .andExpect(jsonPath("$.data.roomList[4].roomName", is("과학-방-5일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[4].memberCount", is(1)));
+    }
+
+    @Test
+    @DisplayName("keyword 입력 x, 카테고리 = [과학/IT], 정렬 = [마감임박순] 일 경우, [과학/IT] 카테고리에 속하는 방 검색 결과가 반환된다.")
+    void search_category_and_sort_deadline() throws Exception {
+        //given
+        RoomJpaEntity science_room_1 = saveRoom("과학/IT", "과학-책", "isbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1), 10);
+        saveUsersToRoom(science_room_1, 4);
+
+        RoomJpaEntity science_room_3 = saveRoom("과학/IT", "과학-책", "isbn3", "무슨방일까요??", LocalDate.now().plusDays(5), 8);
+        saveUsersToRoom(science_room_3, 2);
+
+        RoomJpaEntity room_3 = saveRoom("문학", "문학-책", "isbn5", "방제목에-과학-포함된-문학방", LocalDate.now().plusDays(10), 8);
+        saveUsersToRoom(room_3, 6);
+
+        RoomJpaEntity recruit_expired_room_4 = saveRoom("과학/IT", "과학-책", "isbn6", "모집기한-지난-과학방", LocalDate.now().minusDays(1), 8);
+        saveUsersToRoom(recruit_expired_room_4, 6);
+
+        //when
+        ResultActions result = mockMvc.perform(get("/rooms/search")
+                .requestAttr("userId", 1L)
+                .param("category", "과학/IT")
+                .param("sort", "deadline")
+                .param("page", "1"));
+
+        //then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.roomList", hasSize(2)))     // 결과 리스트 크기 확인
+                .andExpect(jsonPath("$.data.page", is(1)))      // 페이징 정보 검증
+                .andExpect(jsonPath("$.data.size", is(2)))
+                .andExpect(jsonPath("$.data.first", is(true)))
+                .andExpect(jsonPath("$.data.last", is(true)))
+                /**
+                 * roomList 검증 : 정렬 순서, 방 검색 결과 검증
+                 * <정렬 순서>
+                 * 1. 정렬 조건
+                 * 2. 정렬 조건이 같을 경우, 방이름에 keyword가 포함된 검색결과가 책제목에 keyword가 포함된 검색결과보다 우선순위가 더 높다
+                 */
+                .andExpect(jsonPath("$.data.roomList[0].roomName", is("과학-방-1일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[1].roomName", is("무슨방일까요??")));
+    }
+
+    @Test
+    @DisplayName("keyword 입력 x, 카테고리 입력 x, 정렬 = [마감임박순] 일 경우, DB에 존재하는 전체 방 검색 결과가 반환된다.")
+    void search_sort_deadline() throws Exception {
+        //given
+        RoomJpaEntity science_room_1 = saveRoom("과학/IT", "과학-책", "isbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1), 10);
+        saveUsersToRoom(science_room_1, 4);
+
+        RoomJpaEntity science_room_3 = saveRoom("과학/IT", "과학-책", "isbn3", "무슨방일까요??", LocalDate.now().plusDays(5), 8);
+        saveUsersToRoom(science_room_3, 2);
+
+        RoomJpaEntity room_3 = saveRoom("문학", "문학-책", "isbn5", "방제목에-과학-포함된-문학방", LocalDate.now().plusDays(10), 8);
+        saveUsersToRoom(room_3, 6);
+
+        RoomJpaEntity recruit_expired_room_4 = saveRoom("과학/IT", "과학-책", "isbn6", "모집기한-지난-과학방", LocalDate.now().minusDays(1), 8);
+        saveUsersToRoom(recruit_expired_room_4, 6);
+
+        //when
+        ResultActions result = mockMvc.perform(get("/rooms/search")
+                .requestAttr("userId", 1L)
+                .param("sort", "deadline")
+                .param("page", "1"));
+
+        //then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.roomList", hasSize(3)))     // 결과 리스트 크기 확인
+                .andExpect(jsonPath("$.data.page", is(1)))      // 페이징 정보 검증
+                .andExpect(jsonPath("$.data.size", is(3)))
+                .andExpect(jsonPath("$.data.first", is(true)))
+                .andExpect(jsonPath("$.data.last", is(true)))
+                /**
+                 * roomList 검증 : 정렬 순서, 방 검색 결과 검증
+                 * <정렬 순서>
+                 * 1. 정렬 조건
+                 * 2. 정렬 조건이 같을 경우, 방이름에 keyword가 포함된 검색결과가 책제목에 keyword가 포함된 검색결과보다 우선순위가 더 높다
+                 */
+                .andExpect(jsonPath("$.data.roomList[0].roomName", is("과학-방-1일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[1].roomName", is("무슨방일까요??")))
+                .andExpect(jsonPath("$.data.roomList[2].roomName", is("방제목에-과학-포함된-문학방")));
+    }
+
+    @Test
+    @DisplayName("keyword=[과학], category=[과학/IT], 정렬=[마감임박순] 일 경우, keyword, category 조건을 모두 만족하는 방만 반환된다.")
+    void search_keyword_and_category() throws Exception {
+        // given
+        RoomJpaEntity science_room_1 = saveRoom("과학/IT", "과학-책", "isbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1), 10);
+        saveUsersToRoom(science_room_1, 4);
+
+        RoomJpaEntity science_room_3 = saveRoom("과학/IT", "과학-책", "isbn3", "무슨방일까요??", LocalDate.now().plusDays(5), 8);
+        saveUsersToRoom(science_room_3, 2);
+
+        RoomJpaEntity room_3 = saveRoom("문학", "문학-책", "isbn5", "문학방입니다", LocalDate.now().plusDays(10), 8);
+        saveUsersToRoom(room_3, 6);
+
+        RoomJpaEntity recruit_expired_room_4 = saveRoom("과학/IT", "과학-책", "isbn6", "모집기한-지난-과학방", LocalDate.now().minusDays(1), 8);
+        saveUsersToRoom(recruit_expired_room_4, 6);
+
+        // when
+        ResultActions result = mockMvc.perform(get("/rooms/search")
+                .requestAttr("userId", 1L)
+                .param("keyword", "과학")
+                .param("category", "과학/IT")
+                .param("sort", "deadline")
+                .param("page", "1"));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.roomList", hasSize(2)))
+                .andExpect(jsonPath("$.data.page", is(1)))
+                .andExpect(jsonPath("$.data.size", is(2)))
+                .andExpect(jsonPath("$.data.first", is(true)))
+                .andExpect(jsonPath("$.data.last", is(true)))
+                /**
+                 * roomList 검증 : 정렬 순서, 방 검색 결과 검증
+                 * <정렬 순서>
+                 * 1. 정렬 조건
+                 * 2. 정렬 조건이 같을 경우, 방이름에 keyword가 포함된 검색결과가 책제목에 keyword가 포함된 검색결과보다 우선순위가 더 높다
+                 */
+                .andExpect(jsonPath("$.data.roomList[0].roomName", is("과학-방-1일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[1].roomName", is("무슨방일까요??")));
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #55 

## 📝 작업 내용
방 검색 api를 개발하였습니다

<방 검색 api 플로우>
1. controller 진입
2. service 진입
  - category, sort requestParam 유효성 검증
  - Pageable 생성
  - Port 호출 결과를 response dto 로 구성한 후 반환
3. QueryPort 및 QueryDsl 구현체
  - 실제 검색 로직 구현

## 📸 스크린샷

## 💬 리뷰 요구사항
다양한 테스트 케이스를 고려해 '방 검색 api' 통합 테스트 코드를 작성해보았습니다. 테스트 코드를 참고해주시면 QueryDSL 로직이 더 잘 이해되실 것 같습니다!


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 방 검색 API가 추가되어 키워드, 카테고리, 정렬, 페이지별로 방을 조회할 수 있습니다.
  * 방 검색 결과는 모집 마감일, 인기순(멤버 수), 추천(개발 중) 등 다양한 정렬 옵션과 함께 제공됩니다.
  * 방 검색 결과에 모집 마감까지 남은 시간, 카테고리, 멤버 수 등 상세 정보가 포함됩니다.

* **버그 수정**
  * 잘못된 정렬 조건 입력 시 에러 메시지가 제공됩니다.

* **테스트**
  * 방 검색 API의 다양한 필터, 정렬, 페이지네이션 동작을 검증하는 통합 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->