### PR TITLE
[feat] 사용자 정보 수정 api 개발

### DIFF
--- a/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
@@ -38,6 +38,11 @@ public enum ErrorCode implements ResponseCode {
      */
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 70000, "존재하지 않는 USER 입니다."),
     USER_ALREADY_FOLLOWED(HttpStatus.BAD_REQUEST, 70001, "이미 팔로우한 사용자입니다."),
+    USER_NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, 70002, "사용자 닉네임은 10자 이하여야 합니다."),
+    USER_NICKNAME_CANNOT_BE_BLANK(HttpStatus.BAD_REQUEST, 70003, "사용자 닉네임은 비어있을 수 없습니다."),
+    USER_NICKNAME_CANNOT_BE_SAME(HttpStatus.BAD_REQUEST, 70004, "사용자 닉네임은 이전과 동일할 수 없습니다."),
+    USER_NICKNAME_UPDATE_TOO_FREQUENT(HttpStatus.BAD_REQUEST, 70005, "사용자 닉네임은 6개월에 한번 변경할 수 있습니다."),
+    USER_NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, 70006, "다른 사용자가 이미 사용중인 닉네임입니다."),
 
     /**
      * 75000 : follow error

--- a/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
@@ -26,6 +26,16 @@ public enum SwaggerResponseDescription {
     USER_SEARCH(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND
     ))),
+    USER_UPDATE(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            ALIAS_NAME_NOT_MATCH,
+            USER_NICKNAME_TOO_LONG,
+            USER_NICKNAME_CANNOT_BE_BLANK,
+            USER_NICKNAME_CANNOT_BE_SAME,
+            USER_NICKNAME_UPDATE_TOO_FREQUENT,
+            USER_NICKNAME_ALREADY_EXISTS
+    ))),
+
 
     // Follow
     CHANGE_FOLLOW_STATE(new LinkedHashSet<>(Set.of(

--- a/src/main/java/konkuk/thip/user/adapter/in/web/UserCommandController.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/UserCommandController.java
@@ -23,8 +23,7 @@ import org.springframework.web.bind.annotation.*;
 
 import static konkuk.thip.common.security.constant.AuthParameters.JWT_HEADER_KEY;
 import static konkuk.thip.common.security.constant.AuthParameters.JWT_PREFIX;
-import static konkuk.thip.common.swagger.SwaggerResponseDescription.CHANGE_FOLLOW_STATE;
-import static konkuk.thip.common.swagger.SwaggerResponseDescription.USER_SIGNUP;
+import static konkuk.thip.common.swagger.SwaggerResponseDescription.*;
 
 @Tag(name = "User Command API", description = "사용자가 주체가 되는 정보 수정")
 @RestController
@@ -67,6 +66,11 @@ public class UserCommandController {
         )));
     }
 
+    @Operation(
+            summary = "사용자 정보 수정",
+            description = "사용자가 자신의 정보를 수정합니다. 닉네임과 칭호(Alias)를 수정할 수 있습니다."
+    )
+    @ExceptionDescription(USER_UPDATE)
     @PatchMapping("/users")
     public BaseResponse<Void> updateUser(
             @Parameter(hidden = true) @UserId final Long userId,

--- a/src/main/java/konkuk/thip/user/adapter/in/web/UserCommandController.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/UserCommandController.java
@@ -12,15 +12,14 @@ import konkuk.thip.common.security.util.JwtUtil;
 import konkuk.thip.common.swagger.annotation.ExceptionDescription;
 import konkuk.thip.user.adapter.in.web.request.UserFollowRequest;
 import konkuk.thip.user.adapter.in.web.request.UserSignupRequest;
+import konkuk.thip.user.adapter.in.web.request.UserUpdateRequest;
 import konkuk.thip.user.adapter.in.web.response.UserFollowResponse;
 import konkuk.thip.user.adapter.in.web.response.UserSignupResponse;
 import konkuk.thip.user.application.port.in.UserFollowUsecase;
 import konkuk.thip.user.application.port.in.UserSignupUseCase;
+import konkuk.thip.user.application.port.in.UserUpdateUseCase;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static konkuk.thip.common.security.constant.AuthParameters.JWT_HEADER_KEY;
 import static konkuk.thip.common.security.constant.AuthParameters.JWT_PREFIX;
@@ -34,6 +33,8 @@ public class UserCommandController {
 
     private final UserSignupUseCase userSignupUseCase;
     private final UserFollowUsecase userFollowUsecase;
+    private final UserUpdateUseCase userUpdateUseCase;
+
     private final JwtUtil jwtUtil;
 
     @Operation(
@@ -60,9 +61,17 @@ public class UserCommandController {
     public BaseResponse<UserFollowResponse> followUser(
             @Parameter(hidden = true) @UserId final Long userId,
             @Parameter(description = "팔로우/언팔로우할 사용자 ID") @PathVariable final Long followingUserId,
-            @RequestBody @Valid final UserFollowRequest request) {
+            @RequestBody @Valid final UserFollowRequest userFollowRequest) {
         return BaseResponse.ok(UserFollowResponse.of(userFollowUsecase.changeFollowingState(
-                UserFollowRequest.toCommand(userId, followingUserId, request.type())
+                userFollowRequest.toCommand(userId, followingUserId)
         )));
+    }
+
+    @PatchMapping("/users")
+    public BaseResponse<Void> updateUser(
+            @Parameter(hidden = true) @UserId final Long userId,
+            @RequestBody @Valid final UserUpdateRequest userUpdateRequest) {
+        userUpdateUseCase.updateUser(userUpdateRequest.toCommand(userId));
+        return BaseResponse.ok(null);
     }
 }

--- a/src/main/java/konkuk/thip/user/adapter/in/web/request/UserFollowRequest.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/request/UserFollowRequest.java
@@ -10,7 +10,7 @@ public record UserFollowRequest(
         @NotNull(message = "type은 필수 파라미터입니다.")
         Boolean type
 ) {
-        public static UserFollowCommand toCommand(Long userId, Long targetUserId, Boolean type) {
+        public UserFollowCommand toCommand(Long userId, Long targetUserId) {
                 return new UserFollowCommand(userId, targetUserId, type);
         }
 }

--- a/src/main/java/konkuk/thip/user/adapter/in/web/request/UserUpdateRequest.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/request/UserUpdateRequest.java
@@ -1,0 +1,20 @@
+package konkuk.thip.user.adapter.in.web.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import konkuk.thip.user.application.port.in.dto.UserUpdateCommand;
+
+@Schema(description = "사용자 정보 수정 요청 DTO")
+public record UserUpdateRequest(
+
+        @Schema(description = "사용자 수정 칭호", example = "문학가")
+        @NotBlank(message = "칭호는 필수입니다.")
+        String aliasName,
+
+        @Schema(description = "사용자 수정 닉네임", example = "thip")
+        String nickname
+) {
+    public UserUpdateCommand toCommand(Long userId) {
+        return new UserUpdateCommand(aliasName, nickname, userId);
+    }
+}

--- a/src/main/java/konkuk/thip/user/adapter/out/jpa/UserJpaEntity.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/jpa/UserJpaEntity.java
@@ -5,7 +5,8 @@ import jakarta.persistence.*;
 import konkuk.thip.common.entity.BaseJpaEntity;
 import konkuk.thip.user.domain.User;
 import lombok.*;
-import org.springframework.util.Assert;
+
+import java.time.LocalDate;
 
 @Entity
 @Table(name = "users")
@@ -23,6 +24,9 @@ public class UserJpaEntity extends BaseJpaEntity {
     @Column(length = 60, nullable = false)
     private String nickname;
 
+    @Column(name = "nickname_updated_at", nullable = false)
+    private LocalDate nicknameUpdatedAt; // 날짜 형식으로 저장 (예: "2023-10-01")
+
     @Column(name = "oauth2_id", length = 50, nullable = false)
     private String oauth2Id;
 
@@ -37,9 +41,17 @@ public class UserJpaEntity extends BaseJpaEntity {
     @JoinColumn(name = "user_alias_id", nullable = false)
     private AliasJpaEntity aliasForUserJpaEntity;
 
+    public void updateIncludeAliasFrom(User user, AliasJpaEntity aliasJpaEntity) {
+        this.nickname = user.getNickname();
+        this.nicknameUpdatedAt = user.getNicknameUpdatedAt();
+        this.role = UserRole.from(user.getUserRole());
+        this.followerCount = user.getFollowerCount();
+        this.aliasForUserJpaEntity = aliasJpaEntity;
+    }
+
     public void updateFrom(User user) {
         this.nickname = user.getNickname();
-        Assert.notNull(user.getAlias(), "Alias must not be null");
+        this.nicknameUpdatedAt = user.getNicknameUpdatedAt();
         this.role = UserRole.from(user.getUserRole());
         this.followerCount = user.getFollowerCount();
     }

--- a/src/main/java/konkuk/thip/user/adapter/out/mapper/UserMapper.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/mapper/UserMapper.java
@@ -13,6 +13,7 @@ public class UserMapper {
     public UserJpaEntity toJpaEntity(User user, AliasJpaEntity aliasJpaEntity) {
         return UserJpaEntity.builder()
                 .nickname(user.getNickname())
+                .nicknameUpdatedAt(user.getNicknameUpdatedAt())
                 .role(UserRole.from(user.getUserRole()))
                 .oauth2Id(user.getOauth2Id())
                 .followerCount(user.getFollowerCount())
@@ -24,6 +25,7 @@ public class UserMapper {
         return User.builder()
                 .id(userJpaEntity.getUserId())
                 .nickname(userJpaEntity.getNickname())
+                .nicknameUpdatedAt(userJpaEntity.getNicknameUpdatedAt())
                 .userRole(userJpaEntity.getRole().getType())
                 .oauth2Id(userJpaEntity.getOauth2Id())
                 .followerCount(userJpaEntity.getFollowerCount())

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/UserCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/UserCommandPersistenceAdapter.java
@@ -52,4 +52,20 @@ public class UserCommandPersistenceAdapter implements UserCommandPort {
                 .map(userMapper::toDomainEntity)
                 .collect(Collectors.toMap(User::getId, Function.identity()));
     }
+
+    @Override
+    public void update(User user) {
+        UserJpaEntity userJpaEntity = userJpaRepository.findById(user.getId()).orElseThrow(
+                () -> new EntityNotFoundException(USER_NOT_FOUND)
+        );
+
+        aliasJpaRepository.findByValue(user.getAlias().getValue()).ifPresentOrElse(
+                aliasJpaEntity -> userJpaEntity.updateIncludeAliasFrom(user, aliasJpaEntity),
+                () -> {
+                    throw new EntityNotFoundException(ALIAS_NOT_FOUND);
+                }
+        );
+
+        userJpaRepository.save(userJpaEntity);
+    }
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/UserQueryPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/UserQueryPersistenceAdapter.java
@@ -24,6 +24,11 @@ public class UserQueryPersistenceAdapter implements UserQueryPort {
     }
 
     @Override
+    public boolean existsByNicknameAndUserIdNot(String nickname, Long userId) {
+        return userJpaRepository.existsByNicknameAndUserIdNot(nickname, userId);
+    }
+
+    @Override
     public Set<Long> findUserIdsParticipatedInRoomsByBookId(Long bookId) {
         return  userJpaRepository.findUserIdsByBookId(bookId);
     }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/UserJpaRepository.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/UserJpaRepository.java
@@ -9,4 +9,6 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long>, U
     Optional<UserJpaEntity> findByOauth2Id(String oauth2Id);
     boolean existsByNickname(String nickname);
     Optional<UserJpaEntity> findById(Long userId);
+
+    boolean existsByNicknameAndUserIdNot(String nickname, Long userId);
 }

--- a/src/main/java/konkuk/thip/user/application/port/in/UserUpdateUseCase.java
+++ b/src/main/java/konkuk/thip/user/application/port/in/UserUpdateUseCase.java
@@ -1,0 +1,7 @@
+package konkuk.thip.user.application.port.in;
+
+import konkuk.thip.user.application.port.in.dto.UserUpdateCommand;
+
+public interface UserUpdateUseCase {
+    void updateUser(UserUpdateCommand command);
+}

--- a/src/main/java/konkuk/thip/user/application/port/in/dto/UserUpdateCommand.java
+++ b/src/main/java/konkuk/thip/user/application/port/in/dto/UserUpdateCommand.java
@@ -1,0 +1,8 @@
+package konkuk.thip.user.application.port.in.dto;
+
+public record UserUpdateCommand(
+        String aliasName,
+        String nickname,
+        Long userId
+) {
+}

--- a/src/main/java/konkuk/thip/user/application/port/out/UserCommandPort.java
+++ b/src/main/java/konkuk/thip/user/application/port/out/UserCommandPort.java
@@ -10,4 +10,5 @@ public interface UserCommandPort {
     Long save(User user);
     User findById(Long userId);
     Map<Long, User> findByIds(List<Long> userIds);
+    void update(User user);
 }

--- a/src/main/java/konkuk/thip/user/application/port/out/UserQueryPort.java
+++ b/src/main/java/konkuk/thip/user/application/port/out/UserQueryPort.java
@@ -8,6 +8,9 @@ import java.util.Set;
 
 public interface UserQueryPort {
     boolean existsByNickname(String nickname);
+
+    boolean existsByNicknameAndUserIdNot(String nickname, Long userId);
+
     Set<Long> findUserIdsParticipatedInRoomsByBookId(Long bookId);
 
     UserViewAliasChoiceResult getAllAliasesAndCategories();

--- a/src/main/java/konkuk/thip/user/application/service/UserSignupService.java
+++ b/src/main/java/konkuk/thip/user/application/service/UserSignupService.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+
 import static konkuk.thip.user.adapter.out.jpa.UserRole.USER;
 
 
@@ -23,7 +25,7 @@ public class UserSignupService implements UserSignupUseCase {
     public Long signup(UserSignupCommand command) {
         Alias alias = Alias.from(command.aliasName());
         User user = User.withoutId(
-                command.nickname(), USER.getType(), command.oauth2Id(), alias
+                command.nickname(), LocalDate.now(), USER.getType(), command.oauth2Id(), alias
         );
 
         return userCommandPort.save(user);

--- a/src/main/java/konkuk/thip/user/application/service/UserUpdateService.java
+++ b/src/main/java/konkuk/thip/user/application/service/UserUpdateService.java
@@ -1,0 +1,36 @@
+package konkuk.thip.user.application.service;
+
+import konkuk.thip.common.exception.BusinessException;
+import konkuk.thip.common.exception.code.ErrorCode;
+import konkuk.thip.user.application.port.in.UserUpdateUseCase;
+import konkuk.thip.user.application.port.in.dto.UserUpdateCommand;
+import konkuk.thip.user.application.port.out.UserCommandPort;
+import konkuk.thip.user.application.port.out.UserQueryPort;
+import konkuk.thip.user.domain.Alias;
+import konkuk.thip.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserUpdateService implements UserUpdateUseCase {
+
+    private final UserCommandPort userCommandPort;
+    private final UserQueryPort userQueryPort;
+
+    @Override
+    @Transactional
+    public void updateUser(UserUpdateCommand command) {
+        Alias alias = Alias.from(command.aliasName());
+        boolean isNicknameUpdateRequest = command.nickname() != null; // 닉네임이 null이 아니면 닉네임 업데이트 요청
+
+        User user = userCommandPort.findById(command.userId());
+        user.updateUserInfo(command.nickname(), alias, isNicknameUpdateRequest);
+
+        if(isNicknameUpdateRequest && userQueryPort.existsByNicknameAndUserIdNot(command.nickname(), command.userId())) {
+            throw new BusinessException(ErrorCode.USER_NICKNAME_ALREADY_EXISTS);
+        }
+        userCommandPort.update(user);
+    }
+}

--- a/src/main/java/konkuk/thip/user/domain/User.java
+++ b/src/main/java/konkuk/thip/user/domain/User.java
@@ -65,12 +65,12 @@ public class User extends BaseDomainEntity {
         if(nickname.length() > 10) { // 10자 이상 불가
             throw new InvalidStateException(ErrorCode.USER_NICKNAME_TOO_LONG);
         }
-        if(nickname.equals(this.nickname)) { // 현재 닉네임과 같으면 업데이트 불가
-            throw new InvalidStateException(ErrorCode.USER_NICKNAME_CANNOT_BE_SAME);
-        }
         // 닉네임을 변경한지 6개월이 지나지 않았으면 닉네임 업데이트 불가
         if(nicknameUpdatedAt != null && nicknameUpdatedAt.isAfter(LocalDate.now().minusMonths(6))) {
             throw new InvalidStateException(ErrorCode.USER_NICKNAME_UPDATE_TOO_FREQUENT);
+        }
+        if(nickname.equals(this.nickname)) { // 현재 닉네임과 같으면 업데이트 불가
+            throw new InvalidStateException(ErrorCode.USER_NICKNAME_CANNOT_BE_SAME);
         }
     }
 

--- a/src/main/java/konkuk/thip/user/domain/User.java
+++ b/src/main/java/konkuk/thip/user/domain/User.java
@@ -6,6 +6,8 @@ import konkuk.thip.common.exception.code.ErrorCode;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
+import java.time.LocalDate;
+
 @Getter
 @SuperBuilder
 public class User extends BaseDomainEntity {
@@ -13,6 +15,8 @@ public class User extends BaseDomainEntity {
     private Long id;
 
     private String nickname;
+
+    private LocalDate nicknameUpdatedAt;
 
     private String userRole;
 
@@ -22,10 +26,11 @@ public class User extends BaseDomainEntity {
 
     private Alias alias;
 
-    public static User withoutId(String nickname, String userRole, String oauth2Id, Alias alias) {
+    public static User withoutId(String nickname, LocalDate nicknameUpdatedAt, String userRole, String oauth2Id, Alias alias) {
         return User.builder()
                 .id(null)
                 .nickname(nickname)
+                .nicknameUpdatedAt(nicknameUpdatedAt)
                 .userRole(userRole)
                 .oauth2Id(oauth2Id)
                 .followerCount(0)
@@ -42,6 +47,31 @@ public class User extends BaseDomainEntity {
             throw new InvalidStateException(ErrorCode.FOLLOW_COUNT_IS_ZERO);
         }
         followerCount--;
+    }
+
+    public void updateUserInfo(String nickname, Alias alias, boolean isNicknameUpdateRequest) {
+        if(isNicknameUpdateRequest) {
+            validateCanUpdateNickname(nickname);
+            this.nickname = nickname;
+            this.nicknameUpdatedAt = LocalDate.now();
+        }
+        this.alias = alias;
+    }
+
+    private void validateCanUpdateNickname(String nickname) {
+        if(nickname.isBlank()) { // 빈칸 불가
+            throw new InvalidStateException(ErrorCode.USER_NICKNAME_CANNOT_BE_BLANK);
+        }
+        if(nickname.length() > 10) { // 10자 이상 불가
+            throw new InvalidStateException(ErrorCode.USER_NICKNAME_TOO_LONG);
+        }
+        if(nickname.equals(this.nickname)) { // 현재 닉네임과 같으면 업데이트 불가
+            throw new InvalidStateException(ErrorCode.USER_NICKNAME_CANNOT_BE_SAME);
+        }
+        // 닉네임을 변경한지 6개월이 지나지 않았으면 닉네임 업데이트 불가
+        if(nicknameUpdatedAt != null && nicknameUpdatedAt.isAfter(LocalDate.now().minusMonths(6))) {
+            throw new InvalidStateException(ErrorCode.USER_NICKNAME_UPDATE_TOO_FREQUENT);
+        }
     }
 
 }

--- a/src/test/java/konkuk/thip/book/adapter/in/web/BookChangeSavedControllerTest.java
+++ b/src/test/java/konkuk/thip/book/adapter/in/web/BookChangeSavedControllerTest.java
@@ -12,8 +12,8 @@ import konkuk.thip.saved.adapter.out.persistence.repository.SavedBookJpaReposito
 import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.UserRole;
-import konkuk.thip.user.adapter.out.persistence.repository.alias.AliasJpaRepository;
 import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.repository.alias.AliasJpaRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,6 +26,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -72,6 +73,7 @@ class BookChangeSavedControllerTest {
         UserJpaEntity user = userJpaRepository.save(UserJpaEntity.builder()
                 .oauth2Id("kakao_432708231")
                 .nickname("User1")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
                 .build());

--- a/src/test/java/konkuk/thip/book/adapter/in/web/BookDetailSearchControllerTest.java
+++ b/src/test/java/konkuk/thip/book/adapter/in/web/BookDetailSearchControllerTest.java
@@ -66,6 +66,7 @@ class BookDetailSearchControllerTest {
         UserJpaEntity user = userJpaRepository.save(UserJpaEntity.builder()
                 .oauth2Id("kakao_432708231")
                 .nickname("User1")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
                 .build());

--- a/src/test/java/konkuk/thip/book/adapter/in/web/BookMostSearchedBooksControllerTest.java
+++ b/src/test/java/konkuk/thip/book/adapter/in/web/BookMostSearchedBooksControllerTest.java
@@ -68,6 +68,8 @@ class BookMostSearchedBooksControllerTest {
         UserJpaEntity user = userJpaRepository.save(UserJpaEntity.builder()
                 .oauth2Id("kakao_432708231")
                 .nickname("User1")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(1))
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
                 .build());

--- a/src/test/java/konkuk/thip/book/adapter/in/web/BookQueryControllerTest.java
+++ b/src/test/java/konkuk/thip/book/adapter/in/web/BookQueryControllerTest.java
@@ -9,23 +9,26 @@ import konkuk.thip.recentSearch.adapter.out.persistence.repository.RecentSearchJ
 import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.UserRole;
-import konkuk.thip.user.adapter.out.persistence.repository.alias.AliasJpaRepository;
 import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.repository.alias.AliasJpaRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+
+import java.time.LocalDate;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -57,6 +60,7 @@ class BookQueryControllerTest {
         UserJpaEntity user = userJpaRepository.save(UserJpaEntity.builder()
                 .oauth2Id("kakao_432708231")
                 .nickname("User1")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
                 .build());

--- a/src/test/java/konkuk/thip/common/util/TestEntityFactory.java
+++ b/src/test/java/konkuk/thip/common/util/TestEntityFactory.java
@@ -14,11 +14,13 @@ import konkuk.thip.room.adapter.out.jpa.CategoryJpaEntity;
 import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
 import konkuk.thip.room.adapter.out.jpa.RoomParticipantJpaEntity;
 import konkuk.thip.room.adapter.out.jpa.RoomParticipantRole;
+import konkuk.thip.room.domain.Category;
 import konkuk.thip.saved.adapter.out.jpa.SavedFeedJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.FollowingJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.UserRole;
+import konkuk.thip.user.domain.Alias;
 import konkuk.thip.vote.adapter.out.jpa.VoteJpaEntity;
 
 import java.time.LocalDate;
@@ -34,32 +36,32 @@ public class TestEntityFactory {
 
     public static AliasJpaEntity createLiteratureAlias() {
         return AliasJpaEntity.builder()         // 실제 존재하는 값으로
-                .value("문학가")
-                .imageUrl("문학_image")
-                .color("문학_color")
+                .value(Alias.WRITER.getValue())
+                .imageUrl(Alias.WRITER.getImageUrl())
+                .color(Alias.WRITER.getColor())
                 .build();
     }
 
     public static CategoryJpaEntity createLiteratureCategory(AliasJpaEntity alias) {
         return CategoryJpaEntity.builder()      // 실제 존재하는 값으로
-                .value("문학")
-                .imageUrl("문학_image")
+                .value(Category.LITERATURE.getValue())
+                .imageUrl(Category.LITERATURE.getImageUrl())
                 .aliasForCategoryJpaEntity(alias)
                 .build();
     }
 
     public static AliasJpaEntity createScienceAlias() {
         return AliasJpaEntity.builder()         // 실제 존재하는 값으로
-                .value("과학자")
-                .imageUrl("과학_image")
-                .color("과학_color")
+                .value(Alias.SCIENTIST.getValue())
+                .imageUrl(Alias.SCIENTIST.getImageUrl())
+                .color(Alias.SCIENTIST.getColor())
                 .build();
     }
 
     public static CategoryJpaEntity createScienceCategory(AliasJpaEntity alias) {
         return CategoryJpaEntity.builder()      // 실제 존재하는 값으로
-                .value("과학/IT")
-                .imageUrl("과학/IT_image")
+                .value(Category.SCIENCE_IT.getValue())
+                .imageUrl(Category.SCIENCE_IT.getImageUrl())
                 .aliasForCategoryJpaEntity(alias)
                 .build();
     }
@@ -67,6 +69,7 @@ public class TestEntityFactory {
     public static UserJpaEntity createUser(AliasJpaEntity alias) {
         return UserJpaEntity.builder()
                 .nickname("테스터")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                 .oauth2Id("kakao_12345678")
                 .aliasForUserJpaEntity(alias)
                 .role(UserRole.USER)
@@ -76,6 +79,7 @@ public class TestEntityFactory {
     public static UserJpaEntity createUser(AliasJpaEntity alias, String nickname) {
         return UserJpaEntity.builder()
                 .nickname(nickname)
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                 .oauth2Id("kakao_12345678")
                 .aliasForUserJpaEntity(alias)
                 .role(UserRole.USER)

--- a/src/test/java/konkuk/thip/record/adapter/in/web/RecordSearchApiTest.java
+++ b/src/test/java/konkuk/thip/record/adapter/in/web/RecordSearchApiTest.java
@@ -408,6 +408,7 @@ class RecordSearchApiTest {
         UserJpaEntity user = userJpaRepository.save(UserJpaEntity.builder()
                 .oauth2Id("kakao_123")
                 .nickname("테스트사용자")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
                 .build());
@@ -525,6 +526,7 @@ class RecordSearchApiTest {
         UserJpaEntity user = userJpaRepository.save(UserJpaEntity.builder()
                 .oauth2Id("kakao_123")
                 .nickname("테스트사용자")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
                 .build());

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomCloseJoinApiTest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomCloseJoinApiTest.java
@@ -61,18 +61,21 @@ class RoomCloseJoinApiTest {
 
         host = userJpaRepository.save(UserJpaEntity.builder()
                 .nickname("호스트")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                 .oauth2Id("kakao_12345678")
                 .aliasForUserJpaEntity(alias)
                 .role(UserRole.USER)
                 .build());
         member = userJpaRepository.save(UserJpaEntity.builder()
                 .nickname("방 참여자")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                 .oauth2Id("kakao_12345678")
                 .aliasForUserJpaEntity(alias)
                 .role(UserRole.USER)
                 .build());
         outsider = userJpaRepository.save(UserJpaEntity.builder()
                 .nickname("방 미참여자")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                 .oauth2Id("kakao_12345678")
                 .aliasForUserJpaEntity(alias)
                 .role(UserRole.USER)

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomCreateAPITest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomCreateAPITest.java
@@ -78,6 +78,7 @@ class RoomCreateAPITest {
         userJpaRepository.save(UserJpaEntity.builder()
                 .oauth2Id("kakao_432708231")
                 .nickname("User1")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
                 .build());

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomGetMemberListApiTest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomGetMemberListApiTest.java
@@ -26,6 +26,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.time.LocalDate;
+
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -76,6 +78,7 @@ class RoomGetMemberListApiTest {
 
         user1 = userJpaRepository.save(UserJpaEntity.builder()
                 .nickname("테스터1")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                 .oauth2Id("kakao_1")
                 .aliasForUserJpaEntity(alias)
                 .role(UserRole.USER)
@@ -84,6 +87,7 @@ class RoomGetMemberListApiTest {
 
         user2 = userJpaRepository.save(UserJpaEntity.builder()
                 .nickname("테스터2")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                 .oauth2Id("kakao_2")
                 .aliasForUserJpaEntity(alias)
                 .role(UserRole.USER)
@@ -92,6 +96,7 @@ class RoomGetMemberListApiTest {
 
         user3 = userJpaRepository.save(UserJpaEntity.builder()
                 .nickname("테스터3")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                 .oauth2Id("kakao_3")
                 .aliasForUserJpaEntity(alias)
                 .role(UserRole.USER)

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomJoinApiTest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomJoinApiTest.java
@@ -95,6 +95,7 @@ class RoomJoinApiTest {
         host = userJpaRepository.save(UserJpaEntity.builder()
                 .oauth2Id("kakao_432708231")
                 .nickname("user")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
                 .build());
@@ -102,6 +103,7 @@ class RoomJoinApiTest {
         participant = userJpaRepository.save(UserJpaEntity.builder()
                 .oauth2Id("kakao_12345678")
                 .nickname("user123")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
                 .build());

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomPlayingDetailViewApiTest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomPlayingDetailViewApiTest.java
@@ -11,6 +11,7 @@ import konkuk.thip.room.adapter.out.jpa.RoomParticipantRole;
 import konkuk.thip.room.adapter.out.persistence.repository.RoomJpaRepository;
 import konkuk.thip.room.adapter.out.persistence.repository.category.CategoryJpaRepository;
 import konkuk.thip.room.adapter.out.persistence.repository.roomparticipant.RoomParticipantJpaRepository;
+import konkuk.thip.room.domain.Category;
 import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.UserRole;
@@ -121,6 +122,7 @@ class RoomPlayingDetailViewApiTest {
         List<UserJpaEntity> users = IntStream.rangeClosed(1, count)
                 .mapToObj(i -> UserJpaEntity.builder()
                         .nickname("user" + i)
+                        .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                         .oauth2Id("oauth2Id")
                         .role(UserRole.USER)
                         .aliasForUserJpaEntity(alias)
@@ -193,7 +195,7 @@ class RoomPlayingDetailViewApiTest {
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.isHost", is(false)))
                 .andExpect(jsonPath("$.data.roomName", is("과학-방-1일뒤-활동시작")))
-                .andExpect(jsonPath("$.data.roomImageUrl", is("과학/IT_image")))      // 방 대표 이미지 추가
+                .andExpect(jsonPath("$.data.roomImageUrl", is(Category.SCIENCE_IT.getImageUrl())))      // 방 대표 이미지 추가
                 .andExpect(jsonPath("$.data.progressStartDate", is(DateUtil.formatDate(LocalDate.now().plusDays(1)))))
                 .andExpect(jsonPath("$.data.memberCount", is(4)))
                 .andExpect(jsonPath("$.data.recruitCount", is(10)))
@@ -241,7 +243,7 @@ class RoomPlayingDetailViewApiTest {
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.isHost", is(true)))     // 방 HOST 이면 true
                 .andExpect(jsonPath("$.data.roomName", is("과학-방-1일뒤-활동시작")))
-                .andExpect(jsonPath("$.data.roomImageUrl", is("과학/IT_image")))      // 방 대표 이미지 추가
+                .andExpect(jsonPath("$.data.roomImageUrl", is(Category.SCIENCE_IT.getImageUrl())))      // 방 대표 이미지 추가
                 .andExpect(jsonPath("$.data.progressStartDate", is(DateUtil.formatDate(LocalDate.now().plusDays(1)))))
                 .andExpect(jsonPath("$.data.memberCount", is(4)))
                 .andExpect(jsonPath("$.data.recruitCount", is(10)))
@@ -315,7 +317,7 @@ class RoomPlayingDetailViewApiTest {
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.isHost", is(false)))
                 .andExpect(jsonPath("$.data.roomName", is("과학-방-1일뒤-활동시작")))
-                .andExpect(jsonPath("$.data.roomImageUrl", is("과학/IT_image")))      // 방 대표 이미지 추가
+                .andExpect(jsonPath("$.data.roomImageUrl", is(Category.SCIENCE_IT.getImageUrl())))      // 방 대표 이미지 추가
                 .andExpect(jsonPath("$.data.progressStartDate", is(DateUtil.formatDate(LocalDate.now().plusDays(1)))))
                 .andExpect(jsonPath("$.data.memberCount", is(4)))
                 .andExpect(jsonPath("$.data.recruitCount", is(10)))
@@ -367,7 +369,7 @@ class RoomPlayingDetailViewApiTest {
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.isHost", is(false)))
                 .andExpect(jsonPath("$.data.roomName", is("과학-방-1일뒤-활동시작")))
-                .andExpect(jsonPath("$.data.roomImageUrl", is("과학/IT_image")))      // 방 대표 이미지 추가
+                .andExpect(jsonPath("$.data.roomImageUrl", is(Category.SCIENCE_IT.getImageUrl())))      // 방 대표 이미지 추가
                 .andExpect(jsonPath("$.data.progressStartDate", is(DateUtil.formatDate(LocalDate.now().plusDays(1)))))
                 .andExpect(jsonPath("$.data.memberCount", is(4)))
                 .andExpect(jsonPath("$.data.recruitCount", is(10)))

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomRecruitingDetailViewApiTest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomRecruitingDetailViewApiTest.java
@@ -136,6 +136,7 @@ class RoomRecruitingDetailViewApiTest {
         List<UserJpaEntity> users = IntStream.rangeClosed(1, count)
                 .mapToObj(i -> UserJpaEntity.builder()
                         .nickname("user" + i)
+                        .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                         .oauth2Id("oauth2Id")
                         .role(UserRole.USER)
                         .aliasForUserJpaEntity(alias)

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomSearchApiTest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomSearchApiTest.java
@@ -9,6 +9,7 @@ import konkuk.thip.room.adapter.out.jpa.RoomParticipantJpaEntity;
 import konkuk.thip.room.adapter.out.jpa.RoomParticipantRole;
 import konkuk.thip.room.adapter.out.persistence.repository.category.CategoryJpaRepository;
 import konkuk.thip.room.adapter.out.persistence.repository.RoomJpaRepository;
+import konkuk.thip.room.domain.Category;
 import konkuk.thip.user.adapter.out.jpa.*;
 import konkuk.thip.user.adapter.out.persistence.repository.alias.AliasJpaRepository;
 import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
@@ -135,6 +136,7 @@ class RoomSearchApiTest {
         List<UserJpaEntity> users = IntStream.rangeClosed(1, count)
                 .mapToObj(i -> UserJpaEntity.builder()
                         .nickname("user" + i)
+                        .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                         .oauth2Id("oauth2Id")
                         .role(UserRole.USER)
                         .aliasForUserJpaEntity(alias)
@@ -362,7 +364,7 @@ class RoomSearchApiTest {
         ResultActions result = mockMvc.perform(get("/rooms/search")
                 .requestAttr("userId", 1L)
                 .param("keyword", "과학")
-                .param("category", "과학/IT")
+                .param("category", Category.SCIENCE_IT.getValue())
                 .param("sort", "deadline")
                 .param("page", "1"));
 

--- a/src/test/java/konkuk/thip/room/domain/RoomTest.java
+++ b/src/test/java/konkuk/thip/room/domain/RoomTest.java
@@ -21,7 +21,7 @@ class RoomTest {
     private final LocalDate today = LocalDate.now();
     private final LocalDate START = today.plusDays(1);
     private final LocalDate END = today.plusDays(32);
-    private final Category validCategory = Category.from("과학/IT");
+    private final Category validCategory = Category.SCIENCE_IT;
 
     @Test
     @DisplayName("withoutId: 공개 방이면서 password가 not null 이면, InvalidStateException 발생한다.")

--- a/src/test/java/konkuk/thip/user/adapter/in/web/UserFollowApiTest.java
+++ b/src/test/java/konkuk/thip/user/adapter/in/web/UserFollowApiTest.java
@@ -18,6 +18,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -58,6 +59,7 @@ class UserFollowApiTest {
 
         UserJpaEntity followingUser = userJpaRepository.save(UserJpaEntity.builder()
                 .nickname("user100")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                 .oauth2Id("oauth2_user100")
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
@@ -65,6 +67,7 @@ class UserFollowApiTest {
 
         UserJpaEntity target = userJpaRepository.save(UserJpaEntity.builder()
                 .nickname("user200")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                 .oauth2Id("oauth2_user200")
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)

--- a/src/test/java/konkuk/thip/user/adapter/in/web/UserUpdateApiTest.java
+++ b/src/test/java/konkuk/thip/user/adapter/in/web/UserUpdateApiTest.java
@@ -1,0 +1,87 @@
+package konkuk.thip.user.adapter.in.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import konkuk.thip.common.util.TestEntityFactory;
+import konkuk.thip.user.adapter.in.web.request.UserUpdateRequest;
+import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserRole;
+import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.repository.alias.AliasJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("[통합] 사용자 정보 수정 API 통합 테스트")
+class UserUpdateApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private AliasJpaRepository aliasJpaRepository;
+
+    @AfterEach
+    void tearDown() {
+        userJpaRepository.deleteAll();
+        aliasJpaRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("사용자 닉네임과 별칭이 정상적으로 업데이트된다.")
+    void updateUser_success() throws Exception {
+        // given: 기존 alias 및 user 생성
+        AliasJpaEntity oldAlias = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        AliasJpaEntity newAlias = aliasJpaRepository.save(TestEntityFactory.createLiteratureAlias());
+
+        UserJpaEntity user = userJpaRepository.save(UserJpaEntity.builder()
+                .nickname("oldthip")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
+                .oauth2Id("oauth2_user100")
+                .role(UserRole.USER)
+                .aliasForUserJpaEntity(oldAlias)
+                .build());
+
+        Long userId = user.getUserId();
+
+        UserUpdateRequest userUpdateRequest = new UserUpdateRequest(newAlias.getValue(),"newthip");
+
+        // when: API 요청
+        mockMvc.perform(patch("/users")
+                        .requestAttr("userId", userId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(userUpdateRequest)))
+                // then: HTTP 응답 상태 및 기본 응답 검증
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        // DB 검증: 닉네임과 alias가 업데이트되었는지 확인
+        UserJpaEntity updatedUser = userJpaRepository.findById(userId).orElseThrow();
+        assertThat(updatedUser.getNickname()).isEqualTo("newthip");
+
+        AliasJpaEntity updatedAlias = aliasJpaRepository.findById(updatedUser.getAliasForUserJpaEntity().getAliasId()).orElseThrow();
+        assertThat(updatedAlias.getValue()).isEqualTo(newAlias.getValue());
+    }
+}

--- a/src/test/java/konkuk/thip/user/adapter/in/web/UserVerifyNicknameControllerTest.java
+++ b/src/test/java/konkuk/thip/user/adapter/in/web/UserVerifyNicknameControllerTest.java
@@ -19,6 +19,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.time.LocalDate;
+
 import static konkuk.thip.common.exception.code.ErrorCode.API_INVALID_PARAM;
 import static konkuk.thip.user.adapter.out.jpa.UserRole.USER;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -81,6 +83,7 @@ class UserVerifyNicknameControllerTest {
 
         UserJpaEntity userJpaEntity = UserJpaEntity.builder()
                 .nickname("테스트유저")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                 .role(USER)
                 .oauth2Id("kakao_12345678")
                 .aliasForUserJpaEntity(aliasJpaEntity)

--- a/src/test/java/konkuk/thip/user/application/service/UserFollowServiceTest.java
+++ b/src/test/java/konkuk/thip/user/application/service/UserFollowServiceTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
+@DisplayName("[단위] UserFollowService 단위 테스트")
 class UserFollowServiceTest {
 
     private FollowingCommandPort followingCommandPort;

--- a/src/test/java/konkuk/thip/user/application/service/UserUpdateServiceTest.java
+++ b/src/test/java/konkuk/thip/user/application/service/UserUpdateServiceTest.java
@@ -1,0 +1,92 @@
+package konkuk.thip.user.application.service;
+
+import konkuk.thip.common.exception.BusinessException;
+import konkuk.thip.user.application.port.in.dto.UserUpdateCommand;
+import konkuk.thip.user.application.port.out.UserCommandPort;
+import konkuk.thip.user.application.port.out.UserQueryPort;
+import konkuk.thip.user.domain.Alias;
+import konkuk.thip.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@DisplayName("[단위] UserUpdateService 단위 테스트")
+class UserUpdateServiceTest {
+
+    private UserCommandPort userCommandPort;
+    private UserQueryPort userQueryPort;
+    private UserUpdateService userUpdateService;
+    private User existingUser;
+
+    @BeforeEach
+    void setUp() {
+        userCommandPort = mock(UserCommandPort.class);
+        userQueryPort = mock(UserQueryPort.class);
+        userUpdateService = new UserUpdateService(userCommandPort, userQueryPort);
+
+        existingUser = User.builder()
+                .id(1L)
+                .nickname("thip")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
+                .userRole("USER")
+                .oauth2Id("oauth2-id")
+                .followerCount(0)
+                .alias(Alias.WRITER)
+                .build();
+    }
+
+    @Test
+    @DisplayName("닉네임과 별칭을 정상적으로 업데이트")
+    void updateUser_success() {
+        // given
+        UserUpdateCommand command = new UserUpdateCommand(Alias.ARTIST.getValue(), "newthip", existingUser.getId());
+        when(userCommandPort.findById(command.userId())).thenReturn(existingUser);
+        when(userQueryPort.existsByNicknameAndUserIdNot(command.nickname(), command.userId()))
+                .thenReturn(false);
+
+        // when
+        userUpdateService.updateUser(command);
+
+        // then
+        assertThat(existingUser.getNickname()).isEqualTo("newthip");
+        assertThat(existingUser.getAlias()).isEqualTo(Alias.ARTIST);
+        verify(userCommandPort).update(existingUser);
+    }
+
+    @Test
+    @DisplayName("닉네임 중복이면 예외 발생")
+    void updateUser_duplicateNickname_throwsException() {
+        // given
+        UserUpdateCommand command = new UserUpdateCommand(Alias.ARTIST.getValue(), "existingnickname", existingUser.getId());
+        when(userCommandPort.findById(command.userId())).thenReturn(existingUser);
+        when(userQueryPort.existsByNicknameAndUserIdNot(command.nickname(), command.userId()))
+                .thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> userUpdateService.updateUser(command))
+                .isInstanceOf(BusinessException.class);
+        verify(userCommandPort, never()).update(any());
+    }
+
+    @Test
+    @DisplayName("닉네임 없이 별칭만 업데이트")
+    void updateUser_onlyAlias_success() {
+        // given
+        UserUpdateCommand command = new UserUpdateCommand(Alias.SCIENTIST.getValue(), null, existingUser.getId());
+        when(userCommandPort.findById(command.userId())).thenReturn(existingUser);
+
+        // when
+        userUpdateService.updateUser(command);
+
+        // then
+        assertThat(existingUser.getAlias()).isEqualTo(Alias.SCIENTIST);
+        assertThat(existingUser.getNickname()).isEqualTo("thip");
+        verify(userCommandPort).update(existingUser);
+    }
+}

--- a/src/test/java/konkuk/thip/user/domain/UserTest.java
+++ b/src/test/java/konkuk/thip/user/domain/UserTest.java
@@ -1,0 +1,94 @@
+package konkuk.thip.user.domain;
+
+import konkuk.thip.common.exception.InvalidStateException;
+import konkuk.thip.common.exception.code.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("[단위] User 단위 테스트")
+class UserTest {
+
+    private User user;
+    private Alias alias;
+
+    @BeforeEach
+    void setUp() {
+        alias = Alias.WRITER;
+        user = User.builder()
+                .id(1L)
+                .nickname("thip")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7)) // 7개월 전
+                .userRole("USER")
+                .oauth2Id("oauth2-id")
+                .followerCount(10)
+                .alias(alias)
+                .build();
+    }
+
+    @Test
+    @DisplayName("닉네임 빈 값이면 예외 발생")
+            //영어로 네이밍
+    void nicknameCannotBeBlank_throwsException() {
+        assertThatThrownBy(() -> user.updateUserInfo(" ", alias, true))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessageContaining(ErrorCode.USER_NICKNAME_CANNOT_BE_BLANK.getMessage());
+    }
+
+    @Test
+    @DisplayName("닉네임 10자 초과이면 예외 발생")
+    void nicknameTooLong_throwsException() {
+        String longNickname = "thipthipthip"; // 12자
+        assertThatThrownBy(() -> user.updateUserInfo(longNickname, alias, true))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessageContaining(ErrorCode.USER_NICKNAME_TOO_LONG.getMessage());
+    }
+
+    @Test
+    @DisplayName("닉네임이 기존 닉네임과 같으면 예외 발생")
+    void nicknameCannotBeSame_throwsException() {
+        assertThatThrownBy(() -> user.updateUserInfo("thip", alias, true))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessageContaining(ErrorCode.USER_NICKNAME_CANNOT_BE_SAME.getMessage());
+    }
+
+    @Test
+    @DisplayName("닉네임이 6개월 이내에 변경되면 예외 발생")
+    void nicknameUpdateTooFrequent_throwsException() {
+        user = User.builder()
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(3))
+                .build();
+
+        assertThatThrownBy(() -> user.updateUserInfo("newthip", alias, true))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessageContaining(ErrorCode.USER_NICKNAME_UPDATE_TOO_FREQUENT.getMessage());
+    }
+
+    @Test
+    @DisplayName("닉네임과 별칭을 정상적으로 업데이트")
+    void updateUserInfo_success() {
+        Alias newAlias = Alias.ARTIST;
+        String newNickname = "newNick";
+
+        user.updateUserInfo(newNickname, newAlias, true);
+
+        assertThat(user.getNickname()).isEqualTo(newNickname);
+        assertThat(user.getAlias()).isEqualTo(newAlias);
+        assertThat(user.getNicknameUpdatedAt()).isEqualTo(LocalDate.now());
+    }
+
+    @Test
+    @DisplayName("닉네임 업데이트 없이 별칭만 변경")
+    void 닉네임_업데이트_없이_별칭만_변경() {
+        Alias newAlias = Alias.SCIENTIST;
+
+        user.updateUserInfo(null, newAlias, false);
+
+        assertThat(user.getAlias()).isEqualTo(newAlias);
+        assertThat(user.getNickname()).isEqualTo("thip");
+    }
+}

--- a/src/test/java/konkuk/thip/vote/adapter/in/web/VoteCreateControllerTest.java
+++ b/src/test/java/konkuk/thip/vote/adapter/in/web/VoteCreateControllerTest.java
@@ -8,6 +8,7 @@ import konkuk.thip.room.adapter.out.jpa.CategoryJpaEntity;
 import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
 import konkuk.thip.room.adapter.out.persistence.repository.category.CategoryJpaRepository;
 import konkuk.thip.room.adapter.out.persistence.repository.RoomJpaRepository;
+import konkuk.thip.room.domain.Category;
 import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.UserRole;
@@ -95,6 +96,7 @@ class VoteCreateControllerTest {
         UserJpaEntity user = userJpaRepository.save(UserJpaEntity.builder()
                 .oauth2Id("kakao_432708231")
                 .nickname("User1")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
                 .role(UserRole.USER)
                 .aliasForUserJpaEntity(alias)
                 .build());
@@ -112,8 +114,8 @@ class VoteCreateControllerTest {
 
 
         CategoryJpaEntity category = categoryJpaRepository.save(CategoryJpaEntity.builder()
-                .value("과학/IT")
-                .imageUrl("과학/IT_image")
+                .value(Category.SCIENCE_IT.getValue())
+                .imageUrl(Category.SCIENCE_IT.getImageUrl())
                 .aliasForCategoryJpaEntity(alias)
                 .build());
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #122 

## 📝 작업 내용

프로필 편집 시 다음과 같은 경우가 존재합니다.
- 칭호만 변경하고 싶은 경우 : nickname = null & alias != null
- 칭호와 닉네임 모두 변경하고 싶은 경우 : nickname != numm & alias != null
- 칭호는 무조건 보냄

칭호는 무조건 전달되기 때문에 무조건 주어진 alias로 업데이트되고 nickname의 경우 다음과 같은 유효성 검증을 거칩니다.
- 빈칸 x
- 10자 초과 x
- 사용자가 닉네임을 변경한지 6개월이 넘어야함 => 이 유효성 검증 구현을 위해 User 테이블에 nicknameUpdatedAt이라는 컬럼을 추가했습니다.
- 기존 닉네임과 같은 닉네임 x
- 다른 사용자가 사용중인 닉네임 x

## 📸 스크린샷

## 💬 리뷰 요구사항

기존 로컬 DB에 존재하는 데이터 유지시킨채로 nicknameUpdatedAt 컬럼을 추가하려면 sql console에 아래 쿼리 날리시면 됩니다~
```sql
ALTER TABLE users
    ADD COLUMN nickname_updated_at DATE NOT NULL DEFAULT '2023-01-01';
```

추가적으로, 현재 테스트 코드에 카테고리, 칭호와 같은 상수를 문자열로 그대로 사용되고 있어, 유지보수에 좋지 않을 것 같아 최대한 Enum으로 대체하긴 했습니다. 추후에 더 발견되면 그때그때 바꿔줘야 할 것 같습니다 😭

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 자신의 닉네임과 별칭을 수정할 수 있는 사용자 정보 수정 API가 추가되었습니다.
  * 닉네임 변경 시 10자 이하, 공백 불가, 기존 닉네임과 동일 불가, 6개월에 한 번만 변경 가능, 중복 불가 등 다양한 검증이 적용됩니다.

* **버그 수정**
  * 없음

* **테스트**
  * 사용자 정보 수정 및 닉네임 검증 관련 단위/통합 테스트가 추가 및 보완되었습니다.
  * 테스트 데이터에 닉네임 변경일 초기화 로직이 반영되었습니다.

* **문서화**
  * 사용자 정보 수정 API에 대한 스웨거 문서 설명이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->