### PR TITLE
[feat] 피드 조회 시 [내 정보 or 특정 유저 정보] 조회하는 api 개발

### DIFF
--- a/src/main/java/konkuk/thip/feed/adapter/in/web/FeedQueryController.java
+++ b/src/main/java/konkuk/thip/feed/adapter/in/web/FeedQueryController.java
@@ -50,11 +50,19 @@ public class FeedQueryController {
         return BaseResponse.ok(feedShowMineUseCase.showMyFeeds(userId, cursor));
     }
 
+    @Operation(
+            summary = "내 피드 조회의 상단 화면 구성",
+            description = "사용자의 정보, 사용자의 팔로워 정보, 사용자가 작성한 전체 피드 개수를 조회합니다."
+    )
     @GetMapping("/feeds/mine/info")
     public BaseResponse<FeedShowUserInfoResponse> showMyInfoInFeeds(@Parameter(hidden = true) @UserId final Long userId) {
         return BaseResponse.ok(feedShowUserInfoUseCase.showMyInfoInFeeds(userId));
     }
 
+    @Operation(
+            summary = "특정 유저 피드 조회의 상단 화면 구성",
+            description = "사용자의 정보, 사용자의 팔로워 정보, 사용자가 작성한 공개 피드 개수를 조회합니다."
+    )
     @GetMapping("/feeds/users/{userId}/info")
     public BaseResponse<FeedShowUserInfoResponse> showAnotherUserInfoInFeeds(
             @Parameter(description = "피드 조회할 유저의 userId 값") @PathVariable final Long userId

--- a/src/main/java/konkuk/thip/feed/adapter/in/web/FeedQueryController.java
+++ b/src/main/java/konkuk/thip/feed/adapter/in/web/FeedQueryController.java
@@ -5,12 +5,15 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import konkuk.thip.common.dto.BaseResponse;
 import konkuk.thip.common.security.annotation.UserId;
+import konkuk.thip.feed.adapter.in.web.response.FeedShowUserInfoResponse;
 import konkuk.thip.feed.adapter.in.web.response.FeedShowMineResponse;
 import konkuk.thip.feed.adapter.in.web.response.FeedShowAllResponse;
 import konkuk.thip.feed.application.port.in.FeedShowAllUseCase;
 import konkuk.thip.feed.application.port.in.FeedShowMineUseCase;
+import konkuk.thip.feed.application.port.in.FeedShowUserInfoUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,6 +24,7 @@ public class FeedQueryController {
 
     private final FeedShowAllUseCase feedShowAllUseCase;
     private final FeedShowMineUseCase feedShowMineUseCase;
+    private final FeedShowUserInfoUseCase feedShowUserInfoUseCase;
 
     @Operation(
             summary = "피드 전체 조회",
@@ -44,5 +48,17 @@ public class FeedQueryController {
             @Parameter(description = "커서 (첫번째 요청시 : null, 다음 요청시 : 이전 요청에서 반환받은 nextCursor 값)")
             @RequestParam(value = "cursor", required = false) final String cursor) {
         return BaseResponse.ok(feedShowMineUseCase.showMyFeeds(userId, cursor));
+    }
+
+    @GetMapping("/feeds/mine/info")
+    public BaseResponse<FeedShowUserInfoResponse> showMyInfoInFeeds(@Parameter(hidden = true) @UserId final Long userId) {
+        return BaseResponse.ok(feedShowUserInfoUseCase.showMyInfoInFeeds(userId));
+    }
+
+    @GetMapping("/feeds/users/{userId}/info")
+    public BaseResponse<FeedShowUserInfoResponse> showAnotherUserInfoInFeeds(
+            @Parameter(description = "피드 조회할 유저의 userId 값") @PathVariable final Long userId
+    ) {
+        return BaseResponse.ok(feedShowUserInfoUseCase.showAnotherUserInfoInFeeds(userId));
     }
 }

--- a/src/main/java/konkuk/thip/feed/adapter/in/web/response/FeedShowUserInfoResponse.java
+++ b/src/main/java/konkuk/thip/feed/adapter/in/web/response/FeedShowUserInfoResponse.java
@@ -1,0 +1,16 @@
+package konkuk.thip.feed.adapter.in.web.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record FeedShowUserInfoResponse(
+        String profileImageUrl,
+        String nickname,
+        String aliasName,
+        String aliasColor,
+        int followerCount,
+        int totalFeedCount,
+        List<String> latestFollowerProfileImageUrls
+) { }

--- a/src/main/java/konkuk/thip/feed/adapter/out/persistence/FeedQueryPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/persistence/FeedQueryPersistenceAdapter.java
@@ -69,8 +69,13 @@ public class FeedQueryPersistenceAdapter implements FeedQueryPort {
     }
 
     @Override
-    public int countFeedsByUserId(Long userId) {
+    public int countAllFeedsByUserId(Long userId) {
         // int 로 강제 형변환 해도 괜찮죠??
-        return (int) feedJpaRepository.countFeedsByUserId(userId, StatusType.ACTIVE);
+        return (int) feedJpaRepository.countAllFeedsByUserId(userId, StatusType.ACTIVE);
+    }
+
+    @Override
+    public int countPublicFeedsByUserId(Long userId) {
+        return (int) feedJpaRepository.countPublicFeedsByUserId(userId, StatusType.ACTIVE);
     }
 }

--- a/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/FeedJpaRepository.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/FeedJpaRepository.java
@@ -9,5 +9,8 @@ import org.springframework.data.repository.query.Param;
 public interface FeedJpaRepository extends JpaRepository<FeedJpaEntity, Long>, FeedQueryRepository {
 
     @Query("SELECT COUNT(f) FROM FeedJpaEntity f WHERE f.userJpaEntity.userId = :userId AND f.status = :status")
-    long countFeedsByUserId(@Param("userId") Long userId, @Param("status") StatusType status);
+    long countAllFeedsByUserId(@Param("userId") Long userId, @Param("status") StatusType status);
+
+    @Query("SELECT COUNT(f) FROM FeedJpaEntity f WHERE f.userJpaEntity.userId = :userId AND f.isPublic = TRUE AND f.status = :status")
+    long countPublicFeedsByUserId(@Param("userId") Long userId, @Param("status") StatusType status);
 }

--- a/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/FeedQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/FeedQueryRepositoryImpl.java
@@ -221,7 +221,7 @@ public class FeedQueryRepositoryImpl implements FeedQueryRepository {
                 .feedId(e.getPostId())
                 .creatorId(e.getUserJpaEntity().getUserId())
                 .creatorNickname(e.getUserJpaEntity().getNickname())
-                .creatorProfileImageUrl(e.getUserJpaEntity().getImageUrl())
+                .creatorProfileImageUrl(e.getUserJpaEntity().getAliasForUserJpaEntity().getImageUrl())
                 .alias(e.getUserJpaEntity().getAliasForUserJpaEntity().getValue())
                 .createdAt(e.getCreatedAt())
                 .isbn(e.getBookJpaEntity().getIsbn())

--- a/src/main/java/konkuk/thip/feed/application/mapper/FeedQueryMapper.java
+++ b/src/main/java/konkuk/thip/feed/application/mapper/FeedQueryMapper.java
@@ -3,11 +3,14 @@ package konkuk.thip.feed.application.mapper;
 import konkuk.thip.common.util.DateUtil;
 import konkuk.thip.feed.adapter.in.web.response.FeedShowAllResponse;
 import konkuk.thip.feed.adapter.in.web.response.FeedShowMineResponse;
+import konkuk.thip.feed.adapter.in.web.response.FeedShowUserInfoResponse;
 import konkuk.thip.feed.application.port.out.dto.FeedQueryDto;
+import konkuk.thip.user.domain.User;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 
+import java.util.List;
 import java.util.Set;
 
 @Mapper(
@@ -34,4 +37,13 @@ public interface FeedQueryMapper {
             expression = "java(DateUtil.formatBeforeTime(dto.createdAt()))"
     )
     FeedShowMineResponse.FeedDto toFeedShowMineResponse(FeedQueryDto dto);
+
+    @Mapping(target = "profileImageUrl", source = "feedOwner.alias.imageUrl")
+    @Mapping(target = "nickname", source = "feedOwner.nickname")
+    @Mapping(target = "aliasName", source = "feedOwner.alias.value")
+    @Mapping(target = "aliasColor", source = "feedOwner.alias.color")
+    @Mapping(target = "followerCount", source = "feedOwner.followerCount")
+    @Mapping(target = "totalFeedCount", source = "totalFeedCount")
+    @Mapping(target = "latestFollowerProfileImageUrls", source = "latestFollowerProfileImageUrls")
+    FeedShowUserInfoResponse toFeedShowUserInfoResponse(User feedOwner, int totalFeedCount, List<String> latestFollowerProfileImageUrls);
 }

--- a/src/main/java/konkuk/thip/feed/application/port/in/FeedShowUserInfoUseCase.java
+++ b/src/main/java/konkuk/thip/feed/application/port/in/FeedShowUserInfoUseCase.java
@@ -1,0 +1,10 @@
+package konkuk.thip.feed.application.port.in;
+
+import konkuk.thip.feed.adapter.in.web.response.FeedShowUserInfoResponse;
+
+public interface FeedShowUserInfoUseCase {
+
+    FeedShowUserInfoResponse showMyInfoInFeeds(Long userId);
+
+    FeedShowUserInfoResponse showAnotherUserInfoInFeeds(Long anotherUserId);
+}

--- a/src/main/java/konkuk/thip/feed/application/port/out/FeedQueryPort.java
+++ b/src/main/java/konkuk/thip/feed/application/port/out/FeedQueryPort.java
@@ -16,5 +16,7 @@ public interface FeedQueryPort {
 
     CursorBasedList<FeedQueryDto> findMyFeedsByCreatedAt(Long userId, Cursor cursor);
 
-    int countFeedsByUserId(Long userId);
+    int countAllFeedsByUserId(Long userId);
+
+    int countPublicFeedsByUserId(Long userId);
 }

--- a/src/main/java/konkuk/thip/feed/application/service/FeedShowUserInfoService.java
+++ b/src/main/java/konkuk/thip/feed/application/service/FeedShowUserInfoService.java
@@ -1,6 +1,7 @@
 package konkuk.thip.feed.application.service;
 
 import konkuk.thip.feed.adapter.in.web.response.FeedShowUserInfoResponse;
+import konkuk.thip.feed.application.mapper.FeedQueryMapper;
 import konkuk.thip.feed.application.port.in.FeedShowUserInfoUseCase;
 import konkuk.thip.feed.application.port.out.FeedQueryPort;
 import konkuk.thip.user.application.port.out.FollowingQueryPort;
@@ -20,6 +21,7 @@ public class FeedShowUserInfoService implements FeedShowUserInfoUseCase {
     private final UserCommandPort userCommandPort;
     private final FollowingQueryPort followingQueryPort;
     private final FeedQueryPort feedQueryPort;
+    private final FeedQueryMapper feedQueryMapper;
 
     @Transactional(readOnly = true)
     @Override
@@ -33,7 +35,7 @@ public class FeedShowUserInfoService implements FeedShowUserInfoUseCase {
         // 3. 내가 작성한 전체 피드 개수 구하기
         int allFeedCount = feedQueryPort.countAllFeedsByUserId(userId);
 
-        return buildResponse(feedOwner, allFeedCount, latestFollowerProfileImageUrls);
+        return feedQueryMapper.toFeedShowUserInfoResponse(feedOwner, allFeedCount, latestFollowerProfileImageUrls);
     }
 
     @Transactional(readOnly = true)
@@ -48,18 +50,6 @@ public class FeedShowUserInfoService implements FeedShowUserInfoUseCase {
         // 3. 유저가 작성한 공개 피드 개수 구하기
         int publicFeedCount = feedQueryPort.countPublicFeedsByUserId(anotherUserId);
 
-        return buildResponse(feedOwner, publicFeedCount, latestFollowerProfileImageUrls);
-    }
-
-    private FeedShowUserInfoResponse buildResponse(User feedOwner, int totalFeedCount, List<String> latestFollowerProfileImageUrls) {
-        return FeedShowUserInfoResponse.builder()
-                .profileImageUrl(feedOwner.getAlias().getImageUrl())
-                .nickname(feedOwner.getNickname())
-                .aliasName(feedOwner.getAlias().getValue())
-                .aliasColor(feedOwner.getAlias().getColor())
-                .followerCount(feedOwner.getFollowerCount())
-                .totalFeedCount(totalFeedCount)
-                .latestFollowerProfileImageUrls(latestFollowerProfileImageUrls)
-                .build();
+        return feedQueryMapper.toFeedShowUserInfoResponse(feedOwner, publicFeedCount, latestFollowerProfileImageUrls);
     }
 }

--- a/src/main/java/konkuk/thip/feed/application/service/FeedShowUserInfoService.java
+++ b/src/main/java/konkuk/thip/feed/application/service/FeedShowUserInfoService.java
@@ -1,0 +1,65 @@
+package konkuk.thip.feed.application.service;
+
+import konkuk.thip.feed.adapter.in.web.response.FeedShowUserInfoResponse;
+import konkuk.thip.feed.application.port.in.FeedShowUserInfoUseCase;
+import konkuk.thip.feed.application.port.out.FeedQueryPort;
+import konkuk.thip.user.application.port.out.FollowingQueryPort;
+import konkuk.thip.user.application.port.out.UserCommandPort;
+import konkuk.thip.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class FeedShowUserInfoService implements FeedShowUserInfoUseCase {
+
+    private static final int FOLLOWER_DISPLAY_LIMIT = 5;
+    private final UserCommandPort userCommandPort;
+    private final FollowingQueryPort followingQueryPort;
+    private final FeedQueryPort feedQueryPort;
+
+    @Transactional(readOnly = true)
+    @Override
+    public FeedShowUserInfoResponse showMyInfoInFeeds(Long userId) {
+        // 1. User 찾기
+        User feedOwner = userCommandPort.findById(userId);
+
+        // 2. 해당 유저를 팔로우 하는 유저들을 프로필 이미지 정보 구하기
+        List<String> latestFollowerProfileImageUrls = followingQueryPort.getLatestFollowerProfileImageUrlsByUserId(userId, FOLLOWER_DISPLAY_LIMIT);
+
+        // 3. 내가 작성한 전체 피드 개수 구하기
+        int allFeedCount = feedQueryPort.countAllFeedsByUserId(userId);
+
+        return buildResponse(feedOwner, allFeedCount, latestFollowerProfileImageUrls);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public FeedShowUserInfoResponse showAnotherUserInfoInFeeds(Long anotherUserId) {
+        // 1. User 찾기
+        User feedOwner = userCommandPort.findById(anotherUserId);
+
+        // 2. 해당 유저를 팔로우 하는 유저들을 프로필 이미지 정보 구하기
+        List<String> latestFollowerProfileImageUrls = followingQueryPort.getLatestFollowerProfileImageUrlsByUserId(anotherUserId, FOLLOWER_DISPLAY_LIMIT);
+
+        // 3. 유저가 작성한 공개 피드 개수 구하기
+        int publicFeedCount = feedQueryPort.countPublicFeedsByUserId(anotherUserId);
+
+        return buildResponse(feedOwner, publicFeedCount, latestFollowerProfileImageUrls);
+    }
+
+    private FeedShowUserInfoResponse buildResponse(User feedOwner, int totalFeedCount, List<String> latestFollowerProfileImageUrls) {
+        return FeedShowUserInfoResponse.builder()
+                .profileImageUrl(feedOwner.getAlias().getImageUrl())
+                .nickname(feedOwner.getNickname())
+                .aliasName(feedOwner.getAlias().getValue())
+                .aliasColor(feedOwner.getAlias().getColor())
+                .followerCount(feedOwner.getFollowerCount())
+                .totalFeedCount(totalFeedCount)
+                .latestFollowerProfileImageUrls(latestFollowerProfileImageUrls)
+                .build();
+    }
+}

--- a/src/main/java/konkuk/thip/feed/application/service/FeedShowUserInfoService.java
+++ b/src/main/java/konkuk/thip/feed/application/service/FeedShowUserInfoService.java
@@ -28,7 +28,7 @@ public class FeedShowUserInfoService implements FeedShowUserInfoUseCase {
         User feedOwner = userCommandPort.findById(userId);
 
         // 2. 해당 유저를 팔로우 하는 유저들을 프로필 이미지 정보 구하기
-        List<String> latestFollowerProfileImageUrls = followingQueryPort.getLatestFollowerProfileImageUrlsByUserId(userId, FOLLOWER_DISPLAY_LIMIT);
+        List<String> latestFollowerProfileImageUrls = followingQueryPort.getLatestFollowerImageUrls(userId, FOLLOWER_DISPLAY_LIMIT);
 
         // 3. 내가 작성한 전체 피드 개수 구하기
         int allFeedCount = feedQueryPort.countAllFeedsByUserId(userId);
@@ -43,7 +43,7 @@ public class FeedShowUserInfoService implements FeedShowUserInfoUseCase {
         User feedOwner = userCommandPort.findById(anotherUserId);
 
         // 2. 해당 유저를 팔로우 하는 유저들을 프로필 이미지 정보 구하기
-        List<String> latestFollowerProfileImageUrls = followingQueryPort.getLatestFollowerProfileImageUrlsByUserId(anotherUserId, FOLLOWER_DISPLAY_LIMIT);
+        List<String> latestFollowerProfileImageUrls = followingQueryPort.getLatestFollowerImageUrls(anotherUserId, FOLLOWER_DISPLAY_LIMIT);
 
         // 3. 유저가 작성한 공개 피드 개수 구하기
         int publicFeedCount = feedQueryPort.countPublicFeedsByUserId(anotherUserId);

--- a/src/main/java/konkuk/thip/record/adapter/out/persistence/repository/RecordQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/record/adapter/out/persistence/repository/RecordQueryRepositoryImpl.java
@@ -203,7 +203,7 @@ public class RecordQueryRepositoryImpl implements RecordQueryRepository {
                 pageExpr(),
                 user.userId,
                 user.nickname,
-                user.imageUrl,
+                user.aliasForUserJpaEntity.imageUrl,
                 post.content,
                 post.likeCount,
                 post.commentCount,

--- a/src/main/java/konkuk/thip/user/adapter/out/jpa/UserJpaEntity.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/jpa/UserJpaEntity.java
@@ -23,9 +23,6 @@ public class UserJpaEntity extends BaseJpaEntity {
     @Column(length = 60, nullable = false)
     private String nickname;
 
-    @Column(name = "image_url", columnDefinition = "TEXT", nullable = false)
-    private String imageUrl;
-
     @Column(name = "oauth2_id", length = 50, nullable = false)
     private String oauth2Id;
 
@@ -43,7 +40,6 @@ public class UserJpaEntity extends BaseJpaEntity {
     public void updateFrom(User user) {
         this.nickname = user.getNickname();
         Assert.notNull(user.getAlias(), "Alias must not be null");
-        this.imageUrl = user.getAlias().getImageUrl();
         this.role = UserRole.from(user.getUserRole());
         this.followerCount = user.getFollowerCount();
     }

--- a/src/main/java/konkuk/thip/user/adapter/out/mapper/UserMapper.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/mapper/UserMapper.java
@@ -13,7 +13,6 @@ public class UserMapper {
     public UserJpaEntity toJpaEntity(User user, AliasJpaEntity aliasJpaEntity) {
         return UserJpaEntity.builder()
                 .nickname(user.getNickname())
-                .imageUrl(user.getAlias().getImageUrl())
                 .role(UserRole.from(user.getUserRole()))
                 .oauth2Id(user.getOauth2Id())
                 .followerCount(user.getFollowerCount())

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/FollowingQueryPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/FollowingQueryPersistenceAdapter.java
@@ -40,4 +40,9 @@ public class FollowingQueryPersistenceAdapter implements FollowingQueryPort {
 
         return CursorBasedList.of(followingDtos, size, followingDto -> followingDto.createdAt().toString());
     }
+
+    @Override
+    public List<String> getLatestFollowerProfileImageUrlsByUserId(Long userId, int size) {
+        return followingJpaRepository.findTopFollowerProfileImageUrlsByUserIdOrderByCreatedAtDesc(userId, size);
+    }
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/FollowingQueryPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/FollowingQueryPersistenceAdapter.java
@@ -42,7 +42,7 @@ public class FollowingQueryPersistenceAdapter implements FollowingQueryPort {
     }
 
     @Override
-    public List<String> getLatestFollowerProfileImageUrlsByUserId(Long userId, int size) {
-        return followingJpaRepository.findTopFollowerProfileImageUrlsByUserIdOrderByCreatedAtDesc(userId, size);
+    public List<String> getLatestFollowerImageUrls(Long userId, int size) {
+        return followingJpaRepository.findLatestFollowerImageUrls(userId, size);
     }
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingQueryRepository.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingQueryRepository.java
@@ -12,4 +12,6 @@ public interface FollowingQueryRepository {
 
     List<UserQueryDto> findFollowerDtosByUserIdBeforeCreatedAt(Long userId, LocalDateTime cursor, int size);
     List<UserQueryDto> findFollowingDtosByUserIdBeforeCreatedAt(Long userId, LocalDateTime cursor, int size);
+
+    List<String> findTopFollowerProfileImageUrlsByUserIdOrderByCreatedAtDesc(Long userId, int size);
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingQueryRepository.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingQueryRepository.java
@@ -13,5 +13,5 @@ public interface FollowingQueryRepository {
     List<UserQueryDto> findFollowerDtosByUserIdBeforeCreatedAt(Long userId, LocalDateTime cursor, int size);
     List<UserQueryDto> findFollowingDtosByUserIdBeforeCreatedAt(Long userId, LocalDateTime cursor, int size);
 
-    List<String> findTopFollowerProfileImageUrlsByUserIdOrderByCreatedAtDesc(Long userId, int size);
+    List<String> findLatestFollowerImageUrls(Long userId, int size);
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingQueryRepositoryImpl.java
@@ -91,7 +91,7 @@ public class FollowingQueryRepositoryImpl implements FollowingQueryRepository {
     }
 
     @Override
-    public List<String> findTopFollowerProfileImageUrlsByUserIdOrderByCreatedAtDesc(Long userId, int size) {
+    public List<String> findLatestFollowerImageUrls(Long userId, int size) {
         QFollowingJpaEntity following = QFollowingJpaEntity.followingJpaEntity;
         QUserJpaEntity follower = QUserJpaEntity.userJpaEntity;     // userId 를 팔로우하는 사람들(= follower)
         QAliasJpaEntity alias = QAliasJpaEntity.aliasJpaEntity;

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingQueryRepositoryImpl.java
@@ -89,4 +89,22 @@ public class FollowingQueryRepositoryImpl implements FollowingQueryRepository {
                 .limit(size + 1)
                 .fetch();
     }
+
+    @Override
+    public List<String> findTopFollowerProfileImageUrlsByUserIdOrderByCreatedAtDesc(Long userId, int size) {
+        QFollowingJpaEntity following = QFollowingJpaEntity.followingJpaEntity;
+        QUserJpaEntity follower = QUserJpaEntity.userJpaEntity;     // userId 를 팔로우하는 사람들(= follower)
+        QAliasJpaEntity alias = QAliasJpaEntity.aliasJpaEntity;
+
+        return jpaQueryFactory
+                .select(alias.imageUrl)
+                .from(following)
+                .join(following.userJpaEntity, follower)
+                .join(follower.aliasForUserJpaEntity, alias)
+                .where(following.followingUserJpaEntity.userId.eq(userId)
+                        .and(following.status.eq(StatusType.ACTIVE)))
+                .orderBy(following.createdAt.desc())
+                .limit(size)
+                .fetch();
+    }
 }

--- a/src/main/java/konkuk/thip/user/application/port/out/FollowingQueryPort.java
+++ b/src/main/java/konkuk/thip/user/application/port/out/FollowingQueryPort.java
@@ -9,6 +9,6 @@ public interface FollowingQueryPort {
     CursorBasedList<UserQueryDto> getFollowersByUserId(Long userId, String cursor, int size);
     CursorBasedList<UserQueryDto> getFollowingByUserId(Long userId, String cursor, int size);
 
-    List<String> getLatestFollowerProfileImageUrlsByUserId(Long userId, int size);
+    List<String> getLatestFollowerImageUrls(Long userId, int size);
 }
 

--- a/src/main/java/konkuk/thip/user/application/port/out/FollowingQueryPort.java
+++ b/src/main/java/konkuk/thip/user/application/port/out/FollowingQueryPort.java
@@ -3,8 +3,12 @@ package konkuk.thip.user.application.port.out;
 import konkuk.thip.common.util.CursorBasedList;
 import konkuk.thip.user.application.port.out.dto.UserQueryDto;
 
+import java.util.List;
+
 public interface FollowingQueryPort {
     CursorBasedList<UserQueryDto> getFollowersByUserId(Long userId, String cursor, int size);
     CursorBasedList<UserQueryDto> getFollowingByUserId(Long userId, String cursor, int size);
+
+    List<String> getLatestFollowerProfileImageUrlsByUserId(Long userId, int size);
 }
 

--- a/src/test/java/konkuk/thip/book/adapter/in/web/BookChangeSavedControllerTest.java
+++ b/src/test/java/konkuk/thip/book/adapter/in/web/BookChangeSavedControllerTest.java
@@ -72,7 +72,6 @@ class BookChangeSavedControllerTest {
         UserJpaEntity user = userJpaRepository.save(UserJpaEntity.builder()
                 .oauth2Id("kakao_432708231")
                 .nickname("User1")
-                .imageUrl("https://avatar1.jpg")
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
                 .build());

--- a/src/test/java/konkuk/thip/book/adapter/in/web/BookDetailSearchControllerTest.java
+++ b/src/test/java/konkuk/thip/book/adapter/in/web/BookDetailSearchControllerTest.java
@@ -66,7 +66,6 @@ class BookDetailSearchControllerTest {
         UserJpaEntity user = userJpaRepository.save(UserJpaEntity.builder()
                 .oauth2Id("kakao_432708231")
                 .nickname("User1")
-                .imageUrl("https://avatar1.jpg")
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
                 .build());

--- a/src/test/java/konkuk/thip/book/adapter/in/web/BookMostSearchedBooksControllerTest.java
+++ b/src/test/java/konkuk/thip/book/adapter/in/web/BookMostSearchedBooksControllerTest.java
@@ -68,7 +68,6 @@ class BookMostSearchedBooksControllerTest {
         UserJpaEntity user = userJpaRepository.save(UserJpaEntity.builder()
                 .oauth2Id("kakao_432708231")
                 .nickname("User1")
-                .imageUrl("https://avatar1.jpg")
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
                 .build());

--- a/src/test/java/konkuk/thip/book/adapter/in/web/BookQueryControllerTest.java
+++ b/src/test/java/konkuk/thip/book/adapter/in/web/BookQueryControllerTest.java
@@ -57,7 +57,6 @@ class BookQueryControllerTest {
         UserJpaEntity user = userJpaRepository.save(UserJpaEntity.builder()
                 .oauth2Id("kakao_432708231")
                 .nickname("User1")
-                .imageUrl("https://avatar1.jpg")
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
                 .build());

--- a/src/test/java/konkuk/thip/common/util/TestEntityFactory.java
+++ b/src/test/java/konkuk/thip/common/util/TestEntityFactory.java
@@ -67,7 +67,6 @@ public class TestEntityFactory {
     public static UserJpaEntity createUser(AliasJpaEntity alias) {
         return UserJpaEntity.builder()
                 .nickname("테스터")
-                .imageUrl("https://test.img")
                 .oauth2Id("kakao_12345678")
                 .aliasForUserJpaEntity(alias)
                 .role(UserRole.USER)
@@ -77,7 +76,6 @@ public class TestEntityFactory {
     public static UserJpaEntity createUser(AliasJpaEntity alias, String nickname) {
         return UserJpaEntity.builder()
                 .nickname(nickname)
-                .imageUrl("https://test.img")
                 .oauth2Id("kakao_12345678")
                 .aliasForUserJpaEntity(alias)
                 .role(UserRole.USER)
@@ -188,7 +186,7 @@ public class TestEntityFactory {
                 .build();
     }
 
-    public static FollowingJpaEntity createFollowing(UserJpaEntity followerUser,UserJpaEntity followingUser) {
+    public static FollowingJpaEntity createFollowing(UserJpaEntity followerUser, UserJpaEntity followingUser) {
         return FollowingJpaEntity.builder()
                 .userJpaEntity(followerUser)
                 .followingUserJpaEntity(followingUser)

--- a/src/test/java/konkuk/thip/feed/adapter/in/web/FeedShowUserInfoApiTest.java
+++ b/src/test/java/konkuk/thip/feed/adapter/in/web/FeedShowUserInfoApiTest.java
@@ -1,0 +1,271 @@
+package konkuk.thip.feed.adapter.in.web;
+
+import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.adapter.out.persistence.repository.BookJpaRepository;
+import konkuk.thip.common.util.TestEntityFactory;
+import konkuk.thip.feed.adapter.out.persistence.repository.FeedJpaRepository;
+import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.FollowingJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.repository.alias.AliasJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.repository.following.FollowingJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("[통합] 피드 화면에서의 유저 정보 조회 api 통합 테스트")
+class FeedShowUserInfoApiTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private AliasJpaRepository aliasJpaRepository;
+    @Autowired private UserJpaRepository userJpaRepository;
+    @Autowired private FeedJpaRepository feedJpaRepository;
+    @Autowired private FollowingJpaRepository followingJpaRepository;
+    @Autowired private BookJpaRepository bookJpaRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    @AfterEach
+    void tearDown() {
+        feedJpaRepository.deleteAllInBatch();
+        followingJpaRepository.deleteAllInBatch();
+        userJpaRepository.deleteAllInBatch();
+        aliasJpaRepository.deleteAllInBatch();
+        bookJpaRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("내 피드에서의 유저 정보를 조회할 경우, 내 개인 정보, 나의 팔로워 정보, 내가 작성한 모든 피드 개수 를 반환한다.")
+    void feed_show_mine_info_test() throws Exception {
+        //given
+        AliasJpaEntity a0 = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        AliasJpaEntity a1 = aliasJpaRepository.save(TestEntityFactory.createLiteratureAlias());
+        UserJpaEntity me = userJpaRepository.save(TestEntityFactory.createUser(a0, "me"));
+        UserJpaEntity follower1 = userJpaRepository.save(TestEntityFactory.createUser(a0, "follower1"));
+        UserJpaEntity follower2 = userJpaRepository.save(TestEntityFactory.createUser(a1, "follower2"));
+        FollowingJpaEntity followingJpaEntity1 = followingJpaRepository.save(TestEntityFactory.createFollowing(follower1, me));// follower1 가 me를 follow 하는 상황
+        FollowingJpaEntity followingJpaEntity2 = followingJpaRepository.save(TestEntityFactory.createFollowing(follower2, me));// follower2 가 me를 follow 하는 상황
+
+        // 팔로우 한 시각을 조정 (follower1 -> follower2 순 으로 팔로잉을 했다고 가정)
+        followingJpaRepository.flush();
+        LocalDateTime base = LocalDateTime.now();
+        jdbcTemplate.update(
+                "UPDATE followings SET created_at = ? WHERE following_id = ?",
+                Timestamp.valueOf(base.minusMinutes(10)), followingJpaEntity1.getFollowingId());
+        jdbcTemplate.update(
+                "UPDATE followings SET created_at = ? WHERE following_id = ?",
+                Timestamp.valueOf(base.minusMinutes(1)), followingJpaEntity2.getFollowingId());
+        jdbcTemplate.update(
+                "UPDATE users SET follower_count = ? WHERE user_id = ?",
+                2, me.getUserId());      // me 의 followerCount 값을 2로 update
+
+        // 피드 생성 및 생성일 직접 설정
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBook());        // 공통 Book
+        feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true));        // 공개글
+        feedJpaRepository.save(TestEntityFactory.createFeed(me, book, true));        // 공개글
+        feedJpaRepository.save(TestEntityFactory.createFeed(me, book, false));       // 비공개글
+
+        //when //then
+        mockMvc.perform(get("/feeds/mine/info")
+                        .requestAttr("userId", me.getUserId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.profileImageUrl", is(a0.getImageUrl())))
+                .andExpect(jsonPath("$.data.nickname", is(me.getNickname())))
+                .andExpect(jsonPath("$.data.aliasName", is(a0.getValue())))
+                .andExpect(jsonPath("$.data.aliasColor", is(a0.getColor())))
+                .andExpect(jsonPath("$.data.followerCount", is(2)))
+                .andExpect(jsonPath("$.data.totalFeedCount", is(3)))
+                // 팔로워 유저의 프로필 이미지 정렬 순서 : 팔로잉을 최신에 맺은 순 (follower2 -> follower1 순)
+                .andExpect(jsonPath("$.data.latestFollowerProfileImageUrls", is(List.of(a1.getImageUrl(), a0.getImageUrl()))));
+    }
+
+    @Test
+    @DisplayName("나를 팔로우하는 사람이 많을 경우, 팔로우 맺은 일자 기준 최신순으로 최대 5명의 팔로워 프로필 이미지만을 반환한다.")
+    void feed_show_mine_info_follower_many_test() throws Exception {
+        //given
+        AliasJpaEntity a0 = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        AliasJpaEntity a1 = aliasJpaRepository.save(TestEntityFactory.createLiteratureAlias());
+        UserJpaEntity me = userJpaRepository.save(TestEntityFactory.createUser(a0, "me"));
+        UserJpaEntity follower1 = userJpaRepository.save(TestEntityFactory.createUser(a0, "follower1"));
+        UserJpaEntity follower2 = userJpaRepository.save(TestEntityFactory.createUser(a0, "follower2"));
+        UserJpaEntity follower3 = userJpaRepository.save(TestEntityFactory.createUser(a1, "follower3"));
+        UserJpaEntity follower4 = userJpaRepository.save(TestEntityFactory.createUser(a0, "follower4"));
+        UserJpaEntity follower5 = userJpaRepository.save(TestEntityFactory.createUser(a1, "follower5"));
+        UserJpaEntity follower6 = userJpaRepository.save(TestEntityFactory.createUser(a1, "follower6"));
+        UserJpaEntity follower7 = userJpaRepository.save(TestEntityFactory.createUser(a0, "follower7"));
+        FollowingJpaEntity followingJpaEntity1 = followingJpaRepository.save(TestEntityFactory.createFollowing(follower1, me));// follower1 가 me를 follow 하는 상황
+        FollowingJpaEntity followingJpaEntity2 = followingJpaRepository.save(TestEntityFactory.createFollowing(follower2, me));// follower2 가 me를 follow 하는 상황
+        FollowingJpaEntity followingJpaEntity3 = followingJpaRepository.save(TestEntityFactory.createFollowing(follower3, me));// follower3 가 me를 follow 하는 상황
+        FollowingJpaEntity followingJpaEntity4 = followingJpaRepository.save(TestEntityFactory.createFollowing(follower4, me));// follower4 가 me를 follow 하는 상황
+        FollowingJpaEntity followingJpaEntity5 = followingJpaRepository.save(TestEntityFactory.createFollowing(follower5, me));// follower5 가 me를 follow 하는 상황
+        FollowingJpaEntity followingJpaEntity6 = followingJpaRepository.save(TestEntityFactory.createFollowing(follower6, me));// follower6 가 me를 follow 하는 상황
+        FollowingJpaEntity followingJpaEntity7 = followingJpaRepository.save(TestEntityFactory.createFollowing(follower7, me));// follower7 가 me를 follow 하는 상황
+
+        // 팔로우 한 시각을 조정 (follower1 -> follower2 -> ,,, -> follower7 순 으로 팔로잉을 했다고 가정)
+        followingJpaRepository.flush();
+        LocalDateTime base = LocalDateTime.now();
+        jdbcTemplate.update(
+                "UPDATE followings SET created_at = ? WHERE following_id = ?",
+                Timestamp.valueOf(base.minusMinutes(30)), followingJpaEntity1.getFollowingId());
+        jdbcTemplate.update(
+                "UPDATE followings SET created_at = ? WHERE following_id = ?",
+                Timestamp.valueOf(base.minusMinutes(25)), followingJpaEntity2.getFollowingId());
+        jdbcTemplate.update(
+                "UPDATE followings SET created_at = ? WHERE following_id = ?",
+                Timestamp.valueOf(base.minusMinutes(20)), followingJpaEntity3.getFollowingId());
+        jdbcTemplate.update(
+                "UPDATE followings SET created_at = ? WHERE following_id = ?",
+                Timestamp.valueOf(base.minusMinutes(15)), followingJpaEntity4.getFollowingId());
+        jdbcTemplate.update(
+                "UPDATE followings SET created_at = ? WHERE following_id = ?",
+                Timestamp.valueOf(base.minusMinutes(10)), followingJpaEntity5.getFollowingId());
+        jdbcTemplate.update(
+                "UPDATE followings SET created_at = ? WHERE following_id = ?",
+                Timestamp.valueOf(base.minusMinutes(5)), followingJpaEntity6.getFollowingId());
+        jdbcTemplate.update(
+                "UPDATE followings SET created_at = ? WHERE following_id = ?",
+                Timestamp.valueOf(base.minusMinutes(1)), followingJpaEntity7.getFollowingId());
+        jdbcTemplate.update(
+                "UPDATE users SET follower_count = ? WHERE user_id = ?",
+                7, me.getUserId());      // me 의 followerCount 값을 7로 update
+
+        //when //then
+        mockMvc.perform(get("/feeds/mine/info")
+                        .requestAttr("userId", me.getUserId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.followerCount", is(7)))
+                // 팔로워 유저의 프로필 이미지 정렬 순서 : 팔로잉을 최신에 맺은 순 (follower7 -> follower6 -> ,,, -> follower3 순)
+                .andExpect(jsonPath("$.data.latestFollowerProfileImageUrls", is(List.of(
+                        a0.getImageUrl(),
+                        a1.getImageUrl(),
+                        a1.getImageUrl(),
+                        a0.getImageUrl(),
+                        a1.getImageUrl()))));
+    }
+
+    @Test
+    @DisplayName("특정 유저 피드에서의 유저 정보를 조회할 경우, 유저 개인 정보, 유저의 팔로워 정보, 유저가 작성한 모든 '공개' 피드 개수 를 반환한다.")
+    void feed_show_user_info_test() throws Exception {
+        //given
+        AliasJpaEntity a0 = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        AliasJpaEntity a1 = aliasJpaRepository.save(TestEntityFactory.createLiteratureAlias());
+        UserJpaEntity anotherUser = userJpaRepository.save(TestEntityFactory.createUser(a0, "anotherUser"));
+        UserJpaEntity follower1 = userJpaRepository.save(TestEntityFactory.createUser(a0, "follower1"));
+        UserJpaEntity follower2 = userJpaRepository.save(TestEntityFactory.createUser(a1, "follower2"));
+        FollowingJpaEntity followingJpaEntity1 = followingJpaRepository.save(TestEntityFactory.createFollowing(follower1, anotherUser));// follower1 가 anotherUser를 follow 하는 상황
+        FollowingJpaEntity followingJpaEntity2 = followingJpaRepository.save(TestEntityFactory.createFollowing(follower2, anotherUser));// follower2 가 anotherUser를 follow 하는 상황
+
+        // 팔로우 한 시각을 조정 (follower1 -> follower2 순 으로 팔로잉을 했다고 가정)
+        followingJpaRepository.flush();
+        LocalDateTime base = LocalDateTime.now();
+        jdbcTemplate.update(
+                "UPDATE followings SET created_at = ? WHERE following_id = ?",
+                Timestamp.valueOf(base.minusMinutes(10)), followingJpaEntity1.getFollowingId());
+        jdbcTemplate.update(
+                "UPDATE followings SET created_at = ? WHERE following_id = ?",
+                Timestamp.valueOf(base.minusMinutes(1)), followingJpaEntity2.getFollowingId());
+        jdbcTemplate.update(
+                "UPDATE users SET follower_count = ? WHERE user_id = ?",
+                2, anotherUser.getUserId());      // anotherUser 의 followerCount 값을 2로 update
+
+        // 피드 생성 및 생성일 직접 설정
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBook());        // 공통 Book
+        feedJpaRepository.save(TestEntityFactory.createFeed(anotherUser, book, true));        // 공개글
+        feedJpaRepository.save(TestEntityFactory.createFeed(anotherUser, book, true));        // 공개글
+        feedJpaRepository.save(TestEntityFactory.createFeed(anotherUser, book, false));       // 비공개글
+        feedJpaRepository.save(TestEntityFactory.createFeed(anotherUser, book, false));       // 비공개글
+
+        //when //then
+        mockMvc.perform(get("/feeds/users/{userId}/info", anotherUser.getUserId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.profileImageUrl", is(a0.getImageUrl())))
+                .andExpect(jsonPath("$.data.nickname", is(anotherUser.getNickname())))
+                .andExpect(jsonPath("$.data.aliasName", is(a0.getValue())))
+                .andExpect(jsonPath("$.data.aliasColor", is(a0.getColor())))
+                .andExpect(jsonPath("$.data.followerCount", is(2)))
+                .andExpect(jsonPath("$.data.totalFeedCount", is(2)))        // 공개 글만
+                // 팔로워 유저의 프로필 이미지 정렬 순서 : 팔로잉을 최신에 맺은 순 (follower2 -> follower1 순)
+                .andExpect(jsonPath("$.data.latestFollowerProfileImageUrls", is(List.of(a1.getImageUrl(), a0.getImageUrl()))));
+    }
+
+    @Test
+    @DisplayName("특정 유저를 팔로우하는 사람이 많을 경우, 팔로우 맺은 일자 기준 최신순으로 최대 5명의 팔로워 프로필 이미지만을 반환한다.")
+    void feed_show_user_info_follower_many_test() throws Exception {
+        //given
+        AliasJpaEntity a0 = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        AliasJpaEntity a1 = aliasJpaRepository.save(TestEntityFactory.createLiteratureAlias());
+        UserJpaEntity anotherUser = userJpaRepository.save(TestEntityFactory.createUser(a0, "anotherUser"));
+        UserJpaEntity follower1 = userJpaRepository.save(TestEntityFactory.createUser(a0, "follower1"));
+        UserJpaEntity follower2 = userJpaRepository.save(TestEntityFactory.createUser(a0, "follower2"));
+        UserJpaEntity follower3 = userJpaRepository.save(TestEntityFactory.createUser(a1, "follower3"));
+        UserJpaEntity follower4 = userJpaRepository.save(TestEntityFactory.createUser(a0, "follower4"));
+        UserJpaEntity follower5 = userJpaRepository.save(TestEntityFactory.createUser(a1, "follower5"));
+        UserJpaEntity follower6 = userJpaRepository.save(TestEntityFactory.createUser(a1, "follower6"));
+        UserJpaEntity follower7 = userJpaRepository.save(TestEntityFactory.createUser(a0, "follower7"));
+        FollowingJpaEntity followingJpaEntity1 = followingJpaRepository.save(TestEntityFactory.createFollowing(follower1, anotherUser));// follower1 가 anotherUser를 follow 하는 상황
+        FollowingJpaEntity followingJpaEntity2 = followingJpaRepository.save(TestEntityFactory.createFollowing(follower2, anotherUser));// follower2 가 anotherUser를 follow 하는 상황
+        FollowingJpaEntity followingJpaEntity3 = followingJpaRepository.save(TestEntityFactory.createFollowing(follower3, anotherUser));// follower3 가 anotherUser를 follow 하는 상황
+        FollowingJpaEntity followingJpaEntity4 = followingJpaRepository.save(TestEntityFactory.createFollowing(follower4, anotherUser));// follower4 가 anotherUser를 follow 하는 상황
+        FollowingJpaEntity followingJpaEntity5 = followingJpaRepository.save(TestEntityFactory.createFollowing(follower5, anotherUser));// follower5 가 anotherUser를 follow 하는 상황
+        FollowingJpaEntity followingJpaEntity6 = followingJpaRepository.save(TestEntityFactory.createFollowing(follower6, anotherUser));// follower6 가 anotherUser를 follow 하는 상황
+        FollowingJpaEntity followingJpaEntity7 = followingJpaRepository.save(TestEntityFactory.createFollowing(follower7, anotherUser));// follower7 가 anotherUser를 follow 하는 상황
+
+        // 팔로우 한 시각을 조정 (follower1 -> follower2 -> ,,, -> follower7 순 으로 팔로잉을 했다고 가정)
+        followingJpaRepository.flush();
+        LocalDateTime base = LocalDateTime.now();
+        jdbcTemplate.update(
+                "UPDATE followings SET created_at = ? WHERE following_id = ?",
+                Timestamp.valueOf(base.minusMinutes(30)), followingJpaEntity1.getFollowingId());
+        jdbcTemplate.update(
+                "UPDATE followings SET created_at = ? WHERE following_id = ?",
+                Timestamp.valueOf(base.minusMinutes(25)), followingJpaEntity2.getFollowingId());
+        jdbcTemplate.update(
+                "UPDATE followings SET created_at = ? WHERE following_id = ?",
+                Timestamp.valueOf(base.minusMinutes(20)), followingJpaEntity3.getFollowingId());
+        jdbcTemplate.update(
+                "UPDATE followings SET created_at = ? WHERE following_id = ?",
+                Timestamp.valueOf(base.minusMinutes(15)), followingJpaEntity4.getFollowingId());
+        jdbcTemplate.update(
+                "UPDATE followings SET created_at = ? WHERE following_id = ?",
+                Timestamp.valueOf(base.minusMinutes(10)), followingJpaEntity5.getFollowingId());
+        jdbcTemplate.update(
+                "UPDATE followings SET created_at = ? WHERE following_id = ?",
+                Timestamp.valueOf(base.minusMinutes(5)), followingJpaEntity6.getFollowingId());
+        jdbcTemplate.update(
+                "UPDATE followings SET created_at = ? WHERE following_id = ?",
+                Timestamp.valueOf(base.minusMinutes(1)), followingJpaEntity7.getFollowingId());
+        jdbcTemplate.update(
+                "UPDATE users SET follower_count = ? WHERE user_id = ?",
+                7, anotherUser.getUserId());      // anotherUser 의 followerCount 값을 7로 update
+
+        //when //then
+        mockMvc.perform(get("/feeds/users/{userId}/info", anotherUser.getUserId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.followerCount", is(7)))
+                // 팔로워 유저의 프로필 이미지 정렬 순서 : 팔로잉을 최신에 맺은 순 (follower7 -> follower6 -> ,,, -> follower3 순)
+                .andExpect(jsonPath("$.data.latestFollowerProfileImageUrls", is(List.of(
+                        a0.getImageUrl(),
+                        a1.getImageUrl(),
+                        a1.getImageUrl(),
+                        a0.getImageUrl(),
+                        a1.getImageUrl()))));
+    }
+}

--- a/src/test/java/konkuk/thip/record/adapter/in/web/RecordSearchApiTest.java
+++ b/src/test/java/konkuk/thip/record/adapter/in/web/RecordSearchApiTest.java
@@ -408,7 +408,6 @@ class RecordSearchApiTest {
         UserJpaEntity user = userJpaRepository.save(UserJpaEntity.builder()
                 .oauth2Id("kakao_123")
                 .nickname("테스트사용자")
-                .imageUrl("http://user.img")
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
                 .build());
@@ -526,7 +525,6 @@ class RecordSearchApiTest {
         UserJpaEntity user = userJpaRepository.save(UserJpaEntity.builder()
                 .oauth2Id("kakao_123")
                 .nickname("테스트사용자")
-                .imageUrl("http://user.img")
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
                 .build());

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomCloseJoinApiTest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomCloseJoinApiTest.java
@@ -61,21 +61,18 @@ class RoomCloseJoinApiTest {
 
         host = userJpaRepository.save(UserJpaEntity.builder()
                 .nickname("호스트")
-                .imageUrl("https://test.img")
                 .oauth2Id("kakao_12345678")
                 .aliasForUserJpaEntity(alias)
                 .role(UserRole.USER)
                 .build());
         member = userJpaRepository.save(UserJpaEntity.builder()
                 .nickname("방 참여자")
-                .imageUrl("https://test.img")
                 .oauth2Id("kakao_12345678")
                 .aliasForUserJpaEntity(alias)
                 .role(UserRole.USER)
                 .build());
         outsider = userJpaRepository.save(UserJpaEntity.builder()
                 .nickname("방 미참여자")
-                .imageUrl("https://test.img")
                 .oauth2Id("kakao_12345678")
                 .aliasForUserJpaEntity(alias)
                 .role(UserRole.USER)

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomCreateAPITest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomCreateAPITest.java
@@ -78,7 +78,6 @@ class RoomCreateAPITest {
         userJpaRepository.save(UserJpaEntity.builder()
                 .oauth2Id("kakao_432708231")
                 .nickname("User1")
-                .imageUrl("https://avatar1.jpg")
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
                 .build());

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomGetMemberListApiTest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomGetMemberListApiTest.java
@@ -76,7 +76,6 @@ class RoomGetMemberListApiTest {
 
         user1 = userJpaRepository.save(UserJpaEntity.builder()
                 .nickname("테스터1")
-                .imageUrl("https://test1.img")
                 .oauth2Id("kakao_1")
                 .aliasForUserJpaEntity(alias)
                 .role(UserRole.USER)
@@ -85,7 +84,6 @@ class RoomGetMemberListApiTest {
 
         user2 = userJpaRepository.save(UserJpaEntity.builder()
                 .nickname("테스터2")
-                .imageUrl("https://test2.img")
                 .oauth2Id("kakao_2")
                 .aliasForUserJpaEntity(alias)
                 .role(UserRole.USER)
@@ -94,7 +92,6 @@ class RoomGetMemberListApiTest {
 
         user3 = userJpaRepository.save(UserJpaEntity.builder()
                 .nickname("테스터3")
-                .imageUrl("https://test3.img")
                 .oauth2Id("kakao_3")
                 .aliasForUserJpaEntity(alias)
                 .role(UserRole.USER)

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomJoinApiTest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomJoinApiTest.java
@@ -95,7 +95,6 @@ class RoomJoinApiTest {
         host = userJpaRepository.save(UserJpaEntity.builder()
                 .oauth2Id("kakao_432708231")
                 .nickname("user")
-                .imageUrl("img")
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
                 .build());
@@ -103,7 +102,6 @@ class RoomJoinApiTest {
         participant = userJpaRepository.save(UserJpaEntity.builder()
                 .oauth2Id("kakao_12345678")
                 .nickname("user123")
-                .imageUrl("img")
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
                 .build());

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomPlayingDetailViewApiTest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomPlayingDetailViewApiTest.java
@@ -121,7 +121,6 @@ class RoomPlayingDetailViewApiTest {
         List<UserJpaEntity> users = IntStream.rangeClosed(1, count)
                 .mapToObj(i -> UserJpaEntity.builder()
                         .nickname("user" + i)
-                        .imageUrl("http://image")
                         .oauth2Id("oauth2Id")
                         .role(UserRole.USER)
                         .aliasForUserJpaEntity(alias)

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomRecruitingDetailViewApiTest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomRecruitingDetailViewApiTest.java
@@ -136,7 +136,6 @@ class RoomRecruitingDetailViewApiTest {
         List<UserJpaEntity> users = IntStream.rangeClosed(1, count)
                 .mapToObj(i -> UserJpaEntity.builder()
                         .nickname("user" + i)
-                        .imageUrl("http://image")
                         .oauth2Id("oauth2Id")
                         .role(UserRole.USER)
                         .aliasForUserJpaEntity(alias)

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomSearchApiTest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomSearchApiTest.java
@@ -135,7 +135,6 @@ class RoomSearchApiTest {
         List<UserJpaEntity> users = IntStream.rangeClosed(1, count)
                 .mapToObj(i -> UserJpaEntity.builder()
                         .nickname("user" + i)
-                        .imageUrl("http://image")
                         .oauth2Id("oauth2Id")
                         .role(UserRole.USER)
                         .aliasForUserJpaEntity(alias)

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomVerifyPasswordAPITest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomVerifyPasswordAPITest.java
@@ -72,15 +72,7 @@ class RoomVerifyPasswordAPITest {
     void setUp() {
 
         AliasJpaEntity alias = aliasJpaRepository.save(TestEntityFactory.createLiteratureAlias());
-
-        UserJpaEntity user = userJpaRepository.save(UserJpaEntity.builder()
-                .oauth2Id("kakao_432708231")
-                .nickname("User1")
-                .imageUrl("https://avatar1.jpg")
-                .role(UserRole.USER)
-                .aliasForUserJpaEntity(alias)
-                .build());
-
+        UserJpaEntity user = userJpaRepository.save(TestEntityFactory.createUser(alias, "User1"));
         BookJpaEntity book = bookJpaRepository.save(BookJpaEntity.builder()
                 .isbn("1234567890123")
                 .title("테스트책")

--- a/src/test/java/konkuk/thip/user/adapter/in/web/UserFollowApiTest.java
+++ b/src/test/java/konkuk/thip/user/adapter/in/web/UserFollowApiTest.java
@@ -58,7 +58,6 @@ class UserFollowApiTest {
 
         UserJpaEntity followingUser = userJpaRepository.save(UserJpaEntity.builder()
                 .nickname("user100")
-                .imageUrl("http://image")
                 .oauth2Id("oauth2_user100")
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
@@ -66,7 +65,6 @@ class UserFollowApiTest {
 
         UserJpaEntity target = userJpaRepository.save(UserJpaEntity.builder()
                 .nickname("user200")
-                .imageUrl("http://image")
                 .oauth2Id("oauth2_user200")
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)

--- a/src/test/java/konkuk/thip/user/adapter/in/web/UserVerifyNicknameControllerTest.java
+++ b/src/test/java/konkuk/thip/user/adapter/in/web/UserVerifyNicknameControllerTest.java
@@ -81,7 +81,6 @@ class UserVerifyNicknameControllerTest {
 
         UserJpaEntity userJpaEntity = UserJpaEntity.builder()
                 .nickname("테스트유저")
-                .imageUrl("http://image.url")
                 .role(USER)
                 .oauth2Id("kakao_12345678")
                 .aliasForUserJpaEntity(aliasJpaEntity)

--- a/src/test/java/konkuk/thip/vote/adapter/in/web/VoteCreateControllerTest.java
+++ b/src/test/java/konkuk/thip/vote/adapter/in/web/VoteCreateControllerTest.java
@@ -95,7 +95,6 @@ class VoteCreateControllerTest {
         UserJpaEntity user = userJpaRepository.save(UserJpaEntity.builder()
                 .oauth2Id("kakao_432708231")
                 .nickname("User1")
-                .imageUrl("https://avatar1.jpg")
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
                 .build());


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #115 

## 📝 작업 내용
피드 조회 화면의 상단 부분을 구성하는 [유저 정보, 유저의 팔로워 정보, 유저가 작성한 피드 개수] 등을 반환하는 api 를 개발하였습니다.
현재 유저의 피드 조회 api가 [내 피드 조회, 특정 유저의 피드 조회] 이렇게 2가지로 있어서, 해당 api도 2개로 분리하였습니다!!

- api 주요 로직
  - 동일 service class 에서 메서드를 분리하여 api 2개를 구현하였습니다
  - 해당 유저를 팔로우하는 사람의 프로필 이미지 url을 조회해야하는 요구사항이 있는데, 이를 QueryDSL 을 사용해 구현하였습니다
  - 유저가 작성한 피드의 개수를 구하는 2개의 메서드는 모두 jpql + full scan 방식의 count(*) 를 활용하여 구현하였습니다
    - 이는 추후에 인덱스 등을 도입하여 성능 개선의 포인트가 될 수 있을 것 같습니다!!

- 그 외 수정사항
  - UserJpaEntity 에서 imageUrl 필드를 제거하였습니다

## 📸 스크린샷
<img width="1080" height="806" alt="image" src="https://github.com/user-attachments/assets/e3cb72fe-a434-464a-973b-b7c656ee53ab" />
<img width="1074" height="792" alt="image" src="https://github.com/user-attachments/assets/865cd25c-5b15-4faa-a71e-86fc582e5ade" />
postman 을 통해 api 호출을 테스트 해봤습니다!
(로컬 테스트용 데이터를 완벽한 시나리오로 구성하지 않아 캡쳐본에서는 response 끼리의 정합성이 잘 맞지는 않습니다. api 통합 테스트 코드를 통해 확인해주시면 될 것 같습니다!! ^^7)

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 피드에서 사용자 정보를 조회할 수 있는 API 엔드포인트가 추가되었습니다. (내 정보 및 특정 사용자 정보)
  * 피드 사용자 정보에는 프로필 이미지, 닉네임, 별명, 별명 색상, 팔로워 수, 전체/공개 피드 수, 최근 팔로워 프로필 이미지(최대 5명)가 포함됩니다.

* **버그 수정**
  * 사용자 프로필 이미지 URL이 별명 정보에서 제공되도록 일관성 있게 변경되었습니다.

* **테스트**
  * 피드 사용자 정보 조회 API에 대한 통합 테스트가 추가되었습니다.
  * 기존 테스트 및 테스트 데이터에서 imageUrl 관련 코드가 제거되었습니다.

* **리팩토링**
  * 피드 및 팔로워 수 집계 관련 메서드 명칭 및 쿼리 개선, 관련 인터페이스 및 서비스 구조 개선이 이루어졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->