### PR TITLE
[feat] 내가 참여한 모임방 목록 조회

### DIFF
--- a/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
@@ -116,6 +116,8 @@ public enum ErrorCode implements ResponseCode {
     USER_ALREADY_PARTICIPATE(HttpStatus.BAD_REQUEST, 140005, "사용자가 이미 방에 참여한 상태입니다."),
     USER_NOT_PARTICIPATED(HttpStatus.BAD_REQUEST, 140006, "사용자가 방에 참여하지 않은 상태에서 취소하기는 불가합니다."),
     HOST_CANNOT_CANCEL(HttpStatus.BAD_REQUEST, 140007, "방장은 참여 취소를 할 수 없습니다."),
+    INVALID_MY_ROOM_TYPE(HttpStatus.BAD_REQUEST, 140008, "유저가 참가한 방 목록 검색 요청에 유효하지 않은 MY ROOM type 이 있습니다."),
+    INVALID_MY_ROOM_CURSOR(HttpStatus.BAD_REQUEST, 140009, "유저가 참가한 방 목록 검색 요청에 유효하지 않은 cursor 가 있습니다"),
 
     /**
      * 150000 : Category error

--- a/src/main/java/konkuk/thip/room/adapter/in/web/RoomQueryController.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/RoomQueryController.java
@@ -2,11 +2,7 @@ package konkuk.thip.room.adapter.in.web;
 
 import konkuk.thip.common.dto.BaseResponse;
 import konkuk.thip.common.security.annotation.UserId;
-import konkuk.thip.room.adapter.in.web.response.RoomPlayingDetailViewResponse;
-import konkuk.thip.room.adapter.in.web.response.RoomRecruitingDetailViewResponse;
-import konkuk.thip.room.adapter.in.web.response.RoomGetHomeJoinedListResponse;
-import konkuk.thip.room.adapter.in.web.response.RoomGetMemberListResponse;
-import konkuk.thip.room.adapter.in.web.response.RoomSearchResponse;
+import konkuk.thip.room.adapter.in.web.response.*;
 import konkuk.thip.room.application.port.in.*;
 import konkuk.thip.room.application.port.in.RoomGetHomeJoinedListUseCase;
 import konkuk.thip.room.application.port.in.RoomGetMemberListUseCase;
@@ -20,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+
 @RestController
 @RequiredArgsConstructor
 public class RoomQueryController {
@@ -30,6 +28,7 @@ public class RoomQueryController {
     private final RoomShowRecruitingDetailViewUseCase roomShowRecruitingDetailViewUseCase;
     private final RoomGetMemberListUseCase roomGetMemberListUseCase;
     private final RoomShowPlayingDetailViewUseCase roomShowPlayingDetailViewUseCase;
+    private final RoomShowMineUseCase roomShowMineUseCase;
 
     @GetMapping("/rooms/search")
     public BaseResponse<RoomSearchResponse> searchRooms(
@@ -82,4 +81,13 @@ public class RoomQueryController {
         return BaseResponse.ok(roomShowPlayingDetailViewUseCase.getPlayingRoomDetailView(userId, roomId));
     }
 
+    // 내 모임방 리스트 조회
+    @GetMapping("/rooms/my")
+    public BaseResponse<RoomShowMineResponse> getMyRooms(
+            @UserId final Long userId,
+            @RequestParam(value = "type", required = false, defaultValue = "playingAndRecruiting") final String type,
+            @RequestParam(value = "cursorDate", required = false) final LocalDate cursorDate,
+            @RequestParam(value = "cursorId", required = false) final Long cursorId) {
+        return BaseResponse.ok(roomShowMineUseCase.getMyRooms(userId, type, cursorDate, cursorId));
+    }
 }

--- a/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomShowMineResponse.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomShowMineResponse.java
@@ -1,0 +1,20 @@
+package konkuk.thip.room.adapter.in.web.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record RoomShowMineResponse(
+        List<MyRoom> roomList,
+        int size,       // 현제 페이지에 포함된 데이터 수
+        boolean last,
+        LocalDate nextCursorDate,       // 다음 페이지 시작 커서의 endDate 값
+        Long nextCursorId               // 다음 페이지 시작 커서의 roomId 값
+) {
+    public record MyRoom(
+            Long roomId,
+            String bookImageUrl,
+            String roomName,
+            int memberCount,
+            String endDate      // 방 진행 마감일 or 방 모집 마감일 (~ 뒤 형식)
+    ) {}
+}

--- a/src/main/java/konkuk/thip/room/adapter/out/jpa/RoomJpaEntity.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/jpa/RoomJpaEntity.java
@@ -69,4 +69,9 @@ public class RoomJpaEntity extends BaseJpaEntity {
         this.memberCount = room.getMemberCount();
         return this;
     }
+
+    // 테스트 메서드 편의용
+    public void updateMemberCount(int memberCount) {
+        this.memberCount = memberCount;
+    }
 }

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomQueryPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomQueryPersistenceAdapter.java
@@ -3,9 +3,11 @@ package konkuk.thip.room.adapter.out.persistence;
 import konkuk.thip.room.adapter.in.web.response.RoomRecruitingDetailViewResponse;
 import konkuk.thip.room.adapter.in.web.response.RoomGetHomeJoinedListResponse;
 import konkuk.thip.room.adapter.in.web.response.RoomSearchResponse;
+import konkuk.thip.room.adapter.in.web.response.RoomShowMineResponse;
 import konkuk.thip.room.adapter.out.mapper.RoomMapper;
 import konkuk.thip.room.adapter.out.persistence.repository.RoomJpaRepository;
 import konkuk.thip.room.application.port.out.RoomQueryPort;
+import konkuk.thip.room.application.port.out.dto.CursorSliceOfMyRoomView;
 import konkuk.thip.room.domain.Room;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -41,4 +43,25 @@ public class RoomQueryPersistenceAdapter implements RoomQueryPort {
     public Page<RoomGetHomeJoinedListResponse.RoomSearchResult> searchHomeJoinedRooms(Long userId, LocalDate date, Pageable pageable) {
         return roomJpaRepository.searchHomeJoinedRooms(userId, date, pageable);
     }
+
+    @Override
+    public CursorSliceOfMyRoomView<RoomShowMineResponse.MyRoom> findRecruitingRoomsUserParticipated(Long userId, LocalDate lastRoomStartDateCursor, Long lastRoomIdCursor, int pageSize) {
+        return roomJpaRepository.findRecruitingRoomsUserParticipated(userId, lastRoomStartDateCursor, lastRoomIdCursor, pageSize);
+    }
+
+    @Override
+    public CursorSliceOfMyRoomView<RoomShowMineResponse.MyRoom> findPlayingRoomsUserParticipated(Long userId, LocalDate lastRoomEndDateCursor, Long lastRoomIdCursor, int pageSize) {
+        return roomJpaRepository.findPlayingRoomsUserParticipated(userId, lastRoomEndDateCursor, lastRoomIdCursor, pageSize);
+    }
+
+    @Override
+    public CursorSliceOfMyRoomView<RoomShowMineResponse.MyRoom> findPlayingAndRecruitingRoomsUserParticipated(Long userId, LocalDate dateCursor, Long lastRoomIdCursor, int pageSize) {
+        return roomJpaRepository.findPlayingAndRecruitingRoomsUserParticipated(userId, dateCursor, lastRoomIdCursor, pageSize);
+    }
+
+    @Override
+    public CursorSliceOfMyRoomView<RoomShowMineResponse.MyRoom> findExpiredRoomsUserParticipated(Long userId, LocalDate lastRoomEndDateCursor, Long lastRoomIdCursor, int pageSize) {
+        return roomJpaRepository.findExpiredRoomsUserParticipated(userId, lastRoomEndDateCursor, lastRoomIdCursor, pageSize);
+    }
+
 }

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomQueryRepository.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomQueryRepository.java
@@ -3,6 +3,8 @@ package konkuk.thip.room.adapter.out.persistence.repository;
 import konkuk.thip.room.adapter.in.web.response.RoomRecruitingDetailViewResponse;
 import konkuk.thip.room.adapter.in.web.response.RoomGetHomeJoinedListResponse;
 import konkuk.thip.room.adapter.in.web.response.RoomSearchResponse;
+import konkuk.thip.room.adapter.in.web.response.RoomShowMineResponse;
+import konkuk.thip.room.application.port.out.dto.CursorSliceOfMyRoomView;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -15,5 +17,14 @@ public interface RoomQueryRepository {
     Page<RoomSearchResponse.RoomSearchResult> searchRoom(String keyword, String category, Pageable pageable);
 
     List<RoomRecruitingDetailViewResponse.RecommendRoom> findOtherRecruitingRoomsByCategoryOrderByStartDateAsc(Long roomId, String category, int count);
+
     Page<RoomGetHomeJoinedListResponse.RoomSearchResult> searchHomeJoinedRooms(Long userId, LocalDate today, Pageable pageable);
+
+    CursorSliceOfMyRoomView<RoomShowMineResponse.MyRoom> findRecruitingRoomsUserParticipated(Long userId, LocalDate lastDate, Long lastId, int pageSize);
+
+    CursorSliceOfMyRoomView<RoomShowMineResponse.MyRoom> findPlayingRoomsUserParticipated(Long userId, LocalDate lastDate, Long lastId, int pageSize);
+
+    CursorSliceOfMyRoomView<RoomShowMineResponse.MyRoom> findPlayingAndRecruitingRoomsUserParticipated(Long userId, LocalDate lastDate, Long lastId, int pageSize);
+
+    CursorSliceOfMyRoomView<RoomShowMineResponse.MyRoom> findExpiredRoomsUserParticipated(Long userId, LocalDate lastDate, Long lastId, int pageSize);
 }

--- a/src/main/java/konkuk/thip/room/application/port/in/RoomShowMineUseCase.java
+++ b/src/main/java/konkuk/thip/room/application/port/in/RoomShowMineUseCase.java
@@ -1,0 +1,10 @@
+package konkuk.thip.room.application.port.in;
+
+import konkuk.thip.room.adapter.in.web.response.RoomShowMineResponse;
+
+import java.time.LocalDate;
+
+public interface RoomShowMineUseCase {
+
+    RoomShowMineResponse getMyRooms(Long userId, String type, LocalDate cursorDate, Long cursorId);
+}

--- a/src/main/java/konkuk/thip/room/application/port/out/RoomQueryPort.java
+++ b/src/main/java/konkuk/thip/room/application/port/out/RoomQueryPort.java
@@ -3,6 +3,8 @@ package konkuk.thip.room.application.port.out;
 import konkuk.thip.room.adapter.in.web.response.RoomRecruitingDetailViewResponse;
 import konkuk.thip.room.adapter.in.web.response.RoomGetHomeJoinedListResponse;
 import konkuk.thip.room.adapter.in.web.response.RoomSearchResponse;
+import konkuk.thip.room.adapter.in.web.response.RoomShowMineResponse;
+import konkuk.thip.room.application.port.out.dto.CursorSliceOfMyRoomView;
 import konkuk.thip.room.domain.Room;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,9 +13,20 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface RoomQueryPort {
+
     int countRecruitingRoomsByBookAndStartDateAfter(Long bookId, LocalDate currentDate);
+
     Page<RoomSearchResponse.RoomSearchResult> searchRoom(String keyword, String category, Pageable pageable);
 
     List<RoomRecruitingDetailViewResponse.RecommendRoom> findOtherRecruitingRoomsByCategoryOrderByStartDateAsc(Room currentRoom, int count);
+
     Page<RoomGetHomeJoinedListResponse.RoomSearchResult> searchHomeJoinedRooms(Long userId, LocalDate today, Pageable pageable);
+
+    CursorSliceOfMyRoomView<RoomShowMineResponse.MyRoom> findRecruitingRoomsUserParticipated(Long userId, LocalDate lastRoomStartDateCursor, Long lastRoomIdCursor, int pageSize);
+
+    CursorSliceOfMyRoomView<RoomShowMineResponse.MyRoom> findPlayingRoomsUserParticipated(Long userId, LocalDate lastRoomEndDateCursor, Long lastRoomIdCursor, int pageSize);
+
+    CursorSliceOfMyRoomView<RoomShowMineResponse.MyRoom> findPlayingAndRecruitingRoomsUserParticipated(Long userId, LocalDate dateCursor, Long lastRoomIdCursor, int pageSize);
+
+    CursorSliceOfMyRoomView<RoomShowMineResponse.MyRoom> findExpiredRoomsUserParticipated(Long userId, LocalDate lastRoomEndDateCursor, Long lastRoomIdCursor, int pageSize);
 }

--- a/src/main/java/konkuk/thip/room/application/port/out/dto/CursorSliceOfMyRoomView.java
+++ b/src/main/java/konkuk/thip/room/application/port/out/dto/CursorSliceOfMyRoomView.java
@@ -1,0 +1,22 @@
+package konkuk.thip.room.application.port.out.dto;
+
+import lombok.Getter;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+public class CursorSliceOfMyRoomView<T> extends SliceImpl<T> {
+
+    private final LocalDate nextCursorDate;
+    private final Long nextCursorId;
+
+    public CursorSliceOfMyRoomView(List<T> content, Pageable pageable, boolean hasNext,
+                                   LocalDate nextCursorDate, Long nextCursorId) {
+        super(content, pageable, hasNext);
+        this.nextCursorDate = nextCursorDate;
+        this.nextCursorId = nextCursorId;
+    }
+}

--- a/src/main/java/konkuk/thip/room/application/service/RoomShowMineService.java
+++ b/src/main/java/konkuk/thip/room/application/service/RoomShowMineService.java
@@ -1,0 +1,54 @@
+package konkuk.thip.room.application.service;
+
+import konkuk.thip.common.exception.BusinessException;
+import konkuk.thip.room.adapter.in.web.response.RoomShowMineResponse;
+import konkuk.thip.room.application.port.in.RoomShowMineUseCase;
+import konkuk.thip.room.application.port.out.RoomQueryPort;
+import konkuk.thip.room.application.port.out.dto.CursorSliceOfMyRoomView;
+import konkuk.thip.room.domain.MyRoomType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static konkuk.thip.common.exception.code.ErrorCode.INVALID_MY_ROOM_CURSOR;
+
+@Service
+@RequiredArgsConstructor
+public class RoomShowMineService implements RoomShowMineUseCase {
+
+    private final static int PAGE_SIZE = 10;
+
+    private final RoomQueryPort roomQueryPort;
+
+    @Override
+    @Transactional(readOnly = true)
+    public RoomShowMineResponse getMyRooms(Long userId, String type, LocalDate cursorDate, Long cursorId) {
+        // 1. cursor xor 연산 검증
+        if (cursorDate == null ^ cursorId == null) {
+            throw new BusinessException(INVALID_MY_ROOM_CURSOR, new IllegalArgumentException("cursorDate, cursorId는 하나만 null 일 수 없습니다."));
+        }
+
+        // 2. type 검증 및 커서 기반 조회
+        CursorSliceOfMyRoomView<RoomShowMineResponse.MyRoom> slice = switch (MyRoomType.from(type)) {
+                case RECRUITING -> roomQueryPort
+                        .findRecruitingRoomsUserParticipated(userId, cursorDate, cursorId, PAGE_SIZE);
+                case PLAYING    -> roomQueryPort
+                        .findPlayingRoomsUserParticipated(userId, cursorDate, cursorId, PAGE_SIZE);
+                case PLAYING_AND_RECRUITING -> roomQueryPort
+                    .findPlayingAndRecruitingRoomsUserParticipated(userId, cursorDate, cursorId, PAGE_SIZE);
+                case EXPIRED    -> roomQueryPort
+                        .findExpiredRoomsUserParticipated(userId, cursorDate, cursorId, PAGE_SIZE);
+        };
+
+        // 3. return
+        return new RoomShowMineResponse(
+                slice.getContent(),
+                slice.getContent().size(),
+                slice.isLast(),
+                slice.getNextCursorDate(),
+                slice.getNextCursorId()
+        );
+    }
+}

--- a/src/main/java/konkuk/thip/room/domain/MyRoomType.java
+++ b/src/main/java/konkuk/thip/room/domain/MyRoomType.java
@@ -1,0 +1,28 @@
+package konkuk.thip.room.domain;
+
+import konkuk.thip.common.exception.InvalidStateException;
+import konkuk.thip.common.exception.code.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum MyRoomType {
+    PLAYING("playing"),
+    RECRUITING("recruiting"),
+    PLAYING_AND_RECRUITING("playingAndRecruiting"),
+    EXPIRED("expired");
+
+    private final String type;
+
+    public static MyRoomType from(String type) {
+        return Arrays.stream(MyRoomType.values())
+                .filter(param -> param.getType().equals(type))
+                .findFirst()
+                .orElseThrow(
+                        () -> new InvalidStateException(ErrorCode.INVALID_MY_ROOM_TYPE)
+                );
+    }
+}

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomShowMineApiTest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomShowMineApiTest.java
@@ -1,0 +1,542 @@
+package konkuk.thip.room.adapter.in.web;
+
+import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.adapter.out.persistence.repository.BookJpaRepository;
+import konkuk.thip.common.util.TestEntityFactory;
+import konkuk.thip.room.adapter.out.jpa.CategoryJpaEntity;
+import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
+import konkuk.thip.room.adapter.out.jpa.RoomParticipantJpaEntity;
+import konkuk.thip.room.adapter.out.jpa.RoomParticipantRole;
+import konkuk.thip.room.adapter.out.persistence.repository.RoomJpaRepository;
+import konkuk.thip.room.adapter.out.persistence.repository.category.CategoryJpaRepository;
+import konkuk.thip.room.adapter.out.persistence.repository.roomparticipant.RoomParticipantJpaRepository;
+import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.repository.alias.AliasJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDate;
+
+import static konkuk.thip.common.exception.code.ErrorCode.INVALID_MY_ROOM_CURSOR;
+import static konkuk.thip.common.exception.code.ErrorCode.INVALID_MY_ROOM_TYPE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("[통합] 내 방 목록 조회 api 통합 테스트")
+class RoomShowMineApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private AliasJpaRepository aliasJpaRepository;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private CategoryJpaRepository categoryJpaRepository;
+
+    @Autowired
+    private BookJpaRepository bookJpaRepository;
+
+    @Autowired
+    private RoomJpaRepository roomJpaRepository;
+
+    @Autowired
+    private RoomParticipantJpaRepository roomParticipantJpaRepository;
+
+    @AfterEach
+    void tearDown() {
+        roomParticipantJpaRepository.deleteAllInBatch();
+        roomJpaRepository.deleteAllInBatch();
+        bookJpaRepository.deleteAllInBatch();
+        userJpaRepository.deleteAllInBatch();
+        categoryJpaRepository.deleteAllInBatch();
+        aliasJpaRepository.deleteAllInBatch();
+    }
+
+    private RoomJpaEntity saveScienceRoom(String bookTitle, String isbn, String roomName, LocalDate startDate, LocalDate endDate, int recruitCount) {
+        AliasJpaEntity alias = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+
+        BookJpaEntity book = bookJpaRepository.save(BookJpaEntity.builder()
+                .title(bookTitle)
+                .isbn(isbn)
+                .authorName("한강")
+                .bestSeller(false)
+                .publisher("문학동네")
+                .imageUrl("https://image1.jpg")
+                .pageCount(300)
+                .description("한강의 소설")
+                .build());
+
+        CategoryJpaEntity category = categoryJpaRepository.save(TestEntityFactory.createScienceCategory(alias));
+
+        return roomJpaRepository.save(RoomJpaEntity.builder()
+                .title(roomName)
+                .description("한강 작품 읽기 모임")
+                .isPublic(true)
+                .roomPercentage(0.0)
+                .startDate(startDate)
+                .endDate(endDate)
+                .recruitCount(recruitCount)
+                .bookJpaEntity(book)
+                .categoryJpaEntity(category)
+                .build());
+    }
+
+    private void changeRoomMemberCount(RoomJpaEntity roomJpaEntity, int count) {
+        roomJpaEntity.updateMemberCount(count);
+        roomJpaRepository.save(roomJpaEntity);
+    }
+
+    private void saveSingleUserToRoom(RoomJpaEntity roomJpaEntity, UserJpaEntity userJpaEntity) {
+        RoomParticipantJpaEntity roomParticipantJpaEntity = RoomParticipantJpaEntity.builder()
+                .userJpaEntity(userJpaEntity)
+                .roomJpaEntity(roomJpaEntity)
+                .roomParticipantRole(RoomParticipantRole.MEMBER)
+                .build();
+        roomParticipantJpaRepository.save(roomParticipantJpaEntity);
+
+        roomJpaEntity.updateMemberCount(roomJpaEntity.getMemberCount() + 1);
+        roomJpaRepository.save(roomJpaEntity);      // room의 memberCount 값도 업데이트 해줘야 한다
+    }
+
+    @Test
+    @DisplayName("type 으로 playing 을 받을 경우, 해당 유저가 참여중인 방 중 [현재 진행중인 모임방]의 정보를 [활동 마감일 임박순] 으로 반환한다.")
+    void get_my_playing_rooms() throws Exception {
+        //given
+        RoomJpaEntity recruitingRoom1 = saveScienceRoom("모집중인방-책-1", "isbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom1, 5);
+
+        RoomJpaEntity playingRoom1 = saveScienceRoom("진행중인방-책-1", "isbn2", "과학-방-5일뒤-활동마감", LocalDate.now().minusDays(5), LocalDate.now().plusDays(5), 10);
+        changeRoomMemberCount(playingRoom1, 6);
+
+        RoomJpaEntity playingRoom2 = saveScienceRoom("진행중인방-책-2", "isbn3", "과학-방-10일뒤-활동마감", LocalDate.now().minusDays(5), LocalDate.now().plusDays(10), 10);
+        changeRoomMemberCount(playingRoom2, 3);
+
+        RoomJpaEntity expiredRoom1 = saveScienceRoom("만료된방-책-1", "isbn4", "과학-방-5일전-활동마감", LocalDate.now().minusDays(30), LocalDate.now().minusDays(5), 10);
+        changeRoomMemberCount(expiredRoom1, 7);
+
+        AliasJpaEntity scienceAlias = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        UserJpaEntity user = userJpaRepository.save(TestEntityFactory.createUser(scienceAlias));
+
+        // user가 생성한 방에 참여한 상황 가정
+        saveSingleUserToRoom(recruitingRoom1, user);
+        saveSingleUserToRoom(playingRoom1, user);
+        saveSingleUserToRoom(playingRoom2, user);
+        saveSingleUserToRoom(expiredRoom1, user);
+
+        //when
+        ResultActions result = mockMvc.perform(get("/rooms/my")
+                .requestAttr("userId", user.getUserId())
+                .param("type", "playing"));     // 진행중인 방
+
+        //then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.roomList", hasSize(2)))
+                .andExpect(jsonPath("$.data.roomList[0].roomName", is("과학-방-5일뒤-활동마감")))
+                .andExpect(jsonPath("$.data.roomList[0].memberCount", is(7)))      // 기존 6명 + user
+                .andExpect(jsonPath("$.data.roomList[1].roomName", is("과학-방-10일뒤-활동마감")))
+                .andExpect(jsonPath("$.data.roomList[1].memberCount", is(4)));      // 기존 3명 + user
+    }
+
+    @Test
+    @DisplayName("type 으로 recruiting 을 받을 경우, 해당 유저가 참여중인 방 중 [모집중인 모임방]의 정보를 [모집 마감일 임박순] 으로 반환한다.")
+    void get_my_recruiting_rooms() throws Exception {
+        //given
+        RoomJpaEntity recruitingRoom1 = saveScienceRoom("모집중인방-책-1", "isbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom1, 5);
+
+        RoomJpaEntity recruitingRoom2 = saveScienceRoom("모집중인방-책-2", "isbn2", "과학-방-5일뒤-활동시작", LocalDate.now().plusDays(5), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom2, 8);
+
+        RoomJpaEntity playingRoom1 = saveScienceRoom("진행중인방-책-1", "isbn3", "과학-방-5일뒤-활동마감", LocalDate.now().minusDays(5), LocalDate.now().plusDays(5), 10);
+        changeRoomMemberCount(playingRoom1, 6);
+
+        RoomJpaEntity expiredRoom1 = saveScienceRoom("만료된방-책-1", "isbn4", "과학-방-5일전-활동마감", LocalDate.now().minusDays(30), LocalDate.now().minusDays(5), 10);
+        changeRoomMemberCount(expiredRoom1, 7);
+
+        AliasJpaEntity scienceAlias = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        UserJpaEntity user = userJpaRepository.save(TestEntityFactory.createUser(scienceAlias));
+
+        // user가 생성한 방에 참여한 상황 가정
+        saveSingleUserToRoom(recruitingRoom1, user);
+        saveSingleUserToRoom(recruitingRoom2, user);
+        saveSingleUserToRoom(playingRoom1, user);
+        saveSingleUserToRoom(expiredRoom1, user);
+
+        //when
+        ResultActions result = mockMvc.perform(get("/rooms/my")
+                .requestAttr("userId", user.getUserId())
+                .param("type", "recruiting"));      // 모집중인 방
+
+        //then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.roomList", hasSize(2)))
+                .andExpect(jsonPath("$.data.roomList[0].roomName", is("과학-방-1일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[0].memberCount", is(6)))       // 기존 5명 + user
+                .andExpect(jsonPath("$.data.roomList[1].roomName", is("과학-방-5일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[1].memberCount", is(9)));      // 기존 8명 + user
+    }
+
+    @Test
+    @DisplayName("type 이 주어지지 않을 경우, 해당 유저가 참여중인 방 중 [현재 진행중 + 모집중인 모임방]의 정보를 [현재 진행중 -> 모집중] 순 으로 반환한다.")
+    void get_my_playing_and_recruiting_rooms() throws Exception {
+        //given
+        RoomJpaEntity recruitingRoom1 = saveScienceRoom("모집중인방-책-1", "isbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom1, 5);
+
+        RoomJpaEntity recruitingRoom2 = saveScienceRoom("모집중인방-책-2", "isbn2", "과학-방-5일뒤-활동시작", LocalDate.now().plusDays(5), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom2, 8);
+
+        RoomJpaEntity playingRoom1 = saveScienceRoom("진행중인방-책-1", "isbn3", "과학-방-5일뒤-활동마감", LocalDate.now().minusDays(5), LocalDate.now().plusDays(5), 10);
+        changeRoomMemberCount(playingRoom1, 6);
+
+        RoomJpaEntity expiredRoom1 = saveScienceRoom("만료된방-책-1", "isbn4", "과학-방-5일전-활동마감", LocalDate.now().minusDays(30), LocalDate.now().minusDays(5), 10);
+        changeRoomMemberCount(expiredRoom1, 7);
+
+        AliasJpaEntity scienceAlias = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        UserJpaEntity user = userJpaRepository.save(TestEntityFactory.createUser(scienceAlias));
+
+        // user가 생성한 방에 참여한 상황 가정
+        saveSingleUserToRoom(recruitingRoom1, user);
+        saveSingleUserToRoom(recruitingRoom2, user);
+        saveSingleUserToRoom(playingRoom1, user);
+        saveSingleUserToRoom(expiredRoom1, user);
+
+        //when
+        ResultActions result = mockMvc.perform(get("/rooms/my")
+                .requestAttr("userId", user.getUserId()));      // type request param 없는 경우
+
+        //then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.roomList", hasSize(3)))
+                .andExpect(jsonPath("$.data.roomList[0].roomName", is("과학-방-5일뒤-활동마감")))
+                .andExpect(jsonPath("$.data.roomList[0].memberCount", is(7)))       // 기존 6명 + user
+                .andExpect(jsonPath("$.data.roomList[1].roomName", is("과학-방-1일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[1].memberCount", is(6)))       // 기존 5명 + user
+                .andExpect(jsonPath("$.data.roomList[2].roomName", is("과학-방-5일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[2].memberCount", is(9)));       // 기존 8명 + user
+    }
+
+    @Test
+    @DisplayName("type 으로 expired 을 받을 경우, 해당 유저가 참여중인 방 중 [만료된 모임방]의 정보를 [활동 마감일 최신순] 으로 반환한다.")
+    void get_my_expired_rooms() throws Exception {
+        //given
+        RoomJpaEntity recruitingRoom1 = saveScienceRoom("모집중인방-책-1", "isbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom1, 5);
+
+        RoomJpaEntity playingRoom1 = saveScienceRoom("진행중인방-책-1", "isbn2", "과학-방-5일뒤-활동마감", LocalDate.now().minusDays(5), LocalDate.now().plusDays(5), 10);
+        changeRoomMemberCount(playingRoom1, 6);
+
+        RoomJpaEntity expiredRoom1 = saveScienceRoom("만료된방-책-1", "isbn3", "과학-방-5일전-활동마감", LocalDate.now().minusDays(30), LocalDate.now().minusDays(5), 10);
+        changeRoomMemberCount(expiredRoom1, 7);
+
+        RoomJpaEntity expiredRoom2 = saveScienceRoom("만료된방-책-2", "isbn4", "과학-방-10일전-활동마감", LocalDate.now().minusDays(30), LocalDate.now().minusDays(10), 10);
+        changeRoomMemberCount(expiredRoom2, 1);
+
+        AliasJpaEntity scienceAlias = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        UserJpaEntity user = userJpaRepository.save(TestEntityFactory.createUser(scienceAlias));
+
+        // user가 생성한 방에 참여한 상황 가정
+        saveSingleUserToRoom(recruitingRoom1, user);
+        saveSingleUserToRoom(playingRoom1, user);
+        saveSingleUserToRoom(expiredRoom1, user);
+        saveSingleUserToRoom(expiredRoom2, user);
+
+        //when
+        ResultActions result = mockMvc.perform(get("/rooms/my")
+                .requestAttr("userId", user.getUserId())
+                .param("type", "expired"));     // 만료된 방
+
+        //then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.roomList", hasSize(2)))
+                .andExpect(jsonPath("$.data.roomList[0].roomName", is("과학-방-5일전-활동마감")))
+                .andExpect(jsonPath("$.data.roomList[0].memberCount", is(8)))      // 기존 7명 + user
+                .andExpect(jsonPath("$.data.roomList[1].roomName", is("과학-방-10일전-활동마감")))
+                .andExpect(jsonPath("$.data.roomList[1].memberCount", is(2)));      // 기존 1명 + user
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 type 을 받을 경우, 400 error 를 반환한다.")
+    void get_my_rooms_wrong_type() throws Exception {
+        //given
+        RoomJpaEntity recruitingRoom1 = saveScienceRoom("모집중인방-책-1", "isbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom1, 5);
+
+        RoomJpaEntity recruitingRoom2 = saveScienceRoom("모집중인방-책-2", "isbn2", "과학-방-5일뒤-활동시작", LocalDate.now().plusDays(5), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom2, 8);
+
+        RoomJpaEntity playingRoom1 = saveScienceRoom("진행중인방-책-1", "isbn3", "과학-방-5일뒤-활동마감", LocalDate.now().minusDays(5), LocalDate.now().plusDays(5), 10);
+        changeRoomMemberCount(playingRoom1, 6);
+
+        RoomJpaEntity expiredRoom1 = saveScienceRoom("만료된방-책-1", "isbn4", "과학-방-5일전-활동마감", LocalDate.now().minusDays(30), LocalDate.now().minusDays(5), 10);
+        changeRoomMemberCount(expiredRoom1, 7);
+
+        AliasJpaEntity scienceAlias = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        UserJpaEntity user = userJpaRepository.save(TestEntityFactory.createUser(scienceAlias));
+
+        // user가 생성한 방에 참여한 상황 가정
+        saveSingleUserToRoom(recruitingRoom1, user);
+        saveSingleUserToRoom(recruitingRoom2, user);
+        saveSingleUserToRoom(playingRoom1, user);
+        saveSingleUserToRoom(expiredRoom1, user);
+
+        //when
+        ResultActions result = mockMvc.perform(get("/rooms/my")
+                .requestAttr("userId", user.getUserId())
+                .param("type", "wrongType"));     // 이상한 type request param
+
+        //then
+        result.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess", is(false)))
+                .andExpect(jsonPath("$.code", is(INVALID_MY_ROOM_TYPE.getCode())));
+    }
+
+    @Test
+    @DisplayName("cursorDate 만 받고 cursorId 는 받지 않은 경우, 400 error를 반환한다.")
+    void get_my_rooms_only_cursor_date_exist() throws Exception {
+        //given
+        RoomJpaEntity recruitingRoom1 = saveScienceRoom("모집중인방-책-1", "isbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom1, 5);
+
+        RoomJpaEntity recruitingRoom2 = saveScienceRoom("모집중인방-책-2", "isbn2", "과학-방-5일뒤-활동시작", LocalDate.now().plusDays(5), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom2, 8);
+
+        RoomJpaEntity playingRoom1 = saveScienceRoom("진행중인방-책-1", "isbn3", "과학-방-5일뒤-활동마감", LocalDate.now().minusDays(5), LocalDate.now().plusDays(5), 10);
+        changeRoomMemberCount(playingRoom1, 6);
+
+        RoomJpaEntity expiredRoom1 = saveScienceRoom("만료된방-책-1", "isbn4", "과학-방-5일전-활동마감", LocalDate.now().minusDays(30), LocalDate.now().minusDays(5), 10);
+        changeRoomMemberCount(expiredRoom1, 7);
+
+        AliasJpaEntity scienceAlias = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        UserJpaEntity user = userJpaRepository.save(TestEntityFactory.createUser(scienceAlias));
+
+        // user가 생성한 방에 참여한 상황 가정
+        saveSingleUserToRoom(recruitingRoom1, user);
+        saveSingleUserToRoom(recruitingRoom2, user);
+        saveSingleUserToRoom(playingRoom1, user);
+        saveSingleUserToRoom(expiredRoom1, user);
+
+        //when
+        ResultActions result = mockMvc.perform(get("/rooms/my")
+                .requestAttr("userId", user.getUserId())
+                .param("type", "playing")
+                .param("cursorDate", String.valueOf(LocalDate.now())));     // cursor 중 cursorDate 만 request param 으로 넘어온 경우
+
+        //then
+        result.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess", is(false)))
+                .andExpect(jsonPath("$.code", is(INVALID_MY_ROOM_CURSOR.getCode())));
+    }
+
+    @Test
+    @DisplayName("cursorId 만 받고 cursorDate 는 받지 않은 경우, 400 error를 반환한다.")
+    void get_my_rooms_only_cursor_id_exist() throws Exception {
+        //given
+        RoomJpaEntity recruitingRoom1 = saveScienceRoom("모집중인방-책-1", "isbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom1, 5);
+
+        RoomJpaEntity recruitingRoom2 = saveScienceRoom("모집중인방-책-2", "isbn2", "과학-방-5일뒤-활동시작", LocalDate.now().plusDays(5), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom2, 8);
+
+        RoomJpaEntity playingRoom1 = saveScienceRoom("진행중인방-책-1", "isbn3", "과학-방-5일뒤-활동마감", LocalDate.now().minusDays(5), LocalDate.now().plusDays(5), 10);
+        changeRoomMemberCount(playingRoom1, 6);
+
+        RoomJpaEntity expiredRoom1 = saveScienceRoom("만료된방-책-1", "isbn4", "과학-방-5일전-활동마감", LocalDate.now().minusDays(30), LocalDate.now().minusDays(5), 10);
+        changeRoomMemberCount(expiredRoom1, 7);
+
+        AliasJpaEntity scienceAlias = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        UserJpaEntity user = userJpaRepository.save(TestEntityFactory.createUser(scienceAlias));
+
+        // user가 생성한 방에 참여한 상황 가정
+        saveSingleUserToRoom(recruitingRoom1, user);
+        saveSingleUserToRoom(recruitingRoom2, user);
+        saveSingleUserToRoom(playingRoom1, user);
+        saveSingleUserToRoom(expiredRoom1, user);
+
+        //when
+        ResultActions result = mockMvc.perform(get("/rooms/my")
+                .requestAttr("userId", user.getUserId())
+                .param("type", "playing")
+                .param("cursorId", String.valueOf(10L)));       // cursor 중 cursorId 만 request param 으로 넘어온 경우
+
+        //then
+        result.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess", is(false)))
+                .andExpect(jsonPath("$.code", is(INVALID_MY_ROOM_CURSOR.getCode())));
+    }
+
+    @Test
+    @DisplayName("한번에 최대 10개의 데이터만을 반환한다. 다음 페이지에 해당하는 데이터가 있을 경우, 다음 페이지의 cursor 값을 반환한다.")
+    void get_my_rooms_page_1() throws Exception {
+        //given
+        RoomJpaEntity recruitingRoom1 = saveScienceRoom("모집중인방-책-1", "isbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom1, 5);
+
+        RoomJpaEntity recruitingRoom2 = saveScienceRoom("모집중인방-책-2", "isbn2", "과학-방-2일뒤-활동시작", LocalDate.now().plusDays(2), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom2, 8);
+
+        RoomJpaEntity recruitingRoom3 = saveScienceRoom("모집중인방-책-3", "isbn3", "과학-방-3일뒤-활동시작", LocalDate.now().plusDays(3), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom3, 8);
+
+        RoomJpaEntity recruitingRoom4 = saveScienceRoom("모집중인방-책-4", "isbn4", "과학-방-4일뒤-활동시작", LocalDate.now().plusDays(4), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom4, 8);
+
+        RoomJpaEntity recruitingRoom5 = saveScienceRoom("모집중인방-책-5", "isbn5", "과학-방-5일뒤-활동시작", LocalDate.now().plusDays(5), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom5, 8);
+
+        RoomJpaEntity recruitingRoom6 = saveScienceRoom("모집중인방-책-6", "isbn6", "과학-방-6일뒤-활동시작", LocalDate.now().plusDays(6), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom6, 8);
+
+        RoomJpaEntity recruitingRoom7 = saveScienceRoom("모집중인방-책-7", "isbn7", "과학-방-7일뒤-활동시작", LocalDate.now().plusDays(7), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom7, 8);
+
+        RoomJpaEntity recruitingRoom8 = saveScienceRoom("모집중인방-책-8", "isbn8", "과학-방-8일뒤-활동시작", LocalDate.now().plusDays(8), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom8, 8);
+
+        RoomJpaEntity recruitingRoom9 = saveScienceRoom("모집중인방-책-9", "isbn9", "과학-방-9일뒤-활동시작", LocalDate.now().plusDays(9), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom9, 8);
+
+        RoomJpaEntity recruitingRoom10 = saveScienceRoom("모집중인방-책-10", "isbn10", "과학-방-10일뒤-활동시작", LocalDate.now().plusDays(10), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom10, 8);
+
+        RoomJpaEntity recruitingRoom11 = saveScienceRoom("모집중인방-책-11", "isbn11", "과학-방-11일뒤-활동시작", LocalDate.now().plusDays(11), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom11, 8);
+
+        RoomJpaEntity recruitingRoom12 = saveScienceRoom("모집중인방-책-12", "isbn12", "과학-방-12일뒤-활동시작", LocalDate.now().plusDays(12), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom12, 8);
+
+        AliasJpaEntity scienceAlias = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        UserJpaEntity user = userJpaRepository.save(TestEntityFactory.createUser(scienceAlias));
+
+        // user가 생성한 방에 참여한 상황 가정
+        saveSingleUserToRoom(recruitingRoom1, user);
+        saveSingleUserToRoom(recruitingRoom2, user);
+        saveSingleUserToRoom(recruitingRoom3, user);
+        saveSingleUserToRoom(recruitingRoom4, user);
+        saveSingleUserToRoom(recruitingRoom5, user);
+        saveSingleUserToRoom(recruitingRoom6, user);
+        saveSingleUserToRoom(recruitingRoom7, user);
+        saveSingleUserToRoom(recruitingRoom8, user);
+        saveSingleUserToRoom(recruitingRoom9, user);
+        saveSingleUserToRoom(recruitingRoom10, user);
+        saveSingleUserToRoom(recruitingRoom11, user);
+        saveSingleUserToRoom(recruitingRoom12, user);
+
+        //when
+        ResultActions result = mockMvc.perform(get("/rooms/my")
+                .requestAttr("userId", user.getUserId())
+                .param("type", "recruiting"));
+
+        //then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.size", is(10)))
+                .andExpect(jsonPath("$.data.last", is(false)))
+                .andExpect(jsonPath("$.data.nextCursorDate", is(recruitingRoom11.getStartDate().toString())))          // 11번째 데이터의 startDate가 nextCursorDate 이다
+                .andExpect(jsonPath("$.data.nextCursorId", is(recruitingRoom11.getRoomId().intValue())))               // 11번째 데이터의 id가 nextCursorId 이다
+                .andExpect(jsonPath("$.data.roomList", hasSize(10)))
+                // 정렬 조건 : 모집중인 방 == 방 활동 시작일 임박 순
+                .andExpect(jsonPath("$.data.roomList[0].roomName", is("과학-방-1일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[1].roomName", is("과학-방-2일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[2].roomName", is("과학-방-3일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[3].roomName", is("과학-방-4일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[4].roomName", is("과학-방-5일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[5].roomName", is("과학-방-6일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[6].roomName", is("과학-방-7일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[7].roomName", is("과학-방-8일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[8].roomName", is("과학-방-9일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[9].roomName", is("과학-방-10일뒤-활동시작")));
+    }
+
+    @Test
+    @DisplayName("cursor 값을 기준으로 해당 페이지의 데이터를 반환한다.")
+    void get_my_rooms_page_2() throws Exception {
+        //given
+        RoomJpaEntity recruitingRoom1 = saveScienceRoom("모집중인방-책-1", "isbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom1, 5);
+
+        RoomJpaEntity recruitingRoom2 = saveScienceRoom("모집중인방-책-2", "isbn2", "과학-방-2일뒤-활동시작", LocalDate.now().plusDays(2), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom2, 8);
+
+        RoomJpaEntity recruitingRoom3 = saveScienceRoom("모집중인방-책-3", "isbn3", "과학-방-3일뒤-활동시작", LocalDate.now().plusDays(3), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom3, 8);
+
+        RoomJpaEntity recruitingRoom4 = saveScienceRoom("모집중인방-책-4", "isbn4", "과학-방-4일뒤-활동시작", LocalDate.now().plusDays(4), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom4, 8);
+
+        RoomJpaEntity recruitingRoom5 = saveScienceRoom("모집중인방-책-5", "isbn5", "과학-방-5일뒤-활동시작", LocalDate.now().plusDays(5), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom5, 8);
+
+        RoomJpaEntity recruitingRoom6 = saveScienceRoom("모집중인방-책-6", "isbn6", "과학-방-6일뒤-활동시작", LocalDate.now().plusDays(6), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom6, 8);
+
+        RoomJpaEntity recruitingRoom7 = saveScienceRoom("모집중인방-책-7", "isbn7", "과학-방-7일뒤-활동시작", LocalDate.now().plusDays(7), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom7, 8);
+
+        RoomJpaEntity recruitingRoom8 = saveScienceRoom("모집중인방-책-8", "isbn8", "과학-방-8일뒤-활동시작", LocalDate.now().plusDays(8), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom8, 8);
+
+        RoomJpaEntity recruitingRoom9 = saveScienceRoom("모집중인방-책-9", "isbn9", "과학-방-9일뒤-활동시작", LocalDate.now().plusDays(9), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom9, 8);
+
+        RoomJpaEntity recruitingRoom10 = saveScienceRoom("모집중인방-책-10", "isbn10", "과학-방-10일뒤-활동시작", LocalDate.now().plusDays(10), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom10, 8);
+
+        RoomJpaEntity recruitingRoom11 = saveScienceRoom("모집중인방-책-11", "isbn11", "과학-방-11일뒤-활동시작", LocalDate.now().plusDays(11), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom11, 8);
+
+        RoomJpaEntity recruitingRoom12 = saveScienceRoom("모집중인방-책-12", "isbn12", "과학-방-12일뒤-활동시작", LocalDate.now().plusDays(12), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruitingRoom12, 8);
+
+        AliasJpaEntity scienceAlias = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        UserJpaEntity user = userJpaRepository.save(TestEntityFactory.createUser(scienceAlias));
+
+        // user가 생성한 방에 참여한 상황 가정
+        saveSingleUserToRoom(recruitingRoom1, user);
+        saveSingleUserToRoom(recruitingRoom2, user);
+        saveSingleUserToRoom(recruitingRoom3, user);
+        saveSingleUserToRoom(recruitingRoom4, user);
+        saveSingleUserToRoom(recruitingRoom5, user);
+        saveSingleUserToRoom(recruitingRoom6, user);
+        saveSingleUserToRoom(recruitingRoom7, user);
+        saveSingleUserToRoom(recruitingRoom8, user);
+        saveSingleUserToRoom(recruitingRoom9, user);
+        saveSingleUserToRoom(recruitingRoom10, user);
+        saveSingleUserToRoom(recruitingRoom11, user);
+        saveSingleUserToRoom(recruitingRoom12, user);
+
+        //when
+        ResultActions result = mockMvc.perform(get("/rooms/my")
+                .requestAttr("userId", user.getUserId())
+                .param("type", "recruiting")
+                .param("cursorDate", recruitingRoom11.getStartDate().toString())
+                .param("cursorId", recruitingRoom11.getRoomId().toString()));
+
+        //then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.size", is(2)))
+                .andExpect(jsonPath("$.data.last", is(true)))
+                .andExpect(jsonPath("$.data.nextCursorDate", nullValue()))      // 다음 페이지가 없으므로 cursor 값은 null
+                .andExpect(jsonPath("$.data.nextCursorId", nullValue()))
+                .andExpect(jsonPath("$.data.roomList", hasSize(2)))
+                .andExpect(jsonPath("$.data.roomList[0].roomName", is("과학-방-11일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[1].roomName", is("과학-방-12일뒤-활동시작")));
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #89 

## 📝 작업 내용
내가 참여한 목록 조회 api 를 개발하였습니다.

<api 플로우>
- controller
  - type, cursorDate, cursorId 값을 request param 으로 전달받음
  - 위 3개 param은 모두 required=false 로 설정, type은 개발 편의성을 위해 defaultValue 속성 추가
- service
  - cursor 2개의 null 여부를 xor 연산을 통해 검증 (cursor 값 2개는 모두 있거나, 둘다 없거나 만 유효한 상태로 정의)
  - type request param 의 유효성 검증 (enum 을 통해)
  - 영속성 adapter 로부터 받은 데이터를 통해 resposne 구성 (pageSize 는 10으로 설정)
- 영속성 코드
  - type 별로 데이터 조회 메서드를 분리 + 커서 기반 페이징 메서드를 분리하여 최대한 QueryDSL 코드를 간결하게 작성하려고 하였음
  - 각 메서드 별로 요구사항에 정의된 필터링 조건, 정렬 조건 을 만족하도록 구현하였음
- 테스트 코드
  - api 통합 테스트 코드로 테스트 코드를 작성
  - 모든 가능한 type 별로 올바른 응답이 나오는지 테스트 하였음
  - wrong request param 에 대해서 예외 처리가 적절하게 이루어지는지 테스트 하였음
  - 커서 기반 페이징 처리가 잘 이루어지는지 테스트 하였음

## 📸 스크린샷

## 💬 리뷰 요구사항

QueryDSL 관련 로직을 담당하는 RoomQueryRepositoryImpl 의 코드가 많이 복잡해지는 것 같아, 커서 기반 페이징 처리를 담당하는 내부 private 메서드를 정의하고, 이를 공유하여 반환값을 구성하도록 하였습니다.

하지만 이렇게 하더라도 여전히 RoomQueryRepositoryImpl 의 코드가 무겁고, 추후 조회 api 개발하면서 코드가 더 추가될텐데, 더 나은 방식은 없을까 고민해보면 좋을 것 같습니다!

api 통합 테스트 코드를 상세하게 작성하였습니다! 테스트 코드의 흐름을 먼저 보시는 것이 리뷰하기에 더 편할 것 같습니다!

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
