### PR TITLE
[feat] 내 팔로잉 리스트 조회 api 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,10 @@ dependencies {
 
 	//s3 버킷
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	// MapStruct
+	implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 }
 
 def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile

--- a/src/main/java/konkuk/thip/common/util/CursorBasedList.java
+++ b/src/main/java/konkuk/thip/common/util/CursorBasedList.java
@@ -7,11 +7,10 @@ public record CursorBasedList<T>(
         String nextCursor,
         boolean hasNext
 ) {
-    public static <T> CursorBasedList<T> of(List<T> contents, String nextCursor) {
-        return new CursorBasedList<>(
-                contents,
-                nextCursor,
-                nextCursor != null
-        );
+    public static <T> CursorBasedList<T> of(List<T> queryList, int size, CursorExtractor<T> extractor) {
+        boolean hasNext = queryList.size() > size;
+        List<T> contents = hasNext ? queryList.subList(0, size) : queryList;
+        String nextCursor = hasNext ? extractor.extractCursor(contents.get(size - 1)) : null;
+        return new CursorBasedList<>(contents, nextCursor, hasNext);
     }
 }

--- a/src/main/java/konkuk/thip/common/util/CursorBasedList.java
+++ b/src/main/java/konkuk/thip/common/util/CursorBasedList.java
@@ -1,0 +1,17 @@
+package konkuk.thip.common.util;
+
+import java.util.List;
+
+public record CursorBasedList<T>(
+        List<T> contents,
+        String nextCursor,
+        boolean hasNext
+) {
+    public static <T> CursorBasedList<T> of(List<T> contents, String nextCursor) {
+        return new CursorBasedList<>(
+                contents,
+                nextCursor,
+                nextCursor != null
+        );
+    }
+}

--- a/src/main/java/konkuk/thip/common/util/CursorExtractor.java
+++ b/src/main/java/konkuk/thip/common/util/CursorExtractor.java
@@ -1,0 +1,6 @@
+package konkuk.thip.common.util;
+
+@FunctionalInterface
+public interface CursorExtractor<T> {
+    String extractCursor(T lastElement);
+}

--- a/src/main/java/konkuk/thip/user/adapter/in/web/UserCommandController.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/UserCommandController.java
@@ -33,6 +33,9 @@ public class UserCommandController {
     private final UserFollowUsecase userFollowUsecase;
     private final JwtUtil jwtUtil;
 
+    /**
+     * 사용자 회원가입
+     */
     @PostMapping("/users/signup")
     public BaseResponse<UserSignupResponse> signup(@Valid @RequestBody final UserSignupRequest request,
                                                    @Oauth2Id final String oauth2Id,
@@ -43,6 +46,9 @@ public class UserCommandController {
         return BaseResponse.ok(UserSignupResponse.of(userId));
     }
 
+    /**
+     * 닉네임 중복 확인
+     */
     @PostMapping("/users/nickname")
     public BaseResponse<UserVerifyNicknameResponse> verifyNickname(@Valid @RequestBody final UserVerifyNicknameRequest request) {
         return BaseResponse.ok(UserVerifyNicknameResponse.of(
@@ -50,7 +56,9 @@ public class UserCommandController {
         );
     }
 
-    // 팔루우 상태 변경 : true -> 팔로우, false -> 언팔로우
+    /**
+     * 사용자 팔로우 상태 변경 : true -> 팔로우, false -> 언팔로우
+     */
     @PostMapping("/users/following/{followingUserId}")
     public BaseResponse<UserFollowResponse> followUser(@UserId final Long userId,
                                             @PathVariable final Long followingUserId,

--- a/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
@@ -18,6 +18,9 @@ public class UserQueryController {
     private final UserViewAliasChoiceUseCase userViewAliasChoiceUseCase;
     private final UserGetFollowersUsecase userGetFollowersUsecase;
 
+    /**
+     * 사용자 별칭 선택 화면 조회
+     */
     @GetMapping("/users/alias")
     public BaseResponse<UserViewAliasChoiceResponse> showAliasChoiceView() {
         return BaseResponse.ok(UserViewAliasChoiceResponse.of(
@@ -25,6 +28,9 @@ public class UserQueryController {
         ));
     }
 
+    /**
+     * 사용자 팔로워 조회
+     */
     @GetMapping("/users/{userId}/followers")
     public BaseResponse<UserFollowersResponse> showFollowers(@PathVariable final Long userId,
                                                              @RequestParam(required = false) final String cursor) {

--- a/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
@@ -3,7 +3,7 @@ package konkuk.thip.user.adapter.in.web;
 import konkuk.thip.common.dto.BaseResponse;
 import konkuk.thip.user.adapter.in.web.response.UserFollowersResponse;
 import konkuk.thip.user.adapter.in.web.response.UserViewAliasChoiceResponse;
-import konkuk.thip.user.application.port.in.UserGetFollowersUsecase;
+import konkuk.thip.user.application.port.in.UserGetFollowUsecase;
 import konkuk.thip.user.application.port.in.UserViewAliasChoiceUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserQueryController {
 
     private final UserViewAliasChoiceUseCase userViewAliasChoiceUseCase;
-    private final UserGetFollowersUsecase userGetFollowersUsecase;
+    private final UserGetFollowUsecase userGetFollowUsecase;
 
     /**
      * 사용자 별칭 선택 화면 조회
@@ -34,14 +34,14 @@ public class UserQueryController {
     @GetMapping("/users/{userId}/followers")
     public BaseResponse<UserFollowersResponse> showFollowers(@PathVariable final Long userId,
                                                              @RequestParam(required = false) final String cursor) {
-        return BaseResponse.ok(userGetFollowersUsecase.getUserFollowers(userId, cursor));
+        return BaseResponse.ok(userGetFollowUsecase.getUserFollowers(userId, cursor));
     }
 
     /**
      * 내 팔로잉 리스트 조회
      */
-//    @GetMapping("/users/my/following")
-//    public BaseResponse<UserFollowersResponse> showMyFollowing(@RequestParam(required = false) final String cursor) {
-//        return BaseResponse.ok(userGetFollowersUsecase.getMyFollowing(cursor));
-//    }
+    @GetMapping("/users/my/following")
+    public BaseResponse<UserFollowersResponse> showMyFollowing(@RequestParam(required = false) final String cursor) {
+        return BaseResponse.ok(userGetFollowUsecase.getMyFollowing(cursor));
+    }
 }

--- a/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
@@ -36,4 +36,12 @@ public class UserQueryController {
                                                              @RequestParam(required = false) final String cursor) {
         return BaseResponse.ok(userGetFollowersUsecase.getUserFollowers(userId, cursor));
     }
+
+    /**
+     * 내 팔로잉 리스트 조회
+     */
+//    @GetMapping("/users/my/following")
+//    public BaseResponse<UserFollowersResponse> showMyFollowing(@RequestParam(required = false) final String cursor) {
+//        return BaseResponse.ok(userGetFollowersUsecase.getMyFollowing(cursor));
+//    }
 }

--- a/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
@@ -1,7 +1,11 @@
 package konkuk.thip.user.adapter.in.web;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import konkuk.thip.common.dto.BaseResponse;
+import konkuk.thip.common.security.annotation.UserId;
 import konkuk.thip.user.adapter.in.web.response.UserFollowersResponse;
+import konkuk.thip.user.adapter.in.web.response.UserFollowingResponse;
 import konkuk.thip.user.adapter.in.web.response.UserViewAliasChoiceResponse;
 import konkuk.thip.user.application.port.in.UserGetFollowUsecase;
 import konkuk.thip.user.application.port.in.UserViewAliasChoiceUseCase;
@@ -33,15 +37,18 @@ public class UserQueryController {
      */
     @GetMapping("/users/{userId}/followers")
     public BaseResponse<UserFollowersResponse> showFollowers(@PathVariable final Long userId,
-                                                             @RequestParam(required = false) final String cursor) {
-        return BaseResponse.ok(userGetFollowUsecase.getUserFollowers(userId, cursor));
+                                                             @RequestParam(required = false) final String cursor,
+                                                             @RequestParam(defaultValue = "10") @Max(value = 10) @Min(value = 1) final int size) {
+        return BaseResponse.ok(userGetFollowUsecase.getUserFollowers(userId, cursor, size));
     }
 
     /**
      * 내 팔로잉 리스트 조회
      */
     @GetMapping("/users/my/following")
-    public BaseResponse<UserFollowersResponse> showMyFollowing(@RequestParam(required = false) final String cursor) {
-        return BaseResponse.ok(userGetFollowUsecase.getMyFollowing(cursor));
+    public BaseResponse<UserFollowingResponse> showMyFollowing(@UserId final Long userId,
+                                                               @RequestParam(required = false) final String cursor,
+                                                               @RequestParam(defaultValue = "10") @Max(value = 10) @Min(value = 1) final int size) {
+        return BaseResponse.ok(userGetFollowUsecase.getMyFollowing(userId, cursor, size));
     }
 }

--- a/src/main/java/konkuk/thip/user/adapter/in/web/response/UserFollowersResponse.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/response/UserFollowersResponse.java
@@ -2,15 +2,12 @@ package konkuk.thip.user.adapter.in.web.response;
 
 import lombok.Builder;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
 public record UserFollowersResponse(
-        List<Follower> followerList,
-        int size,
-        LocalDateTime nextCursor,
-        boolean isFirst,
+        List<Follower> followers,
+        String nextCursor,
         boolean isLast
 ) {
     @Builder

--- a/src/main/java/konkuk/thip/user/adapter/in/web/response/UserFollowingResponse.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/response/UserFollowingResponse.java
@@ -5,20 +5,18 @@ import lombok.Builder;
 import java.util.List;
 
 @Builder
-public record UserFollowersResponse(
-        List<Follower> followers,
+public record UserFollowingResponse(
+        List<Following> followings,
         String nextCursor,
         boolean isLast
 ) {
     @Builder
-    public record Follower(
+    public record Following(
             Long userId,
             String nickname,
             String profileImageUrl,
-            String aliasName,
-            Integer followerCount
+            String aliasName
     ){
-
     }
 
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/jpa/FollowingJpaEntity.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/jpa/FollowingJpaEntity.java
@@ -21,9 +21,9 @@ public class FollowingJpaEntity extends BaseJpaEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    private UserJpaEntity userJpaEntity;
+    private UserJpaEntity userJpaEntity; // 팔로잉 하는 유저
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "following_user_id")
-    private UserJpaEntity followingUserJpaEntity;
+    private UserJpaEntity followingUserJpaEntity; // 팔로우 당하는 유저
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/FollowingQueryPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/FollowingQueryPersistenceAdapter.java
@@ -2,7 +2,7 @@ package konkuk.thip.user.adapter.out.persistence;
 
 import konkuk.thip.common.util.CursorBasedList;
 import konkuk.thip.common.util.DateUtil;
-import konkuk.thip.user.application.port.out.dto.FollowerQueryDto;
+import konkuk.thip.user.application.port.out.dto.FollowQueryDto;
 import konkuk.thip.user.adapter.out.persistence.repository.following.FollowingJpaRepository;
 import konkuk.thip.user.application.port.out.FollowingQueryPort;
 import lombok.RequiredArgsConstructor;
@@ -18,19 +18,19 @@ public class FollowingQueryPersistenceAdapter implements FollowingQueryPort {
     private final FollowingJpaRepository followingJpaRepository;
 
     @Override
-    public CursorBasedList<FollowerQueryDto> getFollowersByUserId(Long userId, String cursor, int size) {
+    public CursorBasedList<FollowQueryDto> getFollowersByUserId(Long userId, String cursor, int size) {
         LocalDateTime cursorVal = null;
         if (cursor != null && !cursor.isBlank()) {
             cursorVal = DateUtil.parseDateTime(cursor);
         }
-        List<FollowerQueryDto> dtos = followingJpaRepository.findFollowerDtosByUserIdBeforeCreatedAt(
+        List<FollowQueryDto> dtos = followingJpaRepository.findFollowerDtosByUserIdBeforeCreatedAt(
                 userId,
                 cursorVal,
                 size
         );
 
         boolean hasNext = dtos.size() > size;
-        List<FollowerQueryDto> content = hasNext ? dtos.subList(0, size) : dtos;
+        List<FollowQueryDto> content = hasNext ? dtos.subList(0, size) : dtos;
         String  nextCursor = hasNext ? content.get(size - 1).createdAt().toString() : null;
 
         return CursorBasedList.of(content, nextCursor);

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/FollowingQueryPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/FollowingQueryPersistenceAdapter.java
@@ -19,20 +19,25 @@ public class FollowingQueryPersistenceAdapter implements FollowingQueryPort {
 
     @Override
     public CursorBasedList<FollowQueryDto> getFollowersByUserId(Long userId, String cursor, int size) {
-        LocalDateTime cursorVal = null;
-        if (cursor != null && !cursor.isBlank()) {
-            cursorVal = DateUtil.parseDateTime(cursor);
-        }
-        List<FollowQueryDto> dtos = followingJpaRepository.findFollowerDtosByUserIdBeforeCreatedAt(
+        LocalDateTime cursorVal = cursor != null && !cursor.isBlank() ? DateUtil.parseDateTime(cursor) : null;
+        List<FollowQueryDto> followerDtos = followingJpaRepository.findFollowerDtosByUserIdBeforeCreatedAt(
                 userId,
                 cursorVal,
                 size
         );
 
-        boolean hasNext = dtos.size() > size;
-        List<FollowQueryDto> content = hasNext ? dtos.subList(0, size) : dtos;
-        String  nextCursor = hasNext ? content.get(size - 1).createdAt().toString() : null;
+        return CursorBasedList.of(followerDtos, size, followerDto -> followerDto.createdAt().toString());
+    }
 
-        return CursorBasedList.of(content, nextCursor);
+    @Override
+    public CursorBasedList<FollowQueryDto> getFollowingByUserId(Long userId, String cursor, int size) {
+        LocalDateTime cursorVal = cursor != null && !cursor.isBlank() ? DateUtil.parseDateTime(cursor) : null;
+        List<FollowQueryDto> followingDtos = followingJpaRepository.findFollowingDtosByUserIdBeforeCreatedAt(
+                userId,
+                cursorVal,
+                size
+        );
+
+        return CursorBasedList.of(followingDtos, size, followingDto -> followingDto.createdAt().toString());
     }
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/FollowingQueryPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/FollowingQueryPersistenceAdapter.java
@@ -1,9 +1,8 @@
 package konkuk.thip.user.adapter.out.persistence;
 
+import konkuk.thip.common.util.CursorBasedList;
 import konkuk.thip.common.util.DateUtil;
-import konkuk.thip.user.adapter.in.web.response.UserFollowersResponse;
-import konkuk.thip.user.adapter.out.jpa.FollowingJpaEntity;
-import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.application.port.out.dto.FollowerQueryDto;
 import konkuk.thip.user.adapter.out.persistence.repository.following.FollowingJpaRepository;
 import konkuk.thip.user.application.port.out.FollowingQueryPort;
 import lombok.RequiredArgsConstructor;
@@ -19,39 +18,21 @@ public class FollowingQueryPersistenceAdapter implements FollowingQueryPort {
     private final FollowingJpaRepository followingJpaRepository;
 
     @Override
-    public UserFollowersResponse getFollowersByUserId(Long userId, String cursor, int size) {
-        LocalDateTime nextCursor = null;
+    public CursorBasedList<FollowerQueryDto> getFollowersByUserId(Long userId, String cursor, int size) {
+        LocalDateTime cursorVal = null;
         if (cursor != null && !cursor.isBlank()) {
-            nextCursor = DateUtil.parseDateTime(cursor);
+            cursorVal = DateUtil.parseDateTime(cursor);
         }
+        List<FollowerQueryDto> dtos = followingJpaRepository.findFollowerDtosByUserIdBeforeCreatedAt(
+                userId,
+                cursorVal,
+                size
+        );
 
-        List<FollowingJpaEntity> followerEntities =
-                followingJpaRepository.findFollowersByUserIdBeforeCreatedAt(userId, nextCursor, size);
+        boolean hasNext = dtos.size() > size;
+        List<FollowerQueryDto> content = hasNext ? dtos.subList(0, size) : dtos;
+        String  nextCursor = hasNext ? content.get(size - 1).createdAt().toString() : null;
 
-        List<UserJpaEntity> followers = followerEntities.stream()
-                .map(FollowingJpaEntity::getUserJpaEntity) // 팔로워 사용자
-                .toList();
-
-        List<UserFollowersResponse.Follower> followerList = followers.stream()
-                .map(follower -> UserFollowersResponse.Follower.builder()
-                        .userId(follower.getUserId())
-                        .nickname(follower.getNickname())
-                        .profileImageUrl(follower.getAliasForUserJpaEntity().getImageUrl())
-                        .aliasName(follower.getAliasForUserJpaEntity().getValue())
-                        .followerCount(follower.getFollowerCount())
-                        .build())
-                .toList();
-
-        boolean isLast = followerEntities.size() < size;
-        nextCursor = isLast ? null :
-                followerEntities.get(followerEntities.size() - 1).getCreatedAt();
-
-        return UserFollowersResponse.builder()
-                .followerList(followerList)
-                .size(followerList.size())
-                .nextCursor(nextCursor)
-                .isFirst(cursor == null)  // cursor가 null이면 첫 페이지
-                .isLast(isLast)
-                .build();
+        return CursorBasedList.of(content, nextCursor);
     }
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingQueryRepository.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingQueryRepository.java
@@ -1,6 +1,7 @@
 package konkuk.thip.user.adapter.out.persistence.repository.following;
 
 import konkuk.thip.user.adapter.out.jpa.FollowingJpaEntity;
+import konkuk.thip.user.application.port.out.dto.FollowerQueryDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -9,5 +10,5 @@ import java.util.Optional;
 public interface FollowingQueryRepository {
     Optional<FollowingJpaEntity> findByUserAndTargetUser(Long userId, Long targetUserId);
 
-    List<FollowingJpaEntity> findFollowersByUserIdBeforeCreatedAt(Long userId, LocalDateTime cursor, int size);
+    List<FollowerQueryDto> findFollowerDtosByUserIdBeforeCreatedAt(Long userId, LocalDateTime cursor, int size);
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingQueryRepository.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingQueryRepository.java
@@ -1,7 +1,7 @@
 package konkuk.thip.user.adapter.out.persistence.repository.following;
 
 import konkuk.thip.user.adapter.out.jpa.FollowingJpaEntity;
-import konkuk.thip.user.application.port.out.dto.FollowerQueryDto;
+import konkuk.thip.user.application.port.out.dto.FollowQueryDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -10,5 +10,5 @@ import java.util.Optional;
 public interface FollowingQueryRepository {
     Optional<FollowingJpaEntity> findByUserAndTargetUser(Long userId, Long targetUserId);
 
-    List<FollowerQueryDto> findFollowerDtosByUserIdBeforeCreatedAt(Long userId, LocalDateTime cursor, int size);
+    List<FollowQueryDto> findFollowerDtosByUserIdBeforeCreatedAt(Long userId, LocalDateTime cursor, int size);
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingQueryRepository.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingQueryRepository.java
@@ -11,4 +11,5 @@ public interface FollowingQueryRepository {
     Optional<FollowingJpaEntity> findByUserAndTargetUser(Long userId, Long targetUserId);
 
     List<FollowQueryDto> findFollowerDtosByUserIdBeforeCreatedAt(Long userId, LocalDateTime cursor, int size);
+    List<FollowQueryDto> findFollowingDtosByUserIdBeforeCreatedAt(Long userId, LocalDateTime cursor, int size);
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingQueryRepositoryImpl.java
@@ -8,7 +8,7 @@ import konkuk.thip.user.adapter.out.jpa.QAliasJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.QFollowingJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.QUserJpaEntity;
 import konkuk.thip.user.application.port.out.dto.FollowQueryDto;
-import konkuk.thip.user.application.port.out.dto.QFollowerQueryDto;
+import konkuk.thip.user.application.port.out.dto.QFollowQueryDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -37,33 +37,54 @@ public class FollowingQueryRepositoryImpl implements FollowingQueryRepository {
 
     @Override
     public List<FollowQueryDto> findFollowerDtosByUserIdBeforeCreatedAt(Long userId, LocalDateTime cursor, int size) {
+        return findFollowDtos(
+                userId,
+                cursor,
+                size,
+                true // isFollowerQuery
+        );
+    }
+
+    @Override
+    public List<FollowQueryDto> findFollowingDtosByUserIdBeforeCreatedAt(Long userId, LocalDateTime cursor, int size) {
+        return findFollowDtos(
+                userId,
+                cursor,
+                size,
+                false // isFollowingQuery
+        );
+    }
+
+    private List<FollowQueryDto> findFollowDtos(Long userId, LocalDateTime cursor, int size, boolean isFollowerQuery) {
         QFollowingJpaEntity following = QFollowingJpaEntity.followingJpaEntity;
         QUserJpaEntity user = QUserJpaEntity.userJpaEntity;
         QAliasJpaEntity alias = QAliasJpaEntity.aliasJpaEntity;
 
         BooleanBuilder condition = new BooleanBuilder()
-                .and(following.followingUserJpaEntity.userId.eq(userId))
+                .and((isFollowerQuery ? following.followingUserJpaEntity.userId.eq(userId) : following.userJpaEntity.userId.eq(userId)))
                 .and(following.status.eq(StatusType.ACTIVE));
 
         if (cursor != null) {
             condition.and(following.createdAt.lt(cursor));
         }
 
+        QUserJpaEntity targetUser = isFollowerQuery ? following.userJpaEntity : following.followingUserJpaEntity;
+
         return jpaQueryFactory
-                .select(new QFollowerQueryDto(
-                        user.userId,
-                        user.nickname,
+                .select(new QFollowQueryDto(
+                        targetUser.userId,
+                        targetUser.nickname,
                         alias.imageUrl,
                         alias.value,
-                        user.followerCount,
+                        targetUser.followerCount,
                         following.createdAt
                 ))
                 .from(following)
-                .leftJoin(following.userJpaEntity, user)
+                .leftJoin(targetUser, user)
                 .leftJoin(user.aliasForUserJpaEntity, alias)
                 .where(condition)
                 .orderBy(following.createdAt.desc())
-                .limit(size + 1) // hasNext 판단 위해 +1
+                .limit(size + 1)
                 .fetch();
     }
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingQueryRepositoryImpl.java
@@ -7,7 +7,7 @@ import konkuk.thip.user.adapter.out.jpa.FollowingJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.QAliasJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.QFollowingJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.QUserJpaEntity;
-import konkuk.thip.user.application.port.out.dto.FollowerQueryDto;
+import konkuk.thip.user.application.port.out.dto.FollowQueryDto;
 import konkuk.thip.user.application.port.out.dto.QFollowerQueryDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -36,7 +36,7 @@ public class FollowingQueryRepositoryImpl implements FollowingQueryRepository {
     }
 
     @Override
-    public List<FollowerQueryDto> findFollowerDtosByUserIdBeforeCreatedAt(Long userId, LocalDateTime cursor, int size) {
+    public List<FollowQueryDto> findFollowerDtosByUserIdBeforeCreatedAt(Long userId, LocalDateTime cursor, int size) {
         QFollowingJpaEntity following = QFollowingJpaEntity.followingJpaEntity;
         QUserJpaEntity user = QUserJpaEntity.userJpaEntity;
         QAliasJpaEntity alias = QAliasJpaEntity.aliasJpaEntity;

--- a/src/main/java/konkuk/thip/user/application/mapper/FollowDtoMapper.java
+++ b/src/main/java/konkuk/thip/user/application/mapper/FollowDtoMapper.java
@@ -1,0 +1,14 @@
+package konkuk.thip.user.application.mapper;
+
+import konkuk.thip.user.adapter.in.web.response.UserFollowersResponse;
+import konkuk.thip.user.adapter.in.web.response.UserFollowingResponse;
+import konkuk.thip.user.application.port.out.dto.FollowQueryDto;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface FollowDtoMapper {
+
+    UserFollowersResponse.Follower toFollowerList(FollowQueryDto dto);
+
+    UserFollowingResponse.Following toFollowingList(FollowQueryDto dto);
+}

--- a/src/main/java/konkuk/thip/user/application/port/in/UserGetFollowUsecase.java
+++ b/src/main/java/konkuk/thip/user/application/port/in/UserGetFollowUsecase.java
@@ -2,6 +2,8 @@ package konkuk.thip.user.application.port.in;
 
 import konkuk.thip.user.adapter.in.web.response.UserFollowersResponse;
 
-public interface UserGetFollowersUsecase {
+public interface UserGetFollowUsecase {
     UserFollowersResponse getUserFollowers(Long userId, String cursor);
+
+    UserFollowersResponse getMyFollowing(String cursor);
 }

--- a/src/main/java/konkuk/thip/user/application/port/in/UserGetFollowUsecase.java
+++ b/src/main/java/konkuk/thip/user/application/port/in/UserGetFollowUsecase.java
@@ -1,9 +1,10 @@
 package konkuk.thip.user.application.port.in;
 
 import konkuk.thip.user.adapter.in.web.response.UserFollowersResponse;
+import konkuk.thip.user.adapter.in.web.response.UserFollowingResponse;
 
 public interface UserGetFollowUsecase {
-    UserFollowersResponse getUserFollowers(Long userId, String cursor);
+    UserFollowersResponse getUserFollowers(Long userId, String cursor, int size);
 
-    UserFollowersResponse getMyFollowing(String cursor);
+    UserFollowingResponse getMyFollowing(Long userId, String cursor, int size);
 }

--- a/src/main/java/konkuk/thip/user/application/port/in/UserGetFollowersUsecase.java
+++ b/src/main/java/konkuk/thip/user/application/port/in/UserGetFollowersUsecase.java
@@ -3,5 +3,5 @@ package konkuk.thip.user.application.port.in;
 import konkuk.thip.user.adapter.in.web.response.UserFollowersResponse;
 
 public interface UserGetFollowersUsecase {
-    UserFollowersResponse getUserFollowers(Long userId, String nextCursor);
+    UserFollowersResponse getUserFollowers(Long userId, String cursor);
 }

--- a/src/main/java/konkuk/thip/user/application/port/out/FollowingQueryPort.java
+++ b/src/main/java/konkuk/thip/user/application/port/out/FollowingQueryPort.java
@@ -1,8 +1,9 @@
 package konkuk.thip.user.application.port.out;
 
-import konkuk.thip.user.adapter.in.web.response.UserFollowersResponse;
+import konkuk.thip.common.util.CursorBasedList;
+import konkuk.thip.user.application.port.out.dto.FollowerQueryDto;
 
 public interface FollowingQueryPort {
-    UserFollowersResponse getFollowersByUserId(Long userId, String cursor, int size);
+    CursorBasedList<FollowerQueryDto> getFollowersByUserId(Long userId, String cursor, int size);
 }
 

--- a/src/main/java/konkuk/thip/user/application/port/out/FollowingQueryPort.java
+++ b/src/main/java/konkuk/thip/user/application/port/out/FollowingQueryPort.java
@@ -1,9 +1,10 @@
 package konkuk.thip.user.application.port.out;
 
 import konkuk.thip.common.util.CursorBasedList;
-import konkuk.thip.user.application.port.out.dto.FollowerQueryDto;
+import konkuk.thip.user.application.port.out.dto.FollowQueryDto;
 
 public interface FollowingQueryPort {
-    CursorBasedList<FollowerQueryDto> getFollowersByUserId(Long userId, String cursor, int size);
+    CursorBasedList<FollowQueryDto> getFollowersByUserId(Long userId, String cursor, int size);
+
 }
 

--- a/src/main/java/konkuk/thip/user/application/port/out/FollowingQueryPort.java
+++ b/src/main/java/konkuk/thip/user/application/port/out/FollowingQueryPort.java
@@ -5,6 +5,6 @@ import konkuk.thip.user.application.port.out.dto.FollowQueryDto;
 
 public interface FollowingQueryPort {
     CursorBasedList<FollowQueryDto> getFollowersByUserId(Long userId, String cursor, int size);
-
+    CursorBasedList<FollowQueryDto> getFollowingByUserId(Long userId, String cursor, int size);
 }
 

--- a/src/main/java/konkuk/thip/user/application/port/out/dto/FollowQueryDto.java
+++ b/src/main/java/konkuk/thip/user/application/port/out/dto/FollowQueryDto.java
@@ -18,7 +18,7 @@ public record FollowQueryDto(Long userId,
         Assert.notNull(nickname, "nickname must not be null");
         Assert.notNull(profileImageUrl, "profileImageUrl must not be null");
         Assert.notNull(aliasName, "aliasName must not be null");
-        Assert.notNull(followerCount, "followerCount must not be null");
+//        Assert.notNull(followerCount, "followerCount must not be null"); // 내 팔로잉 목록 조회에서는 필요 x
         Assert.notNull(createdAt, "createdAt must not be null");
     }
 }

--- a/src/main/java/konkuk/thip/user/application/port/out/dto/FollowQueryDto.java
+++ b/src/main/java/konkuk/thip/user/application/port/out/dto/FollowQueryDto.java
@@ -5,15 +5,15 @@ import io.jsonwebtoken.lang.Assert;
 
 import java.time.LocalDateTime;
 
-public record FollowerQueryDto(Long userId,
-                               String nickname,
-                               String profileImageUrl,
-                               String aliasName,
-                               Integer followerCount,
-                               LocalDateTime createdAt) {
+public record FollowQueryDto(Long userId,
+                             String nickname,
+                             String profileImageUrl,
+                             String aliasName,
+                             Integer followerCount,
+                             LocalDateTime createdAt) {
 
     @QueryProjection
-    public FollowerQueryDto {
+    public FollowQueryDto {
         Assert.notNull(userId, "userId must not be null");
         Assert.notNull(nickname, "nickname must not be null");
         Assert.notNull(profileImageUrl, "profileImageUrl must not be null");

--- a/src/main/java/konkuk/thip/user/application/port/out/dto/FollowerQueryDto.java
+++ b/src/main/java/konkuk/thip/user/application/port/out/dto/FollowerQueryDto.java
@@ -1,0 +1,24 @@
+package konkuk.thip.user.application.port.out.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import io.jsonwebtoken.lang.Assert;
+
+import java.time.LocalDateTime;
+
+public record FollowerQueryDto(Long userId,
+                               String nickname,
+                               String profileImageUrl,
+                               String aliasName,
+                               Integer followerCount,
+                               LocalDateTime createdAt) {
+
+    @QueryProjection
+    public FollowerQueryDto {
+        Assert.notNull(userId, "userId must not be null");
+        Assert.notNull(nickname, "nickname must not be null");
+        Assert.notNull(profileImageUrl, "profileImageUrl must not be null");
+        Assert.notNull(aliasName, "aliasName must not be null");
+        Assert.notNull(followerCount, "followerCount must not be null");
+        Assert.notNull(createdAt, "createdAt must not be null");
+    }
+}

--- a/src/main/java/konkuk/thip/user/application/service/following/UserGetFollowService.java
+++ b/src/main/java/konkuk/thip/user/application/service/following/UserGetFollowService.java
@@ -2,8 +2,8 @@ package konkuk.thip.user.application.service.following;
 
 import konkuk.thip.common.util.CursorBasedList;
 import konkuk.thip.user.adapter.in.web.response.UserFollowersResponse;
-import konkuk.thip.user.application.port.out.dto.FollowerQueryDto;
-import konkuk.thip.user.application.port.in.UserGetFollowersUsecase;
+import konkuk.thip.user.application.port.out.dto.FollowQueryDto;
+import konkuk.thip.user.application.port.in.UserGetFollowUsecase;
 import konkuk.thip.user.application.port.out.FollowingQueryPort;
 import konkuk.thip.user.application.port.out.UserCommandPort;
 import konkuk.thip.user.domain.User;
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class UserGetFollowersService implements UserGetFollowersUsecase {
+public class UserGetFollowService implements UserGetFollowUsecase {
 
     private final FollowingQueryPort followingQueryPort;
     private final UserCommandPort userCommandPort;
@@ -25,7 +25,7 @@ public class UserGetFollowersService implements UserGetFollowersUsecase {
     public UserFollowersResponse getUserFollowers(Long userId, String cursor) {
         User user = userCommandPort.findById(userId);
 
-        CursorBasedList<FollowerQueryDto> result = followingQueryPort.getFollowersByUserId(
+        CursorBasedList<FollowQueryDto> result = followingQueryPort.getFollowersByUserId(
                 user.getId(), cursor, DEFAULT_PAGE_SIZE
         );
 
@@ -44,5 +44,11 @@ public class UserGetFollowersService implements UserGetFollowersUsecase {
                 .nextCursor(result.nextCursor())
                 .isLast(!result.hasNext())
                 .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserFollowersResponse getMyFollowing(String cursor) {
+        return null;
     }
 }

--- a/src/test/java/konkuk/thip/user/adapter/in/web/UserGetFollowersApiTest.java
+++ b/src/test/java/konkuk/thip/user/adapter/in/web/UserGetFollowersApiTest.java
@@ -82,8 +82,7 @@ class UserGetFollowersApiTest {
         );
 
         firstPageResult.andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.followerList", hasSize(10)))
-                .andExpect(jsonPath("$.data.isFirst").value(true))
+                .andExpect(jsonPath("$.data.followers", hasSize(10)))
                 .andExpect(jsonPath("$.data.isLast").value(false))
                 .andExpect(jsonPath("$.data.nextCursor").exists());
 
@@ -101,8 +100,7 @@ class UserGetFollowersApiTest {
         );
 
         secondPageResult.andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.followerList", hasSize(2)))
-                .andExpect(jsonPath("$.data.isFirst").value(false))
+                .andExpect(jsonPath("$.data.followers", hasSize(2)))
                 .andExpect(jsonPath("$.data.isLast").value(true))
                 .andExpect(jsonPath("$.data.nextCursor").doesNotExist());
     }

--- a/src/test/java/konkuk/thip/user/adapter/in/web/UserGetFollowingApiTest.java
+++ b/src/test/java/konkuk/thip/user/adapter/in/web/UserGetFollowingApiTest.java
@@ -29,9 +29,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @ActiveProfiles("test")
 @AutoConfigureMockMvc(addFilters = false)
-@DisplayName("[통합] 팔로워 조회 API 통합 테스트")
+@DisplayName("[통합] 내 팔로잉 리스트 조회 API 통합 테스트")
 @Transactional
-class UserGetFollowersApiTest {
+class UserGetFollowingApiTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -48,35 +48,36 @@ class UserGetFollowersApiTest {
     @Autowired
     private FollowingJpaRepository followingJpaRepository;
 
-    private UserJpaEntity targetUser; // 팔로워를 조회할 대상 사용자
-    private List<UserJpaEntity> followerUsers; // 팔로워 12명
+    private UserJpaEntity loginUser; // 팔로잉 리스트를 조회하는 로그인한 사용자
+    private List<UserJpaEntity> followingUsers; // 팔로잉 12명
 
     @BeforeEach
     void setUp() {
         AliasJpaEntity alias = aliasJpaRepository.save(TestEntityFactory.createLiteratureAlias());
 
-        // 대상 사용자
-        targetUser = userJpaRepository.save(TestEntityFactory.createUser(alias));
+        // 로그인 사용자
+        loginUser = userJpaRepository.save(TestEntityFactory.createUser(alias));
 
-        // 팔로워 12명 생성 및 저장
-        followerUsers = new ArrayList<>();
+        // 팔로잉 12명 생성 및 저장
+        followingUsers = new ArrayList<>();
         for (int i = 0; i < 12; i++) {
-            UserJpaEntity follower = userJpaRepository.save(TestEntityFactory.createUser(alias));
-            followerUsers.add(follower);
-            followingJpaRepository.save(TestEntityFactory.createFollowing(follower, targetUser));
+            UserJpaEntity followingUser = userJpaRepository.save(TestEntityFactory.createUser(alias));
+            followingUsers.add(followingUser);
+            followingJpaRepository.save(TestEntityFactory.createFollowing(loginUser, followingUser));
         }
     }
 
     @Test
-    @DisplayName("팔로워가 12명일 때 2페이지에 걸쳐 모두 조회되고 커서가 올바르게 작동한다.")
-    void getFollowersWithCursorPaging() throws Exception {
+    @DisplayName("로그인한 사용자의 팔로잉 수가 12명일 때 2페이지에 걸쳐 모두 조회되고 커서가 올바르게 작동한다.")
+    void getFollowingsWithCursorPaging() throws Exception {
         // 1. 첫 번째 요청 (cursor 없음)
         ResultActions firstPageResult = mockMvc.perform(
-                get("/users/{userId}/followers", targetUser.getUserId())
+                get("/users/my/following")
+                        .requestAttr("userId", loginUser.getUserId())
         );
 
         firstPageResult.andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.followers", hasSize(10)))
+                .andExpect(jsonPath("$.data.followings", hasSize(10)))
                 .andExpect(jsonPath("$.data.isLast").value(false))
                 .andExpect(jsonPath("$.data.nextCursor").exists());
 
@@ -89,12 +90,13 @@ class UserGetFollowersApiTest {
 
         // 2. 두 번째 요청 (cursor 사용)
         ResultActions secondPageResult = mockMvc.perform(
-                get("/users/{userId}/followers", targetUser.getUserId())
+                get("/users/my/following")
                         .param("cursor", nextCursor)
+                        .requestAttr("userId", loginUser.getUserId())
         );
 
         secondPageResult.andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.followers", hasSize(2)))
+                .andExpect(jsonPath("$.data.followings", hasSize(2)))
                 .andExpect(jsonPath("$.data.isLast").value(true))
                 .andExpect(jsonPath("$.data.nextCursor").doesNotExist());
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #90 

## 📝 작업 내용
이번 PR은 “팔로워 리스트 조회 API #77”과 로직 구조가 매우 유사하여, 리팩토링 중심으로 작업을 진행하였습니다. 주요 변경 사항은 다음과 같습니다:

1. **CursorBasedList 도입**
대부분의 조회 기능이 무한 스크롤 기반으로 동작하기 때문에, 커서 기반 페이징 방식이 적절하다고 판단하였습니다. 이에 따라 커서 기반 페이징 처리를 표준화하고자 CursorBasedList를 도입하였으며, 관련 상세 내용은 노션에 정리해두었으니 참고 부탁드립니다.
2. **QueryProjection 기반 공통 DTO 적용**
Querydsl의 @QueryProjection을 활용하면 공통 응답 DTO를 생성하는 데 유용하다는 점을 확인하여, 이번에 유사한 조회 로직들에 적용해보았습니다.
FollowQueryDto는 팔로워 및 팔로잉 사용자 정보를 모두 담을 수 있는 구조로 설계되어 있으며, 응답 형식의 차이는 주로 followerCount 포함 여부입니다.
따라서, 쿼리 결과는 FollowQueryDto로 통일하여 받아오고, 서비스 계층에서 필요한 응답 DTO로 변환하는 방식으로 구성해 조회 로직의 재사용성과 응집도를 높였습니다.
3. **MapStruct 도입**
서비스 계층에서 FollowQueryDto를 실제 응답 DTO로 변환하는 작업을 명확하게 분리하고자 MapStruct를 도입하였습니다.
기존에는 조회 DTO → 응답 DTO 변환 책임이 응답 DTO나 서비스 클래스 중 한 곳에 맡아 혼용되고 있었고, 이는 의존성 침해 및 서비스 로직 복잡도 증가라는 단점이 있었습니다.
이러한 문제를 해소하고자 명확한 매핑 책임을 가진 Mapper 클래스를 분리하여 도입하였고, 이를 통해 매핑 로직을 간결하고 명시적으로 관리할 수 있게 되었습니다.

앞으로 다른 조회 API 개발 시에도, 공통 필드는 QueryDto로 분리하고, 매핑에는 MapStruct를 활용하는 구조를 적용하면 유지보수성과 일관성을 높일 수 있을 것으로 기대합니다. 감사합니다.

## 📸 스크린샷

## 💬 리뷰 요구사항

현재 조회 dto(`FollowQueryDto`) -> 응답 dto(`UserFollowingResponse`)를 파싱하는 매퍼 (`FollowMapper`)를 application하위에 mapper 패키지를 만들어서 두었는데 이 위치에 대한 부분도 한번 확인 부탁드릴게요!


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
