### PR TITLE
[feat] 내 피드 조회 api 개발

### DIFF
--- a/src/main/java/konkuk/thip/common/util/Cursor.java
+++ b/src/main/java/konkuk/thip/common/util/Cursor.java
@@ -35,15 +35,25 @@ public class Cursor {
 
     // 디코딩을 위한 정적 팩토리 메서드
     public static Cursor from(String encoded, int pageSize) {
-        if (encoded == null || !encoded.contains("|")) {
-            return new Cursor(List.of(), pageSize); // 빈 커서 생성
+        if (encoded == null) {
+            return new Cursor(List.of(), pageSize);     // 빈 커서 생성
         }
+
+        if (!encoded.contains(JOIN_DELIMITER)) {
+            return new Cursor(List.of(encoded), pageSize);      // 단일 커서
+        }
+
         String decoded = URLDecoder.decode(encoded, StandardCharsets.UTF_8);
         List<String> parts = Arrays.asList(decoded.split(SPLIT_DELIMITER));
-        return new Cursor(parts, pageSize);
+        return new Cursor(parts, pageSize);     // 복합 커서
     }
 
     public String toEncodedString() {
+        if (rawCursorList.size() == 1) {        // 단일 커서
+            return URLEncoder.encode(rawCursorList.get(0), StandardCharsets.UTF_8);
+        }
+
+        // 복합 커서
         String raw = String.join(JOIN_DELIMITER, rawCursorList);
         return URLEncoder.encode(raw, StandardCharsets.UTF_8);
     }

--- a/src/main/java/konkuk/thip/common/util/Cursor.java
+++ b/src/main/java/konkuk/thip/common/util/Cursor.java
@@ -39,11 +39,12 @@ public class Cursor {
             return new Cursor(List.of(), pageSize);     // 빈 커서 생성
         }
 
-        if (!encoded.contains(JOIN_DELIMITER)) {
-            return new Cursor(List.of(encoded), pageSize);      // 단일 커서
+        String decoded = URLDecoder.decode(encoded, StandardCharsets.UTF_8);
+
+        if (!decoded.contains(JOIN_DELIMITER)) {
+            return new Cursor(List.of(decoded), pageSize);      // 단일 커서
         }
 
-        String decoded = URLDecoder.decode(encoded, StandardCharsets.UTF_8);
         List<String> parts = Arrays.asList(decoded.split(SPLIT_DELIMITER));
         return new Cursor(parts, pageSize);     // 복합 커서
     }

--- a/src/main/java/konkuk/thip/config/SecurityConfig.java
+++ b/src/main/java/konkuk/thip/config/SecurityConfig.java
@@ -88,7 +88,10 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(Collections.singletonList("*")); // 배포 시 도메인 명시
+        config.setAllowedOrigins(List.of(
+                "http://localhost:5173",
+                "https://thip-git-develop-thips-projects.vercel.app/"
+        )); // 배포 시 도메인 명시
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.setAllowedHeaders(Collections.singletonList("*"));
         config.setAllowCredentials(true);

--- a/src/main/java/konkuk/thip/feed/adapter/in/web/FeedQueryController.java
+++ b/src/main/java/konkuk/thip/feed/adapter/in/web/FeedQueryController.java
@@ -2,8 +2,10 @@ package konkuk.thip.feed.adapter.in.web;
 
 import konkuk.thip.common.dto.BaseResponse;
 import konkuk.thip.common.security.annotation.UserId;
+import konkuk.thip.feed.adapter.in.web.response.FeedShowMineResponse;
 import konkuk.thip.feed.adapter.in.web.response.FeedShowAllResponse;
 import konkuk.thip.feed.application.port.in.FeedShowAllUseCase;
+import konkuk.thip.feed.application.port.in.FeedShowMineUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -14,11 +16,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class FeedQueryController {
 
     private final FeedShowAllUseCase feedShowAllUseCase;
+    private final FeedShowMineUseCase feedShowMineUseCase;
 
     @GetMapping("/feeds")
     public BaseResponse<FeedShowAllResponse> showAllFeeds(
             @UserId final Long userId,
             @RequestParam(value = "cursor", required = false) final String cursor) {
         return BaseResponse.ok(feedShowAllUseCase.showAllFeeds(userId, cursor));
+    }
+
+    @GetMapping("/feeds/mine")
+    public BaseResponse<FeedShowMineResponse> showMyFeeds(
+            @UserId final Long userId,
+            @RequestParam(value = "cursor", required = false) final String cursor) {
+        return BaseResponse.ok(feedShowMineUseCase.showMyFeeds(userId, cursor));
     }
 }

--- a/src/main/java/konkuk/thip/feed/adapter/in/web/response/FeedShowMineResponse.java
+++ b/src/main/java/konkuk/thip/feed/adapter/in/web/response/FeedShowMineResponse.java
@@ -1,0 +1,23 @@
+package konkuk.thip.feed.adapter.in.web.response;
+
+import java.util.List;
+
+public record FeedShowMineResponse(
+        List<FeedDto> feedList,
+        int totalFeedCount,
+        String nextCursor,
+        boolean isLast
+) {
+    public record FeedDto(
+            Long feedId,
+            String postDate,
+            String isbn,
+            String bookTitle,
+            String bookAuthor,
+            String contentBody,
+            String[] contentUrls,
+            int likeCount,
+            int commentCount,
+            boolean isPublic
+    ) { }
+}

--- a/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/FeedJpaRepository.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/FeedJpaRepository.java
@@ -1,7 +1,13 @@
 package konkuk.thip.feed.adapter.out.persistence.repository;
 
+import konkuk.thip.common.entity.StatusType;
 import konkuk.thip.feed.adapter.out.jpa.FeedJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FeedJpaRepository extends JpaRepository<FeedJpaEntity, Long>, FeedQueryRepository {
+
+    @Query("SELECT COUNT(f) FROM FeedJpaEntity f WHERE f.userJpaEntity.userId = :userId AND f.status = :status")
+    long countFeedsByUserId(@Param("userId") Long userId, @Param("status") StatusType status);
 }

--- a/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/FeedQueryRepository.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/FeedQueryRepository.java
@@ -12,4 +12,6 @@ public interface FeedQueryRepository {
     List<FeedQueryDto> findFeedsByFollowingPriority(Long userId, Integer lastPriority, LocalDateTime lastCreatedAt, int size);
 
     List<FeedQueryDto> findLatestFeedsByCreatedAt(Long userId, LocalDateTime lastCreatedAt, int size);
+
+    List<FeedQueryDto> findMyFeedsByCreatedAt(Long userId, LocalDateTime lastCreatedAt, int size);
 }

--- a/src/main/java/konkuk/thip/feed/application/mapper/FeedQueryMapper.java
+++ b/src/main/java/konkuk/thip/feed/application/mapper/FeedQueryMapper.java
@@ -2,6 +2,7 @@ package konkuk.thip.feed.application.mapper;
 
 import konkuk.thip.common.util.DateUtil;
 import konkuk.thip.feed.adapter.in.web.response.FeedShowAllResponse;
+import konkuk.thip.feed.adapter.in.web.response.FeedShowMineResponse;
 import konkuk.thip.feed.application.port.out.dto.FeedQueryDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -28,4 +29,9 @@ public interface FeedQueryMapper {
             Set<Long> likedFeedIds
     );
 
+    @Mapping(
+            target = "postDate",
+            expression = "java(DateUtil.formatBeforeTime(dto.createdAt()))"
+    )
+    FeedShowMineResponse.FeedDto toFeedShowMineResponse(FeedQueryDto dto);
 }

--- a/src/main/java/konkuk/thip/feed/application/port/in/FeedShowMineUseCase.java
+++ b/src/main/java/konkuk/thip/feed/application/port/in/FeedShowMineUseCase.java
@@ -1,0 +1,8 @@
+package konkuk.thip.feed.application.port.in;
+
+import konkuk.thip.feed.adapter.in.web.response.FeedShowMineResponse;
+
+public interface FeedShowMineUseCase {
+
+    FeedShowMineResponse showMyFeeds(Long userId, String cursor);
+}

--- a/src/main/java/konkuk/thip/feed/application/port/out/FeedQueryPort.java
+++ b/src/main/java/konkuk/thip/feed/application/port/out/FeedQueryPort.java
@@ -4,7 +4,6 @@ import konkuk.thip.common.util.Cursor;
 import konkuk.thip.common.util.CursorBasedList;
 import konkuk.thip.feed.application.port.out.dto.FeedQueryDto;
 
-import java.time.LocalDateTime;
 import java.util.Set;
 
 public interface FeedQueryPort {
@@ -13,5 +12,9 @@ public interface FeedQueryPort {
 
     CursorBasedList<FeedQueryDto> findFeedsByFollowingPriority(Long userId, Cursor cursor);
 
-    CursorBasedList<FeedQueryDto> findLatestFeedsByCreatedAt(Long userId, LocalDateTime lastCreatedAt, int size);
+    CursorBasedList<FeedQueryDto> findLatestFeedsByCreatedAt(Long userId, Cursor cursor);
+
+    CursorBasedList<FeedQueryDto> findMyFeedsByCreatedAt(Long userId, Cursor cursor);
+
+    int countFeedsByUserId(Long userId);
 }

--- a/src/main/java/konkuk/thip/feed/application/port/out/dto/FeedQueryDto.java
+++ b/src/main/java/konkuk/thip/feed/application/port/out/dto/FeedQueryDto.java
@@ -20,5 +20,6 @@ public record FeedQueryDto(
         String[] contentUrls,
         int likeCount,
         int commentCount,
+        boolean isPublic,
         @Nullable Boolean isPriorityFeed
 ) { }

--- a/src/main/java/konkuk/thip/feed/application/service/BasicFeedShowAllService.java
+++ b/src/main/java/konkuk/thip/feed/application/service/BasicFeedShowAllService.java
@@ -1,7 +1,7 @@
 package konkuk.thip.feed.application.service;
 
+import konkuk.thip.common.util.Cursor;
 import konkuk.thip.common.util.CursorBasedList;
-import konkuk.thip.common.util.DateUtil;
 import konkuk.thip.feed.adapter.in.web.response.FeedShowAllResponse;
 import konkuk.thip.feed.application.mapper.FeedQueryMapper;
 import konkuk.thip.feed.application.port.in.FeedShowAllUseCase;
@@ -14,7 +14,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -41,11 +40,11 @@ public class BasicFeedShowAllService implements FeedShowAllUseCase {
     @Transactional(readOnly = true)
     @Override
     public FeedShowAllResponse showAllFeeds(Long userId, String cursor) {
-        // 1. 커서 파싱 : createdAt을 커서로 사용한다
-        LocalDateTime cursorVal = cursor != null && !cursor.isBlank() ? DateUtil.parseDateTime(cursor) : null;
+        // 1. 커서 생성
+        Cursor nextCursor = Cursor.from(cursor, PAGE_SIZE);
 
         // 2. [최신순으로] 피드 조회 with 페이징 처리
-        CursorBasedList<FeedQueryDto> result = feedQueryPort.findLatestFeedsByCreatedAt(userId, cursorVal, PAGE_SIZE);
+        CursorBasedList<FeedQueryDto> result = feedQueryPort.findLatestFeedsByCreatedAt(userId, nextCursor);
         Set<Long> feedIds = result.contents().stream()
                 .map(FeedQueryDto::feedId)
                 .collect(Collectors.toUnmodifiableSet());

--- a/src/main/java/konkuk/thip/feed/application/service/FeedShowMineService.java
+++ b/src/main/java/konkuk/thip/feed/application/service/FeedShowMineService.java
@@ -31,7 +31,7 @@ public class FeedShowMineService implements FeedShowMineUseCase {
         // 3. 유저가 작성한 전체 피드 개수 구하기
         int totalFeedCount = feedQueryPort.countFeedsByUserId(userId);
 
-        // 4.
+        // 4. dto -> response 변환
         var feedList = result.contents().stream()
                 .map(feedQueryMapper::toFeedShowMineResponse)
                 .toList();

--- a/src/main/java/konkuk/thip/feed/application/service/FeedShowMineService.java
+++ b/src/main/java/konkuk/thip/feed/application/service/FeedShowMineService.java
@@ -1,0 +1,46 @@
+package konkuk.thip.feed.application.service;
+
+import konkuk.thip.common.util.Cursor;
+import konkuk.thip.common.util.CursorBasedList;
+import konkuk.thip.feed.adapter.in.web.response.FeedShowMineResponse;
+import konkuk.thip.feed.application.mapper.FeedQueryMapper;
+import konkuk.thip.feed.application.port.in.FeedShowMineUseCase;
+import konkuk.thip.feed.application.port.out.FeedQueryPort;
+import konkuk.thip.feed.application.port.out.dto.FeedQueryDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FeedShowMineService implements FeedShowMineUseCase {
+
+    private static final int PAGE_SIZE = 10;
+    private final FeedQueryPort feedQueryPort;
+    private final FeedQueryMapper feedQueryMapper;
+
+    @Transactional(readOnly = true)
+    @Override
+    public FeedShowMineResponse showMyFeeds(Long userId, String cursor) {
+        // 1. 커서 생성
+        Cursor nextCursor = Cursor.from(cursor, PAGE_SIZE);
+
+        // 2. [최신순으로] 피드 조회 with 페이징 처리
+        CursorBasedList<FeedQueryDto> result = feedQueryPort.findMyFeedsByCreatedAt(userId, nextCursor);
+
+        // 3. 유저가 작성한 전체 피드 개수 구하기
+        int totalFeedCount = feedQueryPort.countFeedsByUserId(userId);
+
+        // 4.
+        var feedList = result.contents().stream()
+                .map(feedQueryMapper::toFeedShowMineResponse)
+                .toList();
+
+        return new FeedShowMineResponse(
+                feedList,
+                totalFeedCount,
+                result.nextCursor(),
+                !result.hasNext()
+        );
+    }
+}

--- a/src/test/java/konkuk/thip/feed/adapter/in/web/FeedShowMineApiTest.java
+++ b/src/test/java/konkuk/thip/feed/adapter/in/web/FeedShowMineApiTest.java
@@ -1,0 +1,350 @@
+package konkuk.thip.feed.adapter.in.web;
+
+import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.adapter.out.persistence.repository.BookJpaRepository;
+import konkuk.thip.common.util.TestEntityFactory;
+import konkuk.thip.feed.adapter.out.jpa.FeedJpaEntity;
+import konkuk.thip.feed.adapter.out.persistence.repository.Content.ContentJpaRepository;
+import konkuk.thip.feed.adapter.out.persistence.repository.FeedJpaRepository;
+import konkuk.thip.post.adapter.out.persistence.PostLikeJpaRepository;
+import konkuk.thip.saved.adapter.out.persistence.repository.SavedFeedJpaRepository;
+import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.repository.alias.AliasJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.repository.following.FollowingJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("[통합] 내 피드 조회 api 통합 테스트")
+class FeedShowMineApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private AliasJpaRepository aliasJpaRepository;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private FeedJpaRepository feedJpaRepository;
+
+    @Autowired
+    private ContentJpaRepository contentJpaRepository;
+
+    @Autowired
+    private FollowingJpaRepository followingJpaRepository;
+
+    @Autowired
+    private BookJpaRepository bookJpaRepository;
+
+    @Autowired
+    private SavedFeedJpaRepository savedFeedJpaRepository;
+
+    @Autowired
+    private PostLikeJpaRepository postLikeJpaRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @AfterEach
+    void tearDown() {
+        postLikeJpaRepository.deleteAllInBatch();
+        savedFeedJpaRepository.deleteAllInBatch();
+        contentJpaRepository.deleteAllInBatch();
+        feedJpaRepository.deleteAllInBatch();
+        followingJpaRepository.deleteAllInBatch();
+        userJpaRepository.deleteAllInBatch();
+        aliasJpaRepository.deleteAllInBatch();
+        bookJpaRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("내 피드 조회를 요청할 경우, [feedId, 작성일, 책정보, ,,] 의 피드 정보를 최신순으로 정렬해서 반환한다.")
+    void feed_show_mine_test() throws Exception {
+        //given
+        AliasJpaEntity a0 = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        UserJpaEntity me = userJpaRepository.save(TestEntityFactory.createUser(a0, "me"));
+        UserJpaEntity otherUser = userJpaRepository.save(TestEntityFactory.createUser(a0, "otherUser"));
+
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBook());        // 공통 Book
+
+        // 피드 생성 및 생성일 직접 설정
+        LocalDateTime base = LocalDateTime.now();
+        FeedJpaEntity f1 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+        FeedJpaEntity f2 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 50, 10, List.of()));
+        FeedJpaEntity f3 = feedJpaRepository.save(TestEntityFactory.createFeed(otherUser, book, true, 50, 10, List.of()));      // otherUser가 작성한 피드
+
+        // JPA flush 후, native update 로 created_at 덮어쓰기
+        // feed 작성 순서 : f3 -> f2 -> f1 (f1 이 가장 최신)
+        feedJpaRepository.flush();
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(1)), f1.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(10)), f2.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(30)), f3.getPostId());
+
+        //when //then
+        mockMvc.perform(get("/feeds/mine")
+                        .requestAttr("userId", me.getUserId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalFeedCount", is(2)))        // 내가 작성한 게시글은 총 2개
+                .andExpect(jsonPath("$.data.feedList", hasSize(2)))
+                /**
+                 * 정렬 조건
+                 * 내 글 최신순 조회
+                 */
+                // 1순위: f1
+                .andExpect(jsonPath("$.data.feedList[0].feedId", is(f1.getPostId().intValue())))
+                .andExpect(jsonPath("$.data.feedList[0].contentUrls", hasSize(2)))
+                .andExpect(jsonPath("$.data.feedList[0].likeCount", is(10)))
+                .andExpect(jsonPath("$.data.feedList[0].commentCount", is(5)))
+                // 2순위: f2
+                .andExpect(jsonPath("$.data.feedList[1].feedId", is(f2.getPostId().intValue())))
+                .andExpect(jsonPath("$.data.feedList[1].contentUrls", hasSize(0)))
+                .andExpect(jsonPath("$.data.feedList[1].likeCount", is(50)))
+                .andExpect(jsonPath("$.data.feedList[1].commentCount", is(10)));
+    }
+
+    @Test
+    @DisplayName("내 피드는 [유저 본인이 작성한 글을 최신순] 으로 반환한다.")
+    void feed_show_mine_order_latest() throws Exception {
+        //given
+        AliasJpaEntity a0 = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        UserJpaEntity me = userJpaRepository.save(TestEntityFactory.createUser(a0, "me"));
+        UserJpaEntity otherUser = userJpaRepository.save(TestEntityFactory.createUser(a0, "otherUser"));
+
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBook());        // 공통 Book
+
+        // 피드 생성 및 생성일 직접 설정
+        LocalDateTime base = LocalDateTime.now();
+        FeedJpaEntity f1 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+        FeedJpaEntity f2 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of()));
+        FeedJpaEntity f3 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of()));
+        FeedJpaEntity f4 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of()));
+        FeedJpaEntity f5 = feedJpaRepository.save(TestEntityFactory.createFeed(otherUser, book, true, 50, 30, List.of()));      // otherUser가 작성한 피드
+        FeedJpaEntity f6 = feedJpaRepository.save(TestEntityFactory.createFeed(otherUser, book, true, 50, 30, List.of()));      // otherUser가 작성한 피드
+        FeedJpaEntity f7 = feedJpaRepository.save(TestEntityFactory.createFeed(otherUser, book, true, 50, 30, List.of()));      // otherUser가 작성한 피드
+        FeedJpaEntity f8 = feedJpaRepository.save(TestEntityFactory.createFeed(otherUser, book, true, 50, 30, List.of()));      // otherUser가 작성한 피드
+
+        // JPA flush 후, native update 로 created_at 덮어쓰기
+        // feed 작성 순서 : f8 -> f7 -> f6 -> f5 -> f4 -> f3 -> f2 -> f1 (f1 이 가장 최신)
+        feedJpaRepository.flush();
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(1)), f1.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(10)), f2.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(15)), f3.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(20)), f4.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(25)), f5.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(30)), f6.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(35)), f7.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(40)), f8.getPostId());
+
+        //when //then
+        mockMvc.perform(get("/feeds/mine")
+                        .requestAttr("userId", me.getUserId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalFeedCount", is(4)))        // 내가 작성한 게시글은 총 4개
+                .andExpect(jsonPath("$.data.feedList", hasSize(4)))
+                /**
+                 * 정렬 조건
+                 * 내 글 & 다른 모든 유저의 공개 글을 최신순 조회
+                 */
+                .andExpect(jsonPath("$.data.feedList[0].feedId", is(f1.getPostId().intValue())))
+                .andExpect(jsonPath("$.data.feedList[1].feedId", is(f2.getPostId().intValue())))
+                .andExpect(jsonPath("$.data.feedList[2].feedId", is(f3.getPostId().intValue())))
+                .andExpect(jsonPath("$.data.feedList[3].feedId", is(f4.getPostId().intValue())));
+    }
+
+    @Test
+    @DisplayName("request parameter의 cursor 값이 null일 경우, 첫번째 페이지에 해당하는 피드 10개와, nextCursor, last 값을 반환한다.")
+    void feed_show_mine_first_page() throws Exception {
+        //given
+        AliasJpaEntity a0 = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        UserJpaEntity me = userJpaRepository.save(TestEntityFactory.createUser(a0, "me"));
+
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBook());        // 공통 Book
+
+        // 피드 생성 및 생성일 직접 설정
+        FeedJpaEntity f1 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+        FeedJpaEntity f2 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 50, 10, List.of()));
+        FeedJpaEntity f3 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+        FeedJpaEntity f4 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 50, 10, List.of()));
+        FeedJpaEntity f5 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+        FeedJpaEntity f6 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+        FeedJpaEntity f7 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+        FeedJpaEntity f8 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+        FeedJpaEntity f9 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+        FeedJpaEntity f10 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+        FeedJpaEntity f11 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+        FeedJpaEntity f12 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+
+        // JPA flush 후, native update 로 created_at 덮어쓰기
+        // feed 작성 순서 : f12 -> f11 -> ,,, -> f1 순
+        feedJpaRepository.flush();
+
+        LocalDateTime base = LocalDateTime.now();
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(5)), f1.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(10)), f2.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(15)), f3.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(20)), f4.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(25)), f5.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(30)), f6.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(35)), f7.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(40)), f8.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(45)), f9.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(50)), f10.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(55)), f11.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(60)), f12.getPostId());
+
+        //when //then
+        mockMvc.perform(get("/feeds/mine")
+                        .requestAttr("userId", me.getUserId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.isLast", is(false)))
+                .andExpect(jsonPath("$.data.feedList", hasSize(10)))
+                /**
+                 * 정렬 조건
+                 * 내 글 & 다른 모든 유저의 공개 글을 최신순 조회
+                 */
+                .andExpect(jsonPath("$.data.feedList[0].feedId", is(f1.getPostId().intValue())))
+                .andExpect(jsonPath("$.data.feedList[1].feedId", is(f2.getPostId().intValue())))
+                .andExpect(jsonPath("$.data.feedList[2].feedId", is(f3.getPostId().intValue())))
+                .andExpect(jsonPath("$.data.feedList[3].feedId", is(f4.getPostId().intValue())))
+                .andExpect(jsonPath("$.data.feedList[4].feedId", is(f5.getPostId().intValue())))
+                .andExpect(jsonPath("$.data.feedList[5].feedId", is(f6.getPostId().intValue())))
+                .andExpect(jsonPath("$.data.feedList[6].feedId", is(f7.getPostId().intValue())))
+                .andExpect(jsonPath("$.data.feedList[7].feedId", is(f8.getPostId().intValue())))
+                .andExpect(jsonPath("$.data.feedList[8].feedId", is(f9.getPostId().intValue())))
+                .andExpect(jsonPath("$.data.feedList[9].feedId", is(f10.getPostId().intValue())));
+    }
+
+    @Test
+    @DisplayName("request parameter의 cursor 값이 존재할 경우, 해당 페이지에 해당하는 피드 10개와, nextCursor, last 값을 반환한다.")
+    void feed_show_mine_with_cursor() throws Exception {
+        //given
+        AliasJpaEntity a0 = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        UserJpaEntity me = userJpaRepository.save(TestEntityFactory.createUser(a0, "me"));
+
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBook());        // 공통 Book
+
+        // 피드 생성 및 생성일 직접 설정 -> 모두 공개 글
+        FeedJpaEntity f1 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+        FeedJpaEntity f2 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 50, 10, List.of()));
+        FeedJpaEntity f3 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+        FeedJpaEntity f4 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 50, 10, List.of()));
+        FeedJpaEntity f5 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+        FeedJpaEntity f6 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+        FeedJpaEntity f7 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+        FeedJpaEntity f8 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+        FeedJpaEntity f9 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+        FeedJpaEntity f10 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+        FeedJpaEntity f11 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+        FeedJpaEntity f12 = feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true, 10, 5, List.of("contentUrl1", "contentUrl2")));
+
+        // JPA flush 후, native update 로 created_at 덮어쓰기
+        // feed 작성 순서 : f12 -> f11 -> ,,, -> f1 순
+        feedJpaRepository.flush();
+
+        LocalDateTime base = LocalDateTime.now();
+        LocalDateTime t10 = base.minusMinutes(50);
+        LocalDateTime t11 = base.minusMinutes(55);
+        LocalDateTime t12 = base.minusMinutes(60);
+
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(t10), f10.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(t11), f11.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(t12), f12.getPostId());
+
+        // DB에 저장된 f10의 createdAt 값을 native query 로 조회
+        LocalDateTime nextCursorVal = jdbcTemplate.queryForObject(
+                "SELECT created_at FROM posts WHERE post_id = ?",
+                (rs, rowNum) -> rs.getTimestamp("created_at").toLocalDateTime(), f10.getPostId()
+        );
+        String nextCursor = nextCursorVal.toString();
+
+        //when //then
+        mockMvc.perform(get("/feeds/mine")
+                        .requestAttr("userId", me.getUserId())
+                        .param("cursor", nextCursor))        // 이전에 f10 까지 조회 -> f10의 createdAt이 커서
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.isLast", is(true)))
+                .andExpect(jsonPath("$.data.feedList", hasSize(2)))
+                /**
+                 * 정렬 조건
+                 * 내 글 & 다른 모든 유저의 공개 글을 최신순 조회
+                 */
+                .andExpect(jsonPath("$.data.feedList[0].feedId", is(f11.getPostId().intValue())))
+                .andExpect(jsonPath("$.data.feedList[1].feedId", is(f12.getPostId().intValue())));
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #110 

## 📝 작업 내용

### 1. 내 피드 조회 api 를 개발하였습니다.
전체적인 코드의 흐름은 https://github.com/THIP-TextHip/THIP-Server/pull/104 와 매우 유사합니다

주요 코드는 아래와 같습니다

- FeedShowMineService
  - 내 피드 조회 api의 response를 구성하기 위해
    1. 유저가 작성한 피드 목록을 페이징 처리하여 최신순으로 조회
    2. 유저가 작성한 전체 피드 개수를 추가로 구하기
    3. 1의 조회결과를 response 로 변환
- 내 피드 조회를 위한 QueryDSL 코드
  - 피드의 조회용 모델인 FeedQueryDto에 해당 피드의 공개/비공개 글 여부를 나타내는 isPublic 필드를 추가하였습니다
  - 전체 피드 조회 api 와 마찬가지로
    1. 조건문 + 페이징 + 정렬을 모두 처리하여 현재 페이지에서 응답해야할 FeedJpaEntity의 id값의 list를 반환
    2. 1의 결과 순서대로 FeedJpaEntity를 조회 (이때 마찬가지로 필요한 정보들을 FetchJoin으로 한번에 조회)
    3. dto로 매핑
    
### 2. 또한 Cursor 클래스의 코드를 수정하였습니다.
- 기존 Cursor 클래스는 "Cursor 를 생성할 때 '|' 구분자를 포함하지 않는 String 타입의 단일 커서를 인자로 전달받을 경우, 내부에서 구분자가 없어 파싱 에러 (500 에러) 가 발생" 하는 이슈가 있었음
- 따라서 String 타입의 단일 커서를 인자로 받을 경우, 내부적으로 구분자를 사용하여 파싱하지 않고, 전달받은 단일 커서를 디코딩하여 보관할 수 있도록 수정
- 또한 Cursor.toEncodedString() 메서드를 수정하여 단일 커서를 전달받을 경우에 '|' 없이 인코딩 하도록 코드를 수정
  - 이래야 response로 넘긴 cursor를 다시 request param으로 받을 때 '|' 구분자가 없이 전달받을 수 있음

### 3. cors allowed origins 에 FE 주소를 추가하였습니다.
- @heeeeyong 님의 요청을 받아 FE 로컬 개발환경 주소, FE 배포 주소를 추가하였습니다.

## 📸 스크린샷

## 💬 리뷰 요구사항
현재 내 피드 조회 api 의 response에 "해당 유저가 작성한 전체 피드 개수" 인 totalFeedCount 의 값을 포함해야합니다.
내 피드 조회를 오프셋 기반 페이징 방식으로 조회한다면 Pageable 을 활용하여 쉽게 응답할 수 있지만, 현재 커서 기반 페이징 방식으로 피드를 조회하므로 해당 데이터를 어떻게 반환할까 고민하였습니다

DB에 유저가 작성한 피드 개수를 추가로 기록, 캐싱, 윈도우 함수 사용 등의 방식을 고려했지만, 최종적으로 별도의 jpql count(*) 쿼리를 날리는 방식으로 구현하였습니다.

비록 모든 페이지마다 jpql 쿼리를 매번 날려야 하고, 전체 피드 테이블을 모두 스캔하여야 하므로 피드가 많이 쌓일 경우 성능이슈가 발생할 수도 있지만, 현재 api 개발을 빠르게 진행해야한다는 최우선 요구사항에 가장 적합한 방식이라고 생각하여 일단 jpql 쿼리를 매번 날리도록 구현하였습니다.

추후에 인덱스를 설정하거나, 다른 해결방법으로 성능 개선을 시도해보면 좋을 것 같습니다!

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
