### PR TITLE
[feat] 팔로잉 조회 여부 api 개발

### DIFF
--- a/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
@@ -6,7 +6,7 @@ import konkuk.thip.common.dto.BaseResponse;
 import konkuk.thip.common.security.annotation.UserId;
 import konkuk.thip.user.adapter.in.web.response.UserFollowersResponse;
 import konkuk.thip.user.adapter.in.web.response.UserFollowingResponse;
-import konkuk.thip.user.adapter.in.web.response.UserIsFollowingRespone;
+import konkuk.thip.user.adapter.in.web.response.UserIsFollowingResponse;
 import konkuk.thip.user.adapter.in.web.response.UserViewAliasChoiceResponse;
 import konkuk.thip.user.application.port.in.UserGetFollowUsecase;
 import konkuk.thip.user.application.port.in.UserIsFollowingUsecase;
@@ -59,8 +59,8 @@ public class UserQueryController {
      * 팔로잉 여부 조회
      */
     @GetMapping("/users/{targetUserId}/is-following")
-    public BaseResponse<UserIsFollowingRespone> checkisFollowing(@UserId final Long userId,
-                                                                 @PathVariable final Long targetUserId) {
+    public BaseResponse<UserIsFollowingResponse> checkisFollowing(@UserId final Long userId,
+                                                                  @PathVariable final Long targetUserId) {
         return BaseResponse.ok(userIsFollowingUsecase.isFollowing(userId, targetUserId));
     }
 }

--- a/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
@@ -6,8 +6,10 @@ import konkuk.thip.common.dto.BaseResponse;
 import konkuk.thip.common.security.annotation.UserId;
 import konkuk.thip.user.adapter.in.web.response.UserFollowersResponse;
 import konkuk.thip.user.adapter.in.web.response.UserFollowingResponse;
+import konkuk.thip.user.adapter.in.web.response.UserIsFollowingRespone;
 import konkuk.thip.user.adapter.in.web.response.UserViewAliasChoiceResponse;
 import konkuk.thip.user.application.port.in.UserGetFollowUsecase;
+import konkuk.thip.user.application.port.in.UserIsFollowingUsecase;
 import konkuk.thip.user.application.port.in.UserViewAliasChoiceUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,6 +23,7 @@ public class UserQueryController {
 
     private final UserViewAliasChoiceUseCase userViewAliasChoiceUseCase;
     private final UserGetFollowUsecase userGetFollowUsecase;
+    private final UserIsFollowingUsecase userIsFollowingUsecase;
 
     /**
      * 사용자 별칭 선택 화면 조회
@@ -50,5 +53,14 @@ public class UserQueryController {
                                                                @RequestParam(required = false) final String cursor,
                                                                @RequestParam(defaultValue = "10") @Max(value = 10) @Min(value = 1) final int size) {
         return BaseResponse.ok(userGetFollowUsecase.getMyFollowing(userId, cursor, size));
+    }
+
+    /**
+     * 팔로잉 여부 조회
+     */
+    @GetMapping("/users/{targetUserId}/is-following")
+    public BaseResponse<UserIsFollowingRespone> checkisFollowing(@UserId final Long userId,
+                                                                 @PathVariable final Long targetUserId) {
+        return BaseResponse.ok(userIsFollowingUsecase.isFollowing(userId, targetUserId));
     }
 }

--- a/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
@@ -61,6 +61,6 @@ public class UserQueryController {
     @GetMapping("/users/{targetUserId}/is-following")
     public BaseResponse<UserIsFollowingResponse> checkisFollowing(@UserId final Long userId,
                                                                   @PathVariable final Long targetUserId) {
-        return BaseResponse.ok(userIsFollowingUsecase.isFollowing(userId, targetUserId));
+        return BaseResponse.ok(UserIsFollowingResponse.of(userIsFollowingUsecase.isFollowing(userId, targetUserId)));
     }
 }

--- a/src/main/java/konkuk/thip/user/adapter/in/web/response/UserIsFollowingRespone.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/response/UserIsFollowingRespone.java
@@ -1,0 +1,6 @@
+package konkuk.thip.user.adapter.in.web.response;
+
+public record UserIsFollowingRespone(
+    boolean isFollowing
+) {
+}

--- a/src/main/java/konkuk/thip/user/adapter/in/web/response/UserIsFollowingResponse.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/response/UserIsFollowingResponse.java
@@ -1,6 +1,6 @@
 package konkuk.thip.user.adapter.in.web.response;
 
-public record UserIsFollowingRespone(
+public record UserIsFollowingResponse(
     boolean isFollowing
 ) {
 }

--- a/src/main/java/konkuk/thip/user/adapter/in/web/response/UserIsFollowingResponse.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/response/UserIsFollowingResponse.java
@@ -3,4 +3,7 @@ package konkuk.thip.user.adapter.in.web.response;
 public record UserIsFollowingResponse(
     boolean isFollowing
 ) {
+    public static UserIsFollowingResponse of(boolean isFollowing) {
+        return new UserIsFollowingResponse(isFollowing);
+    }
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/jpa/FollowingJpaEntity.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/jpa/FollowingJpaEntity.java
@@ -3,12 +3,10 @@ package konkuk.thip.user.adapter.out.jpa;
 import jakarta.persistence.*;
 import konkuk.thip.common.entity.BaseJpaEntity;
 import lombok.*;
-import org.hibernate.annotations.SQLDelete;
 
 @Entity
 @Table(name = "followings")
 @Getter
-@SQLDelete(sql = "UPDATE followings SET status = 'INACTIVE' WHERE following_id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder

--- a/src/main/java/konkuk/thip/user/adapter/out/jpa/UserJpaEntity.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/jpa/UserJpaEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import konkuk.thip.common.entity.BaseJpaEntity;
 import konkuk.thip.user.domain.User;
 import lombok.*;
+import org.springframework.util.Assert;
 
 @Entity
 @Table(name = "users")
@@ -39,12 +40,9 @@ public class UserJpaEntity extends BaseJpaEntity {
     @JoinColumn(name = "user_alias_id", nullable = false)
     private AliasJpaEntity aliasForUserJpaEntity;
 
-    public void updateFollowerCount(int followerCount) {
-        this.followerCount = followerCount;
-    }
-
     public void updateFrom(User user) {
         this.nickname = user.getNickname();
+        Assert.notNull(user.getAlias(), "Alias must not be null");
         this.imageUrl = user.getAlias().getImageUrl();
         this.role = UserRole.from(user.getUserRole());
         this.followerCount = user.getFollowerCount();

--- a/src/main/java/konkuk/thip/user/adapter/out/jpa/UserJpaEntity.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/jpa/UserJpaEntity.java
@@ -3,6 +3,7 @@ package konkuk.thip.user.adapter.out.jpa;
 
 import jakarta.persistence.*;
 import konkuk.thip.common.entity.BaseJpaEntity;
+import konkuk.thip.user.domain.User;
 import lombok.*;
 
 @Entity
@@ -42,4 +43,10 @@ public class UserJpaEntity extends BaseJpaEntity {
         this.followerCount = followerCount;
     }
 
+    public void updateFrom(User user) {
+        this.nickname = user.getNickname();
+        this.imageUrl = user.getAlias().getImageUrl();
+        this.role = UserRole.from(user.getUserRole());
+        this.followerCount = user.getFollowerCount();
+    }
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/FollowingCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/FollowingCommandPersistenceAdapter.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+import static konkuk.thip.common.exception.code.ErrorCode.FOLLOW_NOT_FOUND;
 import static konkuk.thip.common.exception.code.ErrorCode.USER_NOT_FOUND;
 
 @Repository
@@ -50,7 +51,7 @@ public class FollowingCommandPersistenceAdapter implements FollowingCommandPort 
         updateUserFollowerCount(targetUser);
 
         FollowingJpaEntity followingJpaEntity = followingJpaRepository.findByUserAndTargetUser(following.getUserId(), following.getFollowingUserId())
-                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+                .orElseThrow(() -> new EntityNotFoundException(FOLLOW_NOT_FOUND));
 
         followingJpaRepository.delete(followingJpaEntity);
     }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingQueryRepositoryImpl.java
@@ -29,7 +29,8 @@ public class FollowingQueryRepositoryImpl implements FollowingQueryRepository {
         FollowingJpaEntity followingJpaEntity = jpaQueryFactory
                 .selectFrom(following)
                 .where(following.userJpaEntity.userId.eq(userId)
-                        .and(following.followingUserJpaEntity.userId.eq(targetUserId)))
+                        .and(following.followingUserJpaEntity.userId.eq(targetUserId))
+                        .and(following.status.eq(StatusType.ACTIVE)))
                 .fetchOne();
 
         return Optional.ofNullable(followingJpaEntity);

--- a/src/main/java/konkuk/thip/user/application/mapper/FollowQueryMapper.java
+++ b/src/main/java/konkuk/thip/user/application/mapper/FollowQueryMapper.java
@@ -6,7 +6,7 @@ import konkuk.thip.user.application.port.out.dto.FollowQueryDto;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
-public interface FollowDtoMapper {
+public interface FollowQueryMapper {
 
     UserFollowersResponse.Follower toFollowerList(FollowQueryDto dto);
 

--- a/src/main/java/konkuk/thip/user/application/port/in/UserIsFollowingUsecase.java
+++ b/src/main/java/konkuk/thip/user/application/port/in/UserIsFollowingUsecase.java
@@ -1,7 +1,7 @@
 package konkuk.thip.user.application.port.in;
 
-import konkuk.thip.user.adapter.in.web.response.UserIsFollowingRespone;
+import konkuk.thip.user.adapter.in.web.response.UserIsFollowingResponse;
 
 public interface UserIsFollowingUsecase {
-    UserIsFollowingRespone isFollowing(Long userId, Long targetUserId);
+    UserIsFollowingResponse isFollowing(Long userId, Long targetUserId);
 }

--- a/src/main/java/konkuk/thip/user/application/port/in/UserIsFollowingUsecase.java
+++ b/src/main/java/konkuk/thip/user/application/port/in/UserIsFollowingUsecase.java
@@ -1,5 +1,5 @@
 package konkuk.thip.user.application.port.in;
 
 public interface UserIsFollowingUsecase {
-    Boolean isFollowing(Long userId, Long targetUserId);
+    boolean isFollowing(Long userId, Long targetUserId);
 }

--- a/src/main/java/konkuk/thip/user/application/port/in/UserIsFollowingUsecase.java
+++ b/src/main/java/konkuk/thip/user/application/port/in/UserIsFollowingUsecase.java
@@ -1,0 +1,7 @@
+package konkuk.thip.user.application.port.in;
+
+import konkuk.thip.user.adapter.in.web.response.UserIsFollowingRespone;
+
+public interface UserIsFollowingUsecase {
+    UserIsFollowingRespone isFollowing(Long userId, Long targetUserId);
+}

--- a/src/main/java/konkuk/thip/user/application/port/in/UserIsFollowingUsecase.java
+++ b/src/main/java/konkuk/thip/user/application/port/in/UserIsFollowingUsecase.java
@@ -1,7 +1,5 @@
 package konkuk.thip.user.application.port.in;
 
-import konkuk.thip.user.adapter.in.web.response.UserIsFollowingResponse;
-
 public interface UserIsFollowingUsecase {
-    UserIsFollowingResponse isFollowing(Long userId, Long targetUserId);
+    Boolean isFollowing(Long userId, Long targetUserId);
 }

--- a/src/main/java/konkuk/thip/user/application/port/out/FollowingCommandPort.java
+++ b/src/main/java/konkuk/thip/user/application/port/out/FollowingCommandPort.java
@@ -1,5 +1,7 @@
 package konkuk.thip.user.application.port.out;
 
+import konkuk.thip.common.exception.EntityNotFoundException;
+import konkuk.thip.common.exception.code.ErrorCode;
 import konkuk.thip.user.domain.Following;
 import konkuk.thip.user.domain.User;
 
@@ -9,7 +11,12 @@ public interface FollowingCommandPort {
 
     Optional<Following> findByUserIdAndTargetUserId(Long userId, Long targetUserId);
 
+    default Following getByUserIdAndTargetUserIdOrThrow(Long userId, Long targetUserId) {
+        return findByUserIdAndTargetUserId(userId, targetUserId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.FOLLOW_NOT_FOUND));
+    }
+
     void save(Following following, User targetUser);
 
-    void updateStatus(Following following, User targetUser);
+    void deleteFollowing(Following following, User targetUser);
 }

--- a/src/main/java/konkuk/thip/user/application/service/UserIsFollowingService.java
+++ b/src/main/java/konkuk/thip/user/application/service/UserIsFollowingService.java
@@ -1,0 +1,21 @@
+package konkuk.thip.user.application.service;
+
+import konkuk.thip.user.adapter.in.web.response.UserIsFollowingRespone;
+import konkuk.thip.user.application.port.in.UserIsFollowingUsecase;
+import konkuk.thip.user.application.port.out.FollowingCommandPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserIsFollowingService implements UserIsFollowingUsecase {
+
+    private final FollowingCommandPort followingCommandPort;
+
+    @Override
+    public UserIsFollowingRespone isFollowing(Long userId, Long targetUserId) {
+        boolean isFollowing = followingCommandPort.findByUserIdAndTargetUserId(userId, targetUserId)
+                .isPresent();
+        return new UserIsFollowingRespone(isFollowing);
+    }
+}

--- a/src/main/java/konkuk/thip/user/application/service/UserIsFollowingService.java
+++ b/src/main/java/konkuk/thip/user/application/service/UserIsFollowingService.java
@@ -12,7 +12,7 @@ public class UserIsFollowingService implements UserIsFollowingUsecase {
     private final FollowingCommandPort followingCommandPort;
 
     @Override
-    public Boolean isFollowing(Long userId, Long targetUserId) {
+    public boolean isFollowing(Long userId, Long targetUserId) {
         return followingCommandPort.findByUserIdAndTargetUserId(userId, targetUserId)
                 .isPresent();
     }

--- a/src/main/java/konkuk/thip/user/application/service/UserIsFollowingService.java
+++ b/src/main/java/konkuk/thip/user/application/service/UserIsFollowingService.java
@@ -1,6 +1,6 @@
 package konkuk.thip.user.application.service;
 
-import konkuk.thip.user.adapter.in.web.response.UserIsFollowingRespone;
+import konkuk.thip.user.adapter.in.web.response.UserIsFollowingResponse;
 import konkuk.thip.user.application.port.in.UserIsFollowingUsecase;
 import konkuk.thip.user.application.port.out.FollowingCommandPort;
 import lombok.RequiredArgsConstructor;
@@ -13,9 +13,9 @@ public class UserIsFollowingService implements UserIsFollowingUsecase {
     private final FollowingCommandPort followingCommandPort;
 
     @Override
-    public UserIsFollowingRespone isFollowing(Long userId, Long targetUserId) {
+    public UserIsFollowingResponse isFollowing(Long userId, Long targetUserId) {
         boolean isFollowing = followingCommandPort.findByUserIdAndTargetUserId(userId, targetUserId)
                 .isPresent();
-        return new UserIsFollowingRespone(isFollowing);
+        return new UserIsFollowingResponse(isFollowing);
     }
 }

--- a/src/main/java/konkuk/thip/user/application/service/UserIsFollowingService.java
+++ b/src/main/java/konkuk/thip/user/application/service/UserIsFollowingService.java
@@ -1,6 +1,5 @@
 package konkuk.thip.user.application.service;
 
-import konkuk.thip.user.adapter.in.web.response.UserIsFollowingResponse;
 import konkuk.thip.user.application.port.in.UserIsFollowingUsecase;
 import konkuk.thip.user.application.port.out.FollowingCommandPort;
 import lombok.RequiredArgsConstructor;
@@ -13,9 +12,8 @@ public class UserIsFollowingService implements UserIsFollowingUsecase {
     private final FollowingCommandPort followingCommandPort;
 
     @Override
-    public UserIsFollowingResponse isFollowing(Long userId, Long targetUserId) {
-        boolean isFollowing = followingCommandPort.findByUserIdAndTargetUserId(userId, targetUserId)
+    public Boolean isFollowing(Long userId, Long targetUserId) {
+        return followingCommandPort.findByUserIdAndTargetUserId(userId, targetUserId)
                 .isPresent();
-        return new UserIsFollowingResponse(isFollowing);
     }
 }

--- a/src/main/java/konkuk/thip/user/application/service/following/UserFollowService.java
+++ b/src/main/java/konkuk/thip/user/application/service/following/UserFollowService.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Objects;
 import java.util.Optional;
 
 import static konkuk.thip.common.exception.code.ErrorCode.USER_ALREADY_UNFOLLOWED;
@@ -40,7 +39,7 @@ public class UserFollowService implements UserFollowUsecase {
             Following following = optionalFollowing.get();
             boolean isFollowing = following.changeFollowingState(type);
             targetUser.updateFollowerCount(isFollowing);
-            followingCommandPort.updateStatus(following, targetUser);
+            followingCommandPort.deleteFollowing(following, targetUser);
             return isFollowing;
         } else { // 팔로우 관계가 존재하지 않는 경우
             if (!type) {
@@ -53,7 +52,7 @@ public class UserFollowService implements UserFollowUsecase {
     }
 
     private void validateParams(Long userId, Long targetUserId) {
-        if(Objects.equals(userId, targetUserId)) {
+        if(userId.equals(targetUserId)) {
             throw new BusinessException(USER_CANNOT_FOLLOW_SELF);
         }
     }

--- a/src/main/java/konkuk/thip/user/application/service/following/UserGetFollowService.java
+++ b/src/main/java/konkuk/thip/user/application/service/following/UserGetFollowService.java
@@ -3,7 +3,7 @@ package konkuk.thip.user.application.service.following;
 import konkuk.thip.common.util.CursorBasedList;
 import konkuk.thip.user.adapter.in.web.response.UserFollowersResponse;
 import konkuk.thip.user.adapter.in.web.response.UserFollowingResponse;
-import konkuk.thip.user.application.mapper.FollowDtoMapper;
+import konkuk.thip.user.application.mapper.FollowQueryMapper;
 import konkuk.thip.user.application.port.out.dto.FollowQueryDto;
 import konkuk.thip.user.application.port.in.UserGetFollowUsecase;
 import konkuk.thip.user.application.port.out.FollowingQueryPort;
@@ -20,7 +20,7 @@ public class UserGetFollowService implements UserGetFollowUsecase {
     private final FollowingQueryPort followingQueryPort;
     private final UserCommandPort userCommandPort;
 
-    private final FollowDtoMapper followDtoMapper;
+    private final FollowQueryMapper followQueryMapper;
 
     private static final int MAX_PAGE_SIZE = 10;
 
@@ -34,7 +34,7 @@ public class UserGetFollowService implements UserGetFollowUsecase {
         );
 
         var followers = result.contents().stream()
-                .map(followDtoMapper::toFollowerList)
+                .map(followQueryMapper::toFollowerList)
                 .toList();
 
         return UserFollowersResponse.builder()
@@ -54,7 +54,7 @@ public class UserGetFollowService implements UserGetFollowUsecase {
         );
 
         var following = result.contents().stream()
-                .map(followDtoMapper::toFollowingList)
+                .map(followQueryMapper::toFollowingList)
                 .toList();
 
         return UserFollowingResponse.builder()

--- a/src/test/java/konkuk/thip/user/adapter/in/web/UserFollowApiTest.java
+++ b/src/test/java/konkuk/thip/user/adapter/in/web/UserFollowApiTest.java
@@ -5,8 +5,8 @@ import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.FollowingJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.UserRole;
-import konkuk.thip.user.adapter.out.persistence.repository.alias.AliasJpaRepository;
 import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.repository.alias.AliasJpaRepository;
 import konkuk.thip.user.adapter.out.persistence.repository.following.FollowingJpaRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +17,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -49,7 +51,7 @@ class UserFollowApiTest {
     }
 
     @Test
-    @DisplayName("팔로우 요청 후 언팔로우 요청 시 상태가 변경되는지 확인한다.")
+    @DisplayName("팔로우 요청 후 언팔로우 요청 시 엔티티가 삭제되었는지 확인한다.")
     void changeFollowingState_follow_then_unfollow() throws Exception {
         // 사용자 2명 저장
         AliasJpaEntity alias = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
@@ -93,9 +95,9 @@ class UserFollowApiTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.isFollowing").value(false));
 
-        // DB에 상태가 INACTIVE로 변경되었는지 확인
-        FollowingJpaEntity updatedEntity = followingJpaRepository.findByUserAndTargetUser(followingUser.getUserId(), target.getUserId()).orElseThrow();
-        assertThat(updatedEntity.getStatus().name()).isEqualTo("INACTIVE");
+        // DB에서 삭제되었는지 확인
+        Optional<FollowingJpaEntity> followingJpaEntityOptional = followingJpaRepository.findByUserAndTargetUser(followingUser.getUserId(), target.getUserId());
+        assertThat(followingJpaEntityOptional.isPresent()).isFalse();
 
         userJpaEntity = userJpaRepository.findById(target.getUserId()).orElseThrow();
         assertThat(userJpaEntity.getFollowerCount()).isEqualTo(0); // 팔로워 수 감소 확인

--- a/src/test/java/konkuk/thip/user/adapter/in/web/UserIsFollowingApiTest.java
+++ b/src/test/java/konkuk/thip/user/adapter/in/web/UserIsFollowingApiTest.java
@@ -1,0 +1,90 @@
+package konkuk.thip.user.adapter.in.web;
+
+import konkuk.thip.common.util.TestEntityFactory;
+import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.FollowingJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.repository.alias.AliasJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.repository.following.FollowingJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("[통합] 팔로잉 여부 조회 API 통합 테스트")
+class UserIsFollowingApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private AliasJpaRepository aliasJpaRepository;
+
+    @Autowired
+    private FollowingJpaRepository followingJpaRepository;
+
+    @AfterEach
+    void tearDown() {
+        followingJpaRepository.deleteAllInBatch();
+        userJpaRepository.deleteAll();
+        aliasJpaRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("팔로우 관계가 존재하면 true를 반환한다.")
+    void isFollowing_true() throws Exception {
+        // given
+        AliasJpaEntity alias = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+
+        UserJpaEntity user = userJpaRepository.save(TestEntityFactory.createUser(alias));
+
+        UserJpaEntity target = userJpaRepository.save(TestEntityFactory.createUser(alias));
+
+        // 팔로잉 관계 저장
+        followingJpaRepository.save(FollowingJpaEntity.builder()
+                .userJpaEntity(user)
+                .followingUserJpaEntity(target)
+                .build());
+
+        // when & then
+        mockMvc.perform(get("/users/{targetUserId}/is-following", target.getUserId())
+                        .requestAttr("userId", user.getUserId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.isFollowing").value(true));
+    }
+
+    @Test
+    @DisplayName("팔로우 관계가 없으면 false를 반환한다.")
+    void isFollowing_false() throws Exception {
+        // given
+        AliasJpaEntity alias = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+
+        UserJpaEntity user = userJpaRepository.save(TestEntityFactory.createUser(alias));
+
+        UserJpaEntity target = userJpaRepository.save(TestEntityFactory.createUser(alias));
+
+        // when & then
+        mockMvc.perform(get("/users/{targetUserId}/is-following", target.getUserId())
+                        .requestAttr("userId", user.getUserId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.isFollowing").value(false));
+    }
+}

--- a/src/test/java/konkuk/thip/user/application/service/UserFollowServiceTest.java
+++ b/src/test/java/konkuk/thip/user/application/service/UserFollowServiceTest.java
@@ -66,7 +66,7 @@ class UserFollowServiceTest {
             assertThat(result).isTrue();
             assertThat(inactiveFollowing.getStatus()).isEqualTo(StatusType.ACTIVE);
             assertThat(user.getFollowerCount()).isEqualTo(1); // followerCount 증가 확인
-            verify(followingCommandPort).updateStatus(inactiveFollowing, user);
+            verify(followingCommandPort).deleteFollowing(inactiveFollowing, user);
         }
 
         @Test
@@ -130,7 +130,7 @@ class UserFollowServiceTest {
             assertThat(result).isFalse();
             assertThat(activeFollowing.getStatus()).isEqualTo(StatusType.INACTIVE);
             assertThat(user.getFollowerCount()).isEqualTo(0); // followerCount 감소 확인
-            verify(followingCommandPort).updateStatus(activeFollowing, user);
+            verify(followingCommandPort).deleteFollowing(activeFollowing, user);
         }
 
         @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #100 

## 📝 작업 내용

팔로잉 조회 여부 api 개발했습니다.

추가적으로, 이전 pr #76 에서 팔로잉 상태 변경 시에 소프트 딜리트를 적용했었는데, 회의에서 결정한 대로 팔로잉에는 소프트 딜리트를 해제하고 이에 따른 서비스 로직도 변경했습니다.

## 📸 스크린샷

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 다른 사용자를 팔로우하고 있는지 확인할 수 있는 API 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 언팔로우 시 팔로우 관계가 비활성화 처리 대신 완전히 삭제되도록 변경되었습니다.

* **테스트**
  * "팔로우 여부 확인" API에 대한 통합 테스트가 추가되었습니다.
  * 언팔로우 시 팔로우 엔터티 삭제 여부를 검증하는 테스트가 수정되었습니다.

* **리팩터**
  * 사용자 정보 업데이트 시 여러 필드를 한 번에 갱신하도록 개선되었습니다.
  * 팔로우 관계 조회 시 활성 상태만 반환하도록 쿼리가 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->