### PR TITLE
[Feat] 피드 수정 api 개발 및 피드 생성 리펙토링

### DIFF
--- a/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
@@ -129,7 +129,8 @@ public enum ErrorCode implements ResponseCode {
     FEED_NOT_FOUND(HttpStatus.NOT_FOUND, 160000, "존재하지 않는 FEED 입니다."),
     TAG_NAME_NOT_MATCH(HttpStatus.BAD_REQUEST, 160001, "일치하는 태그 이름이 없습니다."),
     TAG_NOT_FOUND(HttpStatus.NOT_FOUND, 160002, "존재하지 않는 TAG 입니다."),
-    INVALID_FEED_CREATE(HttpStatus.BAD_REQUEST, 160003, "유효하지 않은 FEED 생성 요청 입니다."),
+    INVALID_FEED_COMMAND(HttpStatus.BAD_REQUEST, 160003, "유효하지 않은 FEED 생성/수정 요청 입니다."),
+    FEED_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, 160004, "피드 수정 권한이 없습니다."),
 
     /**
      * 170000 : Image File error

--- a/src/main/java/konkuk/thip/feed/adapter/in/web/FeedCommandController.java
+++ b/src/main/java/konkuk/thip/feed/adapter/in/web/FeedCommandController.java
@@ -4,13 +4,13 @@ import jakarta.validation.Valid;
 import konkuk.thip.common.dto.BaseResponse;
 import konkuk.thip.common.security.annotation.UserId;
 import konkuk.thip.feed.adapter.in.web.request.FeedCreateRequest;
-import konkuk.thip.feed.adapter.in.web.response.FeedCreateResponse;
+import konkuk.thip.feed.adapter.in.web.request.FeedUpdateRequest;
+import konkuk.thip.feed.adapter.in.web.response.FeedIdResponse;
 import konkuk.thip.feed.application.port.in.FeedCreateUseCase;
+import konkuk.thip.feed.application.port.in.FeedUpdateUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -21,11 +21,23 @@ import java.util.List;
 public class FeedCommandController {
 
     private final FeedCreateUseCase feedCreateUseCase;
+    private final FeedUpdateUseCase feedUpdateUseCase;
 
+    //피드 작성
     @PostMapping("/feeds")
-    public BaseResponse<FeedCreateResponse> createFeed(@RequestPart("request") @Valid final FeedCreateRequest request,
-                                                       @RequestPart(value = "images", required = false) final List<MultipartFile> images,
-                                                       @UserId final Long userId) {
-        return BaseResponse.ok(FeedCreateResponse.of(feedCreateUseCase.createFeed(request.toCommand(userId),images)));
+    public BaseResponse<FeedIdResponse> createFeed(@RequestPart("request") @Valid final FeedCreateRequest request,
+                                                   @RequestPart(value = "images", required = false) final List<MultipartFile> images,
+                                                   @UserId final Long userId) {
+        return BaseResponse.ok(FeedIdResponse.of(feedCreateUseCase.createFeed(request.toCommand(userId),images)));
+    }
+
+    // 피드 수정 (책 빼고 변경가능)
+    @PatchMapping("/feeds/{feedId}")
+    public BaseResponse<FeedIdResponse> updateFeed(@RequestBody @Valid FeedUpdateRequest request,
+                                                   @PathVariable("feedId") final Long feedId,
+                                                   @UserId Long userId) {
+
+        return BaseResponse.ok(FeedIdResponse.of(feedUpdateUseCase.updateFeed(request.toCommand(userId,feedId))));
+
     }
 }

--- a/src/main/java/konkuk/thip/feed/adapter/in/web/FeedCommandController.java
+++ b/src/main/java/konkuk/thip/feed/adapter/in/web/FeedCommandController.java
@@ -33,9 +33,9 @@ public class FeedCommandController {
 
     // 피드 수정 (책 빼고 변경가능)
     @PatchMapping("/feeds/{feedId}")
-    public BaseResponse<FeedIdResponse> updateFeed(@RequestBody @Valid FeedUpdateRequest request,
+    public BaseResponse<FeedIdResponse> updateFeed(@RequestBody @Valid final FeedUpdateRequest request,
                                                    @PathVariable("feedId") final Long feedId,
-                                                   @UserId Long userId) {
+                                                   @UserId final Long userId) {
 
         return BaseResponse.ok(FeedIdResponse.of(feedUpdateUseCase.updateFeed(request.toCommand(userId,feedId))));
 

--- a/src/main/java/konkuk/thip/feed/adapter/in/web/request/FeedCreateRequest.java
+++ b/src/main/java/konkuk/thip/feed/adapter/in/web/request/FeedCreateRequest.java
@@ -17,8 +17,6 @@ public record FeedCreateRequest(
         @NotNull(message = "방 공개 설정 여부는 필수입니다.")
         Boolean isPublic,
 
-        String category,
-
         List<String> tagList
 ) {
         public FeedCreateCommand toCommand(Long userId) {
@@ -26,7 +24,6 @@ public record FeedCreateRequest(
                         isbn,
                         contentBody,
                         isPublic,
-                        category,
                         tagList,
                         userId
                 );

--- a/src/main/java/konkuk/thip/feed/adapter/in/web/request/FeedUpdateRequest.java
+++ b/src/main/java/konkuk/thip/feed/adapter/in/web/request/FeedUpdateRequest.java
@@ -1,0 +1,27 @@
+package konkuk.thip.feed.adapter.in.web.request;
+
+import konkuk.thip.feed.application.port.in.dto.FeedUpdateCommand;
+
+import java.util.List;
+
+public record FeedUpdateRequest(
+
+        String contentBody,
+
+        Boolean isPublic,
+
+        List<String> tagList,
+
+        List<String> remainImageUrls
+) {
+        public FeedUpdateCommand toCommand(Long userId, Long feedId) {
+                return new FeedUpdateCommand(
+                        contentBody,
+                        isPublic,
+                        tagList,
+                        remainImageUrls,
+                        userId,
+                        feedId
+                );
+        }
+}

--- a/src/main/java/konkuk/thip/feed/adapter/in/web/response/FeedCreateResponse.java
+++ b/src/main/java/konkuk/thip/feed/adapter/in/web/response/FeedCreateResponse.java
@@ -1,7 +1,0 @@
-package konkuk.thip.feed.adapter.in.web.response;
-
-public record FeedCreateResponse(Long feedId) {
-    public static FeedCreateResponse of(Long feedId) {
-        return new FeedCreateResponse(feedId);
-    }
-}

--- a/src/main/java/konkuk/thip/feed/adapter/in/web/response/FeedIdResponse.java
+++ b/src/main/java/konkuk/thip/feed/adapter/in/web/response/FeedIdResponse.java
@@ -1,0 +1,7 @@
+package konkuk.thip.feed.adapter.in.web.response;
+
+public record FeedIdResponse(Long feedId) {
+    public static FeedIdResponse of(Long feedId) {
+        return new FeedIdResponse(feedId);
+    }
+}

--- a/src/main/java/konkuk/thip/feed/adapter/out/jpa/FeedJpaEntity.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/jpa/FeedJpaEntity.java
@@ -3,6 +3,7 @@ package konkuk.thip.feed.adapter.out.jpa;
 
 import jakarta.persistence.*;
 import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.feed.domain.Feed;
 import konkuk.thip.post.adapter.out.jpa.PostJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import lombok.AccessLevel;
@@ -39,5 +40,13 @@ public class FeedJpaEntity extends PostJpaEntity {
         this.reportCount = reportCount;
         this.bookJpaEntity = bookJpaEntity;
         this.contentList = contentList;
+    }
+
+    public void updateFrom(Feed feed) {
+        this.content = feed.getContent();
+        this.isPublic = feed.getIsPublic();
+        this.reportCount = feed.getReportCount();
+        this.likeCount = feed.getLikeCount();
+        this.commentCount = feed.getCommentCount();
     }
 }

--- a/src/main/java/konkuk/thip/feed/adapter/out/mapper/FeedMapper.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/mapper/FeedMapper.java
@@ -6,13 +6,17 @@ import konkuk.thip.feed.adapter.out.jpa.TagJpaEntity;
 import konkuk.thip.feed.domain.Feed;
 import konkuk.thip.feed.domain.Tag;
 import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Component
+@RequiredArgsConstructor
 public class FeedMapper {
+
+    private final ContentMapper contentMapper;
 
     public FeedJpaEntity toJpaEntity(Feed feed, UserJpaEntity userJpaEntity, BookJpaEntity bookJpaEntity) {
         return FeedJpaEntity.builder()
@@ -41,6 +45,9 @@ public class FeedMapper {
                         .map(TagJpaEntity::getValue)
                         .map(Tag::from)
                         .toList())
+                .contentList(feedJpaEntity.getContentList().stream()
+                                .map(contentMapper::toDomainEntity)
+                                .toList())
                 .createdAt(feedJpaEntity.getCreatedAt())
                 .modifiedAt(feedJpaEntity.getModifiedAt())
                 .status(feedJpaEntity.getStatus())

--- a/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/FeedTag/FeedTagJpaRepository.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/FeedTag/FeedTagJpaRepository.java
@@ -1,7 +1,16 @@
 package konkuk.thip.feed.adapter.out.persistence.repository.FeedTag;
 
+import konkuk.thip.feed.adapter.out.jpa.FeedJpaEntity;
 import konkuk.thip.feed.adapter.out.jpa.FeedTagJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FeedTagJpaRepository extends JpaRepository<FeedTagJpaEntity, Long>{
+
+    @Modifying
+    @Query("DELETE FROM FeedTagJpaEntity ft WHERE ft.feedJpaEntity = :feedJpaEntity")
+    void deleteAllByFeedJpaEntity(@Param("feedJpaEntity") FeedJpaEntity feedJpaEntity);
+
 }

--- a/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/Tag/TagJpaRepository.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/Tag/TagJpaRepository.java
@@ -2,9 +2,16 @@ package konkuk.thip.feed.adapter.out.persistence.repository.Tag;
 
 import konkuk.thip.feed.adapter.out.jpa.TagJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TagJpaRepository extends JpaRepository<TagJpaEntity, Long>{
     Optional<TagJpaEntity> findByValue(String value);
+
+    @Query("SELECT ft.tagJpaEntity FROM FeedTagJpaEntity ft WHERE ft.feedJpaEntity.postId = :feedId")
+    List<TagJpaEntity> findAllByFeedId(@Param("feedId") Long feedId);
+
 }

--- a/src/main/java/konkuk/thip/feed/application/port/in/FeedUpdateUseCase.java
+++ b/src/main/java/konkuk/thip/feed/application/port/in/FeedUpdateUseCase.java
@@ -1,0 +1,7 @@
+package konkuk.thip.feed.application.port.in;
+
+import konkuk.thip.feed.application.port.in.dto.FeedUpdateCommand;
+
+public interface FeedUpdateUseCase {
+    Long updateFeed(FeedUpdateCommand command);
+}

--- a/src/main/java/konkuk/thip/feed/application/port/in/dto/FeedCreateCommand.java
+++ b/src/main/java/konkuk/thip/feed/application/port/in/dto/FeedCreateCommand.java
@@ -10,8 +10,6 @@ public record FeedCreateCommand(
 
         Boolean isPublic,
 
-        String category,
-
         List<String> tagList,
 
         Long userId

--- a/src/main/java/konkuk/thip/feed/application/port/in/dto/FeedUpdateCommand.java
+++ b/src/main/java/konkuk/thip/feed/application/port/in/dto/FeedUpdateCommand.java
@@ -1,0 +1,20 @@
+package konkuk.thip.feed.application.port.in.dto;
+
+import java.util.List;
+
+public record FeedUpdateCommand(
+
+        String contentBody,
+
+        Boolean isPublic,
+
+        List<String> tagList,
+
+        List<String> remainImageUrls,
+
+        Long userId,
+
+        Long feedId
+)
+{
+}

--- a/src/main/java/konkuk/thip/feed/application/port/out/FeedCommandPort.java
+++ b/src/main/java/konkuk/thip/feed/application/port/out/FeedCommandPort.java
@@ -5,4 +5,6 @@ import konkuk.thip.feed.domain.Feed;
 
 public interface FeedCommandPort {
     Long save(Feed feed);
+    Long update(Feed feed);
+    Feed findById(Long id);
 }

--- a/src/main/java/konkuk/thip/feed/application/service/FeedUpdateService.java
+++ b/src/main/java/konkuk/thip/feed/application/service/FeedUpdateService.java
@@ -23,15 +23,14 @@ public class FeedUpdateService implements FeedUpdateUseCase {
     @Transactional
     public Long updateFeed(FeedUpdateCommand command) {
 
-        // 1. 유효성 검증
+        //1. 유효성 검증
         Feed.validateTags(command.tagList());
         Feed.validateImageCount(command.remainImageUrls() != null ? command.remainImageUrls().size() : 0);
 
-        // 2. 피드 조회 및 유효성 검증
+        // 2. 피드 조회
         Feed feed = feedCommandPort.findById(command.feedId());
-        feed.validateCreator(command.userId());
 
-        // 3. 도메인 내부 상태 변경
+        // 3. 도메인 내에서 내부 상태 변경 및 검증
         applyPartialFeedUpdate(feed, command);
 
         // 4. 업데이트
@@ -41,17 +40,16 @@ public class FeedUpdateService implements FeedUpdateUseCase {
     private void applyPartialFeedUpdate(Feed feed, FeedUpdateCommand command) {
 
         if (command.remainImageUrls() != null) {
-            feed.validateOwnsImages(command.remainImageUrls());
-            feed.updateImages(command.remainImageUrls());
+            feed.updateImages(command.userId(), command.remainImageUrls());
         }
         if (command.contentBody() != null) {
-            feed.updateContent(command.contentBody());
+            feed.updateContent(command.userId(), command.contentBody());
         }
         if (command.isPublic() != null) {
-            feed.updateVisibility(command.isPublic());
+            feed.updateVisibility(command.userId(), command.isPublic());
         }
         if (command.tagList() != null) {
-            feed.updateTags(command.tagList());
+            feed.updateTags(command.userId(), command.tagList());
         }
     }
 

--- a/src/main/java/konkuk/thip/feed/application/service/FeedUpdateService.java
+++ b/src/main/java/konkuk/thip/feed/application/service/FeedUpdateService.java
@@ -1,0 +1,72 @@
+package konkuk.thip.feed.application.service;
+
+import konkuk.thip.feed.application.port.in.FeedUpdateUseCase;
+import konkuk.thip.feed.application.port.in.dto.FeedUpdateCommand;
+import konkuk.thip.feed.application.port.out.FeedCommandPort;
+import konkuk.thip.feed.application.port.out.S3CommandPort;
+import konkuk.thip.feed.domain.Content;
+import konkuk.thip.feed.domain.Feed;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FeedUpdateService implements FeedUpdateUseCase {
+
+    private final S3CommandPort s3CommandPort;
+    private final FeedCommandPort feedCommandPort;
+
+    @Override
+    @Transactional
+    public Long updateFeed(FeedUpdateCommand command) {
+
+        // 1. 유효성 검증
+        Feed.validateTags(command.tagList());
+        Feed.validateImageCount(command.remainImageUrls() != null ? command.remainImageUrls().size() : 0);
+
+        // 2. 피드 조회 및 유효성 검증
+        Feed feed = feedCommandPort.findById(command.feedId());
+        feed.validateCreator(command.userId());
+
+        // 3. 도메인 내부 상태 변경
+        applyPartialFeedUpdate(feed, command);
+
+        // 4. 업데이트
+        return feedCommandPort.update(feed);
+    }
+
+    private void applyPartialFeedUpdate(Feed feed, FeedUpdateCommand command) {
+
+        if (command.remainImageUrls() != null) {
+            feed.validateOwnsImages(command.remainImageUrls());
+            feed.updateImages(command.remainImageUrls());
+        }
+        if (command.contentBody() != null) {
+            feed.updateContent(command.contentBody());
+        }
+        if (command.isPublic() != null) {
+            feed.updateVisibility(command.isPublic());
+        }
+        if (command.tagList() != null) {
+            feed.updateTags(command.tagList());
+        }
+    }
+
+    //TODO 추후 이벤트 기반으로 트랜잭션 커밋후 S3 삭제하도록 리펙토링 or 사용하지 않는 이미지 배치 삭제방식 논의
+    private void handleFeedImageDelete(Feed feed, List<String> remainImageUrls) {
+        List<String> oldImageUrls = feed.getContentList().stream()
+                .map(Content::getContentUrl)
+                .filter(url -> url != null && !url.isBlank())
+                .toList();
+
+        List<String> toDelete = oldImageUrls.stream()
+                .filter(url -> !remainImageUrls.contains(url))
+                .toList();
+        if (!toDelete.isEmpty()) {
+            s3CommandPort.deleteImages(toDelete);
+        }
+    }
+}

--- a/src/main/java/konkuk/thip/feed/domain/Feed.java
+++ b/src/main/java/konkuk/thip/feed/domain/Feed.java
@@ -44,6 +44,9 @@ public class Feed extends BaseDomainEntity {
     public static Feed withoutId(String content, Long creatorId, Boolean isPublic, Long targetBookId,
                                  List<String> tagValues, List<String> imageUrls) {
 
+        validateTags(tagValues);
+        validateImageCount(imageUrls != null ? imageUrls.size() : 0);
+
         return Feed.builder()
                 .id(null)
                 .content(content)
@@ -95,20 +98,28 @@ public class Feed extends BaseDomainEntity {
         }
     }
 
-    public void updateContent(String newContent) {
+    public void updateContent(Long userId, String newContent) {
+        validateCreator(userId);
         this.content = newContent;
     }
 
-    public void updateVisibility(Boolean isPublic) {
+    public void updateVisibility(Long userId, Boolean isPublic) {
+        validateCreator(userId);
         this.isPublic = isPublic;
     }
 
-    public void updateTags(List<String> tagValues) {
-        this.tagList = Tag.fromList(tagValues);
+    public void updateTags(Long userId, List<String> newTagValues) {
+        validateCreator(userId);
+        validateTags(newTagValues);
+        this.tagList = Tag.fromList(newTagValues); // Tag.from(...) 등으로 변환
     }
 
-    public void updateImages(List<String> imageUrls) {
-        this.contentList = convertToContentList(imageUrls);
+    public void updateImages(Long userId, List<String> newImageUrls) {
+        validateCreator(userId);
+        validateImageCount(newImageUrls.size());
+        validateOwnsImages(newImageUrls);
+
+        this.contentList = convertToContentList(newImageUrls);
     }
 
     public void validateOwnsImages(List<String> candidateImageUrls) {

--- a/src/main/java/konkuk/thip/post/adapter/out/jpa/PostJpaEntity.java
+++ b/src/main/java/konkuk/thip/post/adapter/out/jpa/PostJpaEntity.java
@@ -21,11 +21,11 @@ public abstract class PostJpaEntity extends BaseJpaEntity {
     private Long postId;
 
     @Column(length = 6100, nullable = false)
-    private String content;
+    protected String content;
 
-    private Integer likeCount = 0;
+    protected Integer likeCount = 0;
 
-    private Integer commentCount = 0;
+    protected Integer commentCount = 0;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomCommandPersistenceAdapter.java
@@ -9,7 +9,6 @@ import konkuk.thip.room.adapter.out.mapper.RoomMapper;
 import konkuk.thip.room.adapter.out.persistence.repository.category.CategoryJpaRepository;
 import konkuk.thip.room.adapter.out.persistence.repository.RoomJpaRepository;
 import konkuk.thip.room.application.port.out.RoomCommandPort;
-import konkuk.thip.room.domain.Category;
 import konkuk.thip.room.domain.Room;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -46,13 +45,6 @@ public class RoomCommandPersistenceAdapter implements RoomCommandPort {
 
         RoomJpaEntity roomJpaEntity = roomMapper.toJpaEntity(room, bookJpaEntity, categoryJpaEntity);
         return roomJpaRepository.save(roomJpaEntity).getRoomId();
-    }
-
-    @Override
-    public Category findCategoryByValue(String value) {
-        CategoryJpaEntity categoryJpaEntity = categoryJpaRepository.findByValue(value).orElseThrow(
-                () -> new EntityNotFoundException(CATEGORY_NOT_FOUND));
-        return Category.from(categoryJpaEntity.getValue());
     }
 
     @Override

--- a/src/main/java/konkuk/thip/room/application/port/out/RoomCommandPort.java
+++ b/src/main/java/konkuk/thip/room/application/port/out/RoomCommandPort.java
@@ -9,7 +9,5 @@ public interface RoomCommandPort {
 
     Long save(Room room);
 
-    Category findCategoryByValue(String value);
-
     void updateMemberCount(Room room);
 }

--- a/src/main/java/konkuk/thip/room/application/port/out/RoomCommandPort.java
+++ b/src/main/java/konkuk/thip/room/application/port/out/RoomCommandPort.java
@@ -19,8 +19,5 @@ public interface RoomCommandPort {
 
     Long save(Room room);
 
-    void updateMemberCount(Room room);
-    Category findCategoryByValue(String value);
-
     void update(Room room);
 }

--- a/src/test/java/konkuk/thip/common/util/TestEntityFactory.java
+++ b/src/test/java/konkuk/thip/common/util/TestEntityFactory.java
@@ -2,6 +2,9 @@ package konkuk.thip.common.util;
 
 import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
 import konkuk.thip.comment.adapter.out.jpa.CommentJpaEntity;
+import konkuk.thip.feed.adapter.out.jpa.ContentJpaEntity;
+import konkuk.thip.feed.adapter.out.jpa.FeedJpaEntity;
+import konkuk.thip.feed.adapter.out.jpa.FeedTagJpaEntity;
 import konkuk.thip.post.adapter.out.jpa.PostJpaEntity;
 import konkuk.thip.feed.adapter.out.jpa.TagJpaEntity;
 import konkuk.thip.record.adapter.out.jpa.RecordJpaEntity;
@@ -16,6 +19,8 @@ import konkuk.thip.user.adapter.out.jpa.UserRole;
 import konkuk.thip.vote.adapter.out.jpa.VoteJpaEntity;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 public class TestEntityFactory {
@@ -169,4 +174,52 @@ public class TestEntityFactory {
                 .value(value)
                 .build();
     }
+
+    public static FeedJpaEntity createFeed(UserJpaEntity user, BookJpaEntity book, boolean isPublic) {
+
+        return FeedJpaEntity.builder()
+                .content("기본 피드 본문입니다.")
+                .isPublic(isPublic)
+                .likeCount(0)
+                .commentCount(0)
+                .reportCount(0)
+                .userJpaEntity(user)
+                .bookJpaEntity(book)
+                .contentList(new ArrayList<>())
+                .build();
+    }
+
+    public static FeedTagJpaEntity createFeedTagMapping(FeedJpaEntity feed, TagJpaEntity tag) {
+        return FeedTagJpaEntity.builder()
+                .feedJpaEntity(feed)
+                .tagJpaEntity(tag)
+                .build();
+    }
+
+
+    public static FeedJpaEntity createFeedWithContents(UserJpaEntity user, BookJpaEntity book, List<String> imageUrls, boolean isPublic) {
+
+        FeedJpaEntity feed = FeedJpaEntity.builder()
+                .content("이미지 포함 피드")
+                .isPublic(isPublic)
+                .likeCount(0)
+                .commentCount(0)
+                .reportCount(0)
+                .userJpaEntity(user)
+                .bookJpaEntity(book)
+                .contentList(new ArrayList<>())
+                .build();
+
+        List<ContentJpaEntity> contents = imageUrls.stream()
+                .map(url -> ContentJpaEntity.builder()
+                        .contentUrl(url)
+                        .postJpaEntity(feed)
+                        .build())
+                .toList();
+
+        feed.getContentList().addAll(contents);
+        return feed;
+    }
+
+
 }

--- a/src/test/java/konkuk/thip/feed/adapter/in/web/FeedCreateControllerTest.java
+++ b/src/test/java/konkuk/thip/feed/adapter/in/web/FeedCreateControllerTest.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import static konkuk.thip.common.exception.code.ErrorCode.API_INVALID_PARAM;
-import static konkuk.thip.common.exception.code.ErrorCode.INVALID_FEED_CREATE;
+import static konkuk.thip.common.exception.code.ErrorCode.INVALID_FEED_COMMAND;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -55,7 +55,7 @@ class FeedCreateControllerTest {
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
                         .requestAttr("userId", 1L))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value(INVALID_FEED_CREATE.getCode()))
+                .andExpect(jsonPath("$.code").value(INVALID_FEED_COMMAND.getCode()))
                 .andExpect(jsonPath("$.message", containsString(message)));
     }
 
@@ -102,24 +102,8 @@ class FeedCreateControllerTest {
     }
 
     @Nested
-    @DisplayName("카테고리/태그 입력 불일치 검증")
-    class CategoryTagValidation {
-
-        @Test
-        @DisplayName("카테고리만 있고 태그가 없을 때 400 반환")
-        void onlyCategory() throws Exception {
-            Map<String, Object> req = buildValidRequest();
-            req.put("tagList", List.of());
-            assertBadRequest_InvalidFeedCreate(req, "카테고리와 태그는 모두 입력되거나 모두 비워져야 합니다.");
-        }
-
-        @Test
-        @DisplayName("태그만 있고 카테고리가 없을 때 400 반환")
-        void onlyTags() throws Exception {
-            Map<String, Object> req = buildValidRequest();
-            req.put("category", null);
-            assertBadRequest_InvalidFeedCreate(req, "카테고리와 태그는 모두 입력되거나 모두 비워져야 합니다.");
-        }
+    @DisplayName("태그 입력 불일치 검증")
+    class TagValidation {
 
         @Test
         @DisplayName("태그가 6개 이상이면 400 반환")
@@ -171,7 +155,7 @@ class FeedCreateControllerTest {
             );
 
             result.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.code").value(INVALID_FEED_CREATE.getCode()))
+                    .andExpect(jsonPath("$.code").value(INVALID_FEED_COMMAND.getCode()))
                     .andExpect(jsonPath("$.message",containsString("이미지는 최대 3개까지 업로드할 수 있습니다.")));
 
         }

--- a/src/test/java/konkuk/thip/feed/adapter/in/web/FeedUpdateAPITest.java
+++ b/src/test/java/konkuk/thip/feed/adapter/in/web/FeedUpdateAPITest.java
@@ -1,0 +1,216 @@
+package konkuk.thip.feed.adapter.in.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.adapter.out.persistence.repository.BookJpaRepository;
+import konkuk.thip.common.util.TestEntityFactory;
+import konkuk.thip.config.TestS3MockConfig;
+import konkuk.thip.feed.adapter.out.jpa.ContentJpaEntity;
+import konkuk.thip.feed.adapter.out.jpa.FeedJpaEntity;
+import konkuk.thip.feed.adapter.out.jpa.FeedTagJpaEntity;
+import konkuk.thip.feed.adapter.out.jpa.TagJpaEntity;
+import konkuk.thip.feed.adapter.out.persistence.repository.Content.ContentJpaRepository;
+import konkuk.thip.feed.adapter.out.persistence.repository.FeedJpaRepository;
+import konkuk.thip.feed.adapter.out.persistence.repository.FeedTag.FeedTagJpaRepository;
+import konkuk.thip.feed.adapter.out.persistence.repository.Tag.TagJpaRepository;
+import konkuk.thip.room.adapter.out.jpa.CategoryJpaEntity;
+import konkuk.thip.room.adapter.out.persistence.repository.category.CategoryJpaRepository;
+import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.repository.alias.AliasJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+@Transactional
+@Import(TestS3MockConfig.class)
+@DisplayName("[통합] 피드 수정 api 통합 테스트")
+class FeedUpdateAPITest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private AliasJpaRepository aliasJpaRepository;
+    @Autowired private UserJpaRepository userJpaRepository;
+    @Autowired private CategoryJpaRepository categoryJpaRepository;
+    @Autowired private BookJpaRepository bookJpaRepository;
+    @Autowired private TagJpaRepository tagJpaRepository;
+    @Autowired private FeedJpaRepository feedJpaRepository;
+    @Autowired private FeedTagJpaRepository feedTagJpaRepository;
+    @Autowired private ContentJpaRepository contentJpaRepository;
+
+    private UserJpaEntity user;
+    private BookJpaEntity book;
+    private FeedJpaEntity feed;
+    private TagJpaEntity tag1;
+    private TagJpaEntity tag2;
+    private TagJpaEntity tag3;
+
+    @BeforeEach
+    void setUp() {
+        AliasJpaEntity alias = aliasJpaRepository.save(TestEntityFactory.createLiteratureAlias());
+        user = userJpaRepository.save(TestEntityFactory.createUser(alias));
+        CategoryJpaEntity category = categoryJpaRepository.save(TestEntityFactory.createLiteratureCategory(alias));
+
+        tag1 = tagJpaRepository.save(TestEntityFactory.createTag(category, "소설추천"));
+        tag2 = tagJpaRepository.save(TestEntityFactory.createTag(category, "책추천"));
+        tag3 = tagJpaRepository.save(TestEntityFactory.createTag(category, "오늘의책"));
+        book = bookJpaRepository.save(TestEntityFactory.createBookWithISBN("9788954682152"));
+        feed = feedJpaRepository.save(TestEntityFactory.createFeed(user,book, true));
+    }
+
+    @Test
+    @DisplayName("여러 태그가 있는 피드에서 태그를 수정하면 최종 태그로 반영되어 저장된다.")
+    void updateTaggedFeed_shouldUpdateTagsCorrectly() throws Exception {
+
+        // given
+        Long feedId = feed.getPostId();
+
+        // 기존 태그 3개 연관
+        List<TagJpaEntity> existingTags = List.of(tag1, tag2, tag3);
+        List<FeedTagJpaEntity> mappings = existingTags.stream()
+                .map(tag -> TestEntityFactory.createFeedTagMapping(feed, tag))
+                .toList();
+
+        feedTagJpaRepository.saveAll(mappings);
+
+        // 수정 요청
+        Map<String, Object> request = new HashMap<>();
+        request.put("contentBody", "태그 갱신 테스트");
+        request.put("isPublic", false);
+        request.put("tagList", List.of("소설추천", "오늘의책")); // 하나 제거됨
+
+        // when
+        ResultActions result = mockMvc.perform(patch("/feeds/{feedId}", feedId)
+                .requestAttr("userId", user.getUserId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isOk());
+        long tagCount = feedTagJpaRepository.findAll().stream()
+                .filter(ft -> ft.getFeedJpaEntity().getPostId().equals(feedId))
+                .count();
+        assertThat(tagCount).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("이미지가 여러 개인 피드에서 이미지 일부만 유지하도록 수정할 수 있다.")
+    void updateImageFeed_shouldRetainSomeImagesOnly() throws Exception {
+
+        // given
+        List<String> originalImages = List.of(
+                "https://s3-mock/image-1.jpg",
+                "https://s3-mock/image-2.jpg",
+                "https://s3-mock/image-3.jpg"
+        );
+
+        FeedJpaEntity feed = feedJpaRepository.save(TestEntityFactory.createFeedWithContents(user, book, originalImages, true));
+        Long feedId = feed.getPostId();
+
+        // 수정 요청: 이미지 1개만 유지
+        Map<String, Object> request = new HashMap<>();
+        request.put("contentBody", "이미지 삭제 테스트");
+        request.put("isPublic", false);
+        request.put("remainImageUrls", List.of("https://s3-mock/image-2.jpg")); // 나머지 삭제
+
+        // when
+        ResultActions result = mockMvc.perform(patch("/feeds/{feedId}", feedId)
+                .requestAttr("userId", user.getUserId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isOk());
+        FeedJpaEntity updatedFeed = feedJpaRepository.findById(feedId).orElseThrow();
+        assertThat(updatedFeed.getContentList()).hasSize(1);
+        assertThat(updatedFeed.getContentList().get(0).getContentUrl()).isEqualTo("https://s3-mock/image-2.jpg");
+        List<ContentJpaEntity> contentRows = contentJpaRepository.findAll().stream()
+                .filter(c -> c.getPostJpaEntity().getPostId().equals(feedId))
+                .toList();
+        assertThat(contentRows).hasSize(1);
+        assertThat(contentRows.get(0).getContentUrl()).isEqualTo("https://s3-mock/image-2.jpg");
+    }
+
+    @Test
+    @DisplayName("피드의 내용, 공개 여부, 태그, 이미지 전체를 모두 수정할 수 있다.")
+    void updateFeedWithAllFields_shouldModifyEverythingCorrectly() throws Exception {
+
+        // given
+        // 기존 이미지 3개
+        List<String> originalImages = List.of(
+                "https://s3-mock/image-1.jpg",
+                "https://s3-mock/image-2.jpg",
+                "https://s3-mock/image-3.jpg"
+        );
+        FeedJpaEntity feed = feedJpaRepository.save(TestEntityFactory.createFeedWithContents(user, book, originalImages, true));
+        Long feedId = feed.getPostId();
+
+        // 기존 태그 3개 매핑
+        List<TagJpaEntity> existingTags = List.of(tag1, tag2, tag3);
+        List<FeedTagJpaEntity> tagMappings = existingTags.stream()
+                .map(tag -> TestEntityFactory.createFeedTagMapping(feed, tag))
+                .collect(Collectors.toList());
+        feedTagJpaRepository.saveAll(tagMappings);
+
+        // 수정 요청: 태그 일부 삭제 & 이미지 일부 삭제 & 본문 변경 & 공개 여부 변경
+        Map<String, Object> request = new HashMap<>();
+        request.put("contentBody", "전부 수정되는 피드 테스트");
+        request.put("isPublic", false);
+        request.put("remainImageUrls", List.of("https://s3-mock/image-2.jpg")); // 이미지 1개 유지
+        request.put("tagList", List.of("소설추천", "오늘의책")); // 태그 2개만 남김
+
+        // when
+        ResultActions result = mockMvc.perform(patch("/feeds/{feedId}", feedId)
+                .requestAttr("userId", user.getUserId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isOk());
+
+        FeedJpaEntity updated = feedJpaRepository.findById(feedId).orElseThrow();
+        // 1. 본문
+        assertThat(updated.getContent()).isEqualTo("전부 수정되는 피드 테스트");
+        // 2. 공개 여부
+        assertThat(updated.getIsPublic()).isFalse();
+        // 3. 이미지
+        assertThat(updated.getContentList()).hasSize(1);
+        assertThat(updated.getContentList().get(0).getContentUrl()).isEqualTo("https://s3-mock/image-2.jpg");
+        List<ContentJpaEntity> contentRows = contentJpaRepository.findAll().stream()
+                .filter(c -> c.getPostJpaEntity().getPostId().equals(feedId))
+                .toList();
+        assertThat(contentRows).hasSize(1);
+        assertThat(contentRows.get(0).getContentUrl()).isEqualTo("https://s3-mock/image-2.jpg");
+        // 4. 태그 갯수
+        long tagCount = feedTagJpaRepository.findAll().stream()
+                .filter(tag -> tag.getFeedJpaEntity().getPostId().equals(feedId))
+                .count();
+        assertThat(tagCount).isEqualTo(2);
+    }
+
+}

--- a/src/test/java/konkuk/thip/feed/adapter/in/web/FeedUpdateControllerTest.java
+++ b/src/test/java/konkuk/thip/feed/adapter/in/web/FeedUpdateControllerTest.java
@@ -109,7 +109,7 @@ class FeedUpdateControllerTest {
         }
 
         @Test
-        @DisplayName("피드 생성자가 아닌 유저가 수정하려는 경우 400 반환")
+        @DisplayName("피드 생성자가 아닌 유저가 수정하려는 경우 403 반환")
         void unauthorizedFeedEdit() throws Exception {
             Map<String, Object> req = buildValidUpdateRequest();
             mockMvc.perform(patch("/feeds/" + savedFeedId)

--- a/src/test/java/konkuk/thip/feed/adapter/in/web/FeedUpdateControllerTest.java
+++ b/src/test/java/konkuk/thip/feed/adapter/in/web/FeedUpdateControllerTest.java
@@ -1,0 +1,208 @@
+package konkuk.thip.feed.adapter.in.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.adapter.out.persistence.repository.BookJpaRepository;
+import konkuk.thip.common.util.TestEntityFactory;
+import konkuk.thip.feed.adapter.out.persistence.repository.Content.ContentJpaRepository;
+import konkuk.thip.feed.adapter.out.persistence.repository.FeedJpaRepository;
+import konkuk.thip.feed.adapter.out.persistence.repository.FeedTag.FeedTagJpaRepository;
+import konkuk.thip.feed.adapter.out.persistence.repository.Tag.TagJpaRepository;
+import konkuk.thip.room.adapter.out.jpa.CategoryJpaEntity;
+import konkuk.thip.room.adapter.out.persistence.repository.category.CategoryJpaRepository;
+import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.repository.alias.AliasJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static konkuk.thip.common.exception.code.ErrorCode.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+@Transactional
+@DisplayName("[단위] 피드 생성 api controller 단위 테스트")
+class FeedUpdateControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private AliasJpaRepository aliasJpaRepository;
+    @Autowired private UserJpaRepository userJpaRepository;
+    @Autowired private CategoryJpaRepository categoryJpaRepository;
+    @Autowired private BookJpaRepository bookJpaRepository;
+    @Autowired private TagJpaRepository tagJpaRepository;
+    @Autowired private FeedJpaRepository feedJpaRepository;
+    @Autowired private FeedTagJpaRepository feedTagJpaRepository;
+    @Autowired private ContentJpaRepository contentJpaRepository;
+
+    private Long savedFeedId;
+    private Long creatorUserId;
+
+    @BeforeEach
+    void setUp() {
+
+        AliasJpaEntity alias = aliasJpaRepository.save(TestEntityFactory.createLiteratureAlias());
+        UserJpaEntity user = userJpaRepository.save(TestEntityFactory.createUser(alias));
+        CategoryJpaEntity category = categoryJpaRepository.save(TestEntityFactory.createLiteratureCategory(alias));
+
+        tagJpaRepository.save(TestEntityFactory.createTag(category, "소설추천"));
+        tagJpaRepository.save(TestEntityFactory.createTag(category, "책추천"));
+        tagJpaRepository.save(TestEntityFactory.createTag(category, "오늘의책"));
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBookWithISBN("9788954682152"));
+        savedFeedId = feedJpaRepository.save(TestEntityFactory.createFeed(user,book, true)).getPostId();
+        creatorUserId = user.getUserId();
+    }
+
+    private Map<String, Object> buildValidUpdateRequest() {
+        Map<String, Object> request = new HashMap<>();
+        request.put("contentBody", "수정된 테스트 콘텐츠");
+        request.put("isPublic", true);
+        request.put("tagList", List.of("책추천", "소설추천"));
+        request.put("remainImageUrls", List.of());
+        return request;
+    }
+
+    private void assertBadRequest(int expectedCode, Map<String, Object> request, String message) throws Exception {
+        mockMvc.perform(patch("/feeds/1")
+                                .requestAttr("userId", 100L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsBytes(request))
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(expectedCode))
+                .andExpect(jsonPath("$.message", containsString(message)));
+    }
+
+    @Nested
+    @DisplayName("피드 관련 검증")
+    class BasicValidation {
+
+        @Test
+        @DisplayName("존재하지 않는 피드를 삭제(수정)하려는 경우 404 반환")
+        void deleteNonExistentFeed() throws Exception {
+            Map<String, Object> req = buildValidUpdateRequest();
+            mockMvc.perform(patch("/feeds/99999")
+                            .requestAttr("userId", 100L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(req))
+                    )
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(FEED_NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.message", containsString("존재하지 않는 FEED 입니다.")));
+        }
+
+        @Test
+        @DisplayName("피드 생성자가 아닌 유저가 수정하려는 경우 400 반환")
+        void unauthorizedFeedEdit() throws Exception {
+            Map<String, Object> req = buildValidUpdateRequest();
+            mockMvc.perform(patch("/feeds/" + savedFeedId)
+                    .requestAttr("userId",100L)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(req))
+                    )
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value(FEED_UPDATE_FORBIDDEN.getCode()))
+                    .andExpect(jsonPath("$.message", containsString("피드 수정 권한이 없습니다.")));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("태그 검증")
+    class TagValidation {
+
+        @Test
+        @DisplayName("태그리스트 중 존재하지 않는 태그가 있을 때 400 반환")
+        void invalidTagNames() throws Exception {
+            Map<String, Object> req = buildValidUpdateRequest();
+            req.put("tagList", List.of("에세이", "휴식", "힐링"));
+            mockMvc.perform(patch("/feeds/" + savedFeedId)
+                            .requestAttr("userId",creatorUserId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(req))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(TAG_NAME_NOT_MATCH.getCode()))
+                    .andExpect(jsonPath("$.message", containsString("일치하는 태그 이름이 없습니다")))
+                    .andExpect(jsonPath("$.message", containsString("에세이")))
+                    .andExpect(jsonPath("$.message", containsString("휴식")))
+                    .andExpect(jsonPath("$.message", containsString("힐링")));
+        }
+
+        @Test
+        @DisplayName("태그가 5개 초과일 경우 400 반환")
+        void tooManyTags() throws Exception {
+            Map<String, Object> req = buildValidUpdateRequest();
+            req.put("tagList", List.of("t1","t2","t3","t4","t5","t6"));
+            assertBadRequest(INVALID_FEED_COMMAND.getCode(), req, "태그는 최대 5개까지 입력할 수 있습니다.");
+        }
+
+        @Test
+        @DisplayName("태그가 중복되어 있을 경우 400 반환")
+        void duplicatedTags() throws Exception {
+            Map<String, Object> req = buildValidUpdateRequest();
+            req.put("tagList", List.of("중복", "중복"));
+            assertBadRequest(INVALID_FEED_COMMAND.getCode(), req, "태그는 중복 될 수 없습니다.");
+        }
+
+    }
+
+    @Nested
+    @DisplayName("이미지 검증")
+    class ImageValidation {
+
+        @Test
+        @DisplayName("이미지가 3개 초과되면 400 반환")
+        void tooManyImages() throws Exception {
+            Map<String, Object> req = buildValidUpdateRequest();
+            req.put("remainImageUrls",
+                    List.of("https://s3.../profile1.png", "https://s3.../profile2.png",
+                    "https://s3.../profile3.png", "https://s3.../profile4.png"));
+            mockMvc.perform(patch("/feeds/" + savedFeedId)
+                            .requestAttr("userId",creatorUserId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(req))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(INVALID_FEED_COMMAND.getCode()))
+                    .andExpect(jsonPath("$.message",containsString("이미지는 최대 3개까지 업로드할 수 있습니다.")));
+        }
+
+        @Test
+        @DisplayName("이미지 url이 잘못되었을 때 400 반환")
+        void invalidImageUrl() throws Exception {
+            Map<String, Object> req = buildValidUpdateRequest();
+            req.put("remainImageUrls", List.of("https://s3.../profile1.png"));
+            mockMvc.perform(patch("/feeds/" + savedFeedId)
+                            .requestAttr("userId",creatorUserId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(req))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(INVALID_FEED_COMMAND.getCode()))
+                    .andExpect(jsonPath("$.message", containsString("해당 이미지는 이 피드에 존재하지 않습니다")));
+        }
+    }
+
+}

--- a/src/test/java/konkuk/thip/feed/adapter/in/web/FeedUpdateControllerTest.java
+++ b/src/test/java/konkuk/thip/feed/adapter/in/web/FeedUpdateControllerTest.java
@@ -95,8 +95,8 @@ class FeedUpdateControllerTest {
     class BasicValidation {
 
         @Test
-        @DisplayName("존재하지 않는 피드를 삭제(수정)하려는 경우 404 반환")
-        void deleteNonExistentFeed() throws Exception {
+        @DisplayName("존재하지 않는 피드를 수정하려는 경우 404 반환")
+        void updateNonExistentFeed() throws Exception {
             Map<String, Object> req = buildValidUpdateRequest();
             mockMvc.perform(patch("/feeds/99999")
                             .requestAttr("userId", 100L)

--- a/src/test/java/konkuk/thip/feed/adapter/in/web/FeedUpdateControllerTest.java
+++ b/src/test/java/konkuk/thip/feed/adapter/in/web/FeedUpdateControllerTest.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
 import konkuk.thip.book.adapter.out.persistence.repository.BookJpaRepository;
 import konkuk.thip.common.util.TestEntityFactory;
-import konkuk.thip.feed.adapter.out.persistence.repository.Content.ContentJpaRepository;
 import konkuk.thip.feed.adapter.out.persistence.repository.FeedJpaRepository;
-import konkuk.thip.feed.adapter.out.persistence.repository.FeedTag.FeedTagJpaRepository;
 import konkuk.thip.feed.adapter.out.persistence.repository.Tag.TagJpaRepository;
 import konkuk.thip.room.adapter.out.jpa.CategoryJpaEntity;
 import konkuk.thip.room.adapter.out.persistence.repository.category.CategoryJpaRepository;
@@ -40,7 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("test")
 @AutoConfigureMockMvc(addFilters = false)
 @Transactional
-@DisplayName("[단위] 피드 생성 api controller 단위 테스트")
+@DisplayName("[단위] 피드 수정 api controller 단위 테스트")
 class FeedUpdateControllerTest {
 
     @Autowired
@@ -53,8 +51,6 @@ class FeedUpdateControllerTest {
     @Autowired private BookJpaRepository bookJpaRepository;
     @Autowired private TagJpaRepository tagJpaRepository;
     @Autowired private FeedJpaRepository feedJpaRepository;
-    @Autowired private FeedTagJpaRepository feedTagJpaRepository;
-    @Autowired private ContentJpaRepository contentJpaRepository;
 
     private Long savedFeedId;
     private Long creatorUserId;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #86

## 📝 작업 내용

- 피드 수정 api를 개발했습니다.
- 피드 생성/수정시에 카테고리 관계없이 여러 태그를 받을 수있는 요구사항을 피드 생성 개발 후에 확인하여서, 피드 수정시에 같이 수정했습니다.
- 여러 카테고리를 동시에 받을 수 있으면 그에 해당하는 태그가 무엇인지도 같이 검증을해야하고, 이미 DB에 사용자가 아닌 개발자/관리자에 의해 생성되는 값인 태그를 검증하려면 jpa 엔티티 상에서만 검증하는것이 더 타당할 것 같아 해당 태그가 상위 카테고리에 대한 태그인지에 대한 검증하는 로직은 삭제되었습니다.
- 피드 생성/수정시에 response dto가 동일하여 `FeedIdResponse`로 통일했습니다. 
- 피드 생성시에 Feed <-> Content의 양방향 매핑관계 설정 후, 피드 도메인 변환시 누락되었던 content 매핑관게를 추가했습니다.
- 피드 수정시에 상속구조인 피드가 부모(post)의 공통 필드를 수정하기 위해 접근 제어자를 protected로 수정했습니다.
- 관련 레포지토리 메서드도 작성하였는데 feed_tag 관계 테이블 때문에 join이 불가피하지만 한번만 하면되고, 다소 간단한 로직이라 JPQL을 사용해 구현했습니다.
- s3에 업로드된 이미지 삭제들은 추후에 배치방식으로 한번에 사용되지않는 이미지를 일괄 삭제할지,이벤트 처리 기반방식으로 할지 논의를 해봐야할 것 같아 관련 부분 TODO로 작성하였습니다. 개발 속도를 올리기위해 이미지 삭제는 추후에 이야기 해봐도 좋을 것 같습니다.
- 피드 생성/수정시에 입력값 검증이 같아 에러코드를 `INVALID_FEED_COMMAND`로 통일하였습니다. 
- 피드 수정 api 흐름은 다음과 같습니다.
1. 컨트롤러에 수정하고자하는 값들 요청
2. 서비스에서 피드가 도메인 규칙 검증 및 커맨드어댑터 호출
3. 어댑터에서 기존에 존재하는 feed 조회 후 업데이트
4. 업데이트된 해당 feedId 반환
## 📸 스크린샷

## 💬 리뷰 요구사항

> 피드 생성시에 Feed <-> Content의 양방향 매핑관계 설정 후, 피드 도메인 변환시 누락되었던 content 매핑관게를 추가했습니다.

해당FeedMappe에 ContentMapper를 의존관계를 갖도록 하여 구현했는데  피드 도메인(Feed)과 콘텐츠(Content)는 양방향 연관관계를 갖고 있으며, Feed가 애그리거트 루트로서 콘텐츠 리스트도 함께 관리하는 구조입니다. 
따라서 도메인 객체 변환시점에서 Feed ↔ Content 간 매핑 정보도 함께 변환되어야 했습니다. 
FeedJpaEntity → Feed(Domain) 변환 시 외부에서 Content 리스트를 따로 조회하거나 주입하는 것은 애그리거트 내부 연관 데이터를 외부에서 처리하는 책임 분산의 문제가 있어, FeedMapper 내부에서 ContentMapper를 의존성 주입받아 직접 처리하도록 구현했습니다.

도메인 규칙상, Feed는 자신이 가지는 콘텐츠의 생명주기를 함께 관리해야 하므로, 연관된 Content의 변환도 FeedMapper 내부에서 수행되는 것이 가장 자연스럽고 명확하다고 판단하여 해당방식과 같이 구현했는데 이 방식에대해 더 좋은 개선방안이 있다면 리뷰 부탁드립니다.

> 관련 레포지토리 메서드도 작성하였는데 feed_tag 관계 테이블 때문에 join이 불가피하지만 한번만 하면되고, 다소 간단한 로직이라 JPQL을 사용해 구현했습니다.

Feed와 Tag의 관계는 다대다(N:N)이며, 관계 테이블인 FeedTagJpaEntity를 통해 연결되어 있기 때문에, Feed와 Tag를 직접 조인하려면 중간 엔티티 조인(feed_tag)이 불가피한 구조입니다.
관계 테이블 조인은 Feed → FeedTag → Tag의 단순한 1회 Join만으로도 충분하기 때문에 JPQL 기반으로 깔끔하게 처리할 수 있다고 판단했습니다.
마찬가지로, Feed에 연결된 태그 정보를 제거하는 deleteAllByFeedJpaEntity 역시 복잡한 쿼리 없이 Feed 기준으로 중간 관계 테이블만 삭제하면 되므로, JPQL + @Modifying 조합으로 구현하는 것이 깔끔하다고 생각했습니다.
관련해서 더 좋은 개선방안이 있다면 리뷰 부탁드립니다.

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * 피드 수정(업데이트) API가 추가되어 사용자가 기존 피드를 부분적으로 수정할 수 있습니다.
  * 피드 수정 요청 시 내용, 공개 여부, 태그, 이미지 관리가 가능해졌습니다.

* **기능 개선**
  * 피드 생성 시 카테고리 입력이 제거되어 요청이 간소화되었습니다.
  * 피드 생성 및 수정 관련 오류 메시지가 명확해지고, 권한 없는 수정 시 403 오류가 반환됩니다.
  * 피드 내용과 이미지, 태그 관리 로직이 개선되어 유연한 업데이트가 가능합니다.

* **버그 수정**
  * 태그 중복, 최대 개수 초과, 이미지 개수 제한, 권한 검증 등 피드 생성 및 수정 시 유효성 검사가 강화되었습니다.

* **테스트**
  * 피드 수정 API에 대한 통합 및 단위 테스트가 추가되어 권한, 태그, 이미지 관련 다양한 시나리오를 검증합니다.

* **기타**
  * 내부 코드 구조 개선 및 중복 제거, 예외 처리 로직이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->