### PR TITLE
[feat] 투표하기 api 구현

### DIFF
--- a/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
@@ -50,7 +50,7 @@ public enum ErrorCode implements ResponseCode {
     FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, 75000, "존재하지 않는 FOLLOW 입니다."),
     USER_ALREADY_UNFOLLOWED(HttpStatus.BAD_REQUEST, 75001, "이미 언팔로우한 사용자입니다."),
     USER_CANNOT_FOLLOW_SELF(HttpStatus.BAD_REQUEST, 75002, "사용자는 자신을 팔로우할 수 없습니다."),
-    FOLLOW_COUNT_IS_ZERO(HttpStatus.BAD_REQUEST, 75003, "사용자의 팔로우 수가 0일때는 언팔로우는 불가능합니다."),
+    FOLLOW_COUNT_CANNOT_BE_NEGATIVE(HttpStatus.BAD_REQUEST, 75003, "사용자의 팔로우 수가 0일때는 언팔로우는 불가능합니다."),
 
     /**
      * 80000 : book error
@@ -106,6 +106,7 @@ public enum ErrorCode implements ResponseCode {
     VOTE_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, 120000, "투표는 존재하지만 투표항목이 비어있습니다."),
     VOTE_ITEM_ALREADY_VOTED(HttpStatus.BAD_REQUEST, 120001, "이미 투표한 투표항목입니다."),
     VOTE_ITEM_NOT_VOTED_CANNOT_CANCEL(HttpStatus.BAD_REQUEST, 120002, "투표하지 않은 투표항목은 취소할 수 없습니다."),
+    VOTE_ITEM_COUNT_CANNOT_BE_NEGATIVE(HttpStatus.BAD_REQUEST, 120003, "투표항목의 투표 수는 0 이하로 감소할 수 없습니다."),
 
 
     /**

--- a/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
@@ -104,6 +104,14 @@ public enum ErrorCode implements ResponseCode {
      * 120000 : voteItem error
      */
     VOTE_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, 120000, "투표는 존재하지만 투표항목이 비어있습니다."),
+    VOTE_ITEM_ALREADY_VOTED(HttpStatus.BAD_REQUEST, 120001, "이미 투표한 투표항목입니다."),
+    VOTE_ITEM_NOT_VOTED_CANNOT_CANCEL(HttpStatus.BAD_REQUEST, 120002, "투표하지 않은 투표항목은 취소할 수 없습니다."),
+
+
+    /**
+     * 125000 : voteParticipant error
+     */
+    VOTE_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, 125000, "존재하지 않는 VOTE PARTICIPANT 입니다."),
 
     /**
      * 130000 : record error

--- a/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
@@ -43,7 +43,7 @@ public enum SwaggerResponseDescription {
             USER_ALREADY_FOLLOWED,
             USER_ALREADY_UNFOLLOWED,
             USER_CANNOT_FOLLOW_SELF,
-            FOLLOW_COUNT_IS_ZERO
+            FOLLOW_COUNT_CANNOT_BE_NEGATIVE
     ))),
     GET_USER_FOLLOW(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND
@@ -136,7 +136,8 @@ public enum SwaggerResponseDescription {
             ROOM_ACCESS_FORBIDDEN,
             VOTE_ITEM_NOT_FOUND,
             VOTE_ITEM_ALREADY_VOTED,
-            VOTE_ITEM_NOT_VOTED_CANNOT_CANCEL
+            VOTE_ITEM_NOT_VOTED_CANNOT_CANCEL,
+            VOTE_ITEM_COUNT_CANNOT_BE_NEGATIVE
     ))),
 
 

--- a/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
@@ -132,6 +132,13 @@ public enum SwaggerResponseDescription {
             VOTE_CANNOT_BE_OVERVIEW,
             INVALID_VOTE_PAGE_RANGE
     ))),
+    VOTE(new LinkedHashSet<>(Set.of(
+            ROOM_ACCESS_FORBIDDEN,
+            VOTE_ITEM_NOT_FOUND,
+            VOTE_ITEM_ALREADY_VOTED,
+            VOTE_ITEM_NOT_VOTED_CANNOT_CANCEL
+    ))),
+
 
     // FEED
     FEED_CREATE(new LinkedHashSet<>(Set.of(

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/roomparticipant/RoomParticipantJpaRepository.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/roomparticipant/RoomParticipantJpaRepository.java
@@ -10,16 +10,22 @@ import java.util.Optional;
 
 public interface RoomParticipantJpaRepository extends JpaRepository<RoomParticipantJpaEntity, Long>, RoomParticipantQueryRepository{
 
-    @Query(value = "SELECT * FROM room_participants WHERE user_id = :userId AND room_id = :roomId AND status = 'ACTIVE'", nativeQuery = true)
+    @Query("SELECT rp FROM RoomParticipantJpaEntity rp " +
+            "WHERE rp.userJpaEntity.userId = :userId " +
+            "AND rp.roomJpaEntity.roomId = :roomId " +
+            "AND rp.status = 'ACTIVE'")
     Optional<RoomParticipantJpaEntity> findByUserIdAndRoomId(@Param("userId") Long userId, @Param("roomId") Long roomId);
 
-    @Query(value = "SELECT * FROM room_participants WHERE room_id = :roomId AND status = 'ACTIVE'", nativeQuery = true)
+    @Query("SELECT rp FROM RoomParticipantJpaEntity rp " +
+            "WHERE rp.roomJpaEntity.roomId = :roomId " +
+            "AND rp.status = 'ACTIVE'")
     List<RoomParticipantJpaEntity> findAllByRoomId(@Param("roomId") Long roomId);
 
-    @Query(
-            value = "SELECT EXISTS (SELECT 1 FROM room_participants rp WHERE rp.user_id = :userId AND rp.room_id = :roomId AND rp.status = 'ACTIVE')",
-            nativeQuery = true
-    )
+    @Query("SELECT CASE WHEN COUNT(rp) > 0 THEN true ELSE false END " +
+            "FROM RoomParticipantJpaEntity rp " +
+            "WHERE rp.userJpaEntity.userId = :userId " +
+            "AND rp.roomJpaEntity.roomId = :roomId " +
+            "AND rp.status = 'ACTIVE'")
     boolean existByUserIdAndRoomId(@Param("userId") Long userId, @Param("roomId") Long roomId);
 
 }

--- a/src/main/java/konkuk/thip/room/application/service/validator/RoomParticipantValidator.java
+++ b/src/main/java/konkuk/thip/room/application/service/validator/RoomParticipantValidator.java
@@ -14,7 +14,7 @@ public class RoomParticipantValidator{
 
     // 사용자가 방에 속해있는지 검증
     public void validateUserIsRoomMember(Long roomId, Long userId) {
-        if (!participantPort.existByUserIdAndRoomId(roomId, userId)) {
+        if (!participantPort.existByUserIdAndRoomId(userId, roomId)) {
             throw new InvalidStateException(ROOM_ACCESS_FORBIDDEN,
                 new IllegalArgumentException("사용자가 이 방의 참가자가 아닙니다. roomId=" + roomId + ", userId=" + userId));
         }

--- a/src/main/java/konkuk/thip/user/domain/User.java
+++ b/src/main/java/konkuk/thip/user/domain/User.java
@@ -44,7 +44,7 @@ public class User extends BaseDomainEntity {
 
     public void decreaseFollowerCount() {
         if(followerCount == 0) {
-            throw new InvalidStateException(ErrorCode.FOLLOW_COUNT_IS_ZERO);
+            throw new InvalidStateException(ErrorCode.FOLLOW_COUNT_CANNOT_BE_NEGATIVE);
         }
         followerCount--;
     }

--- a/src/main/java/konkuk/thip/vote/adapter/in/web/VoteCommandController.java
+++ b/src/main/java/konkuk/thip/vote/adapter/in/web/VoteCommandController.java
@@ -6,14 +6,20 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import konkuk.thip.common.dto.BaseResponse;
 import konkuk.thip.common.security.annotation.UserId;
+import konkuk.thip.common.swagger.annotation.ExceptionDescription;
 import konkuk.thip.vote.adapter.in.web.request.VoteCreateRequest;
+import konkuk.thip.vote.adapter.in.web.request.VoteRequest;
 import konkuk.thip.vote.adapter.in.web.response.VoteCreateResponse;
+import konkuk.thip.vote.adapter.in.web.response.VoteResponse;
 import konkuk.thip.vote.application.port.in.VoteCreateUseCase;
+import konkuk.thip.vote.application.port.in.VoteUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import static konkuk.thip.common.swagger.SwaggerResponseDescription.VOTE;
 
 @Tag(name = "Vote Command API", description = "투표 상태변경 관련 API")
 @RestController
@@ -21,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class VoteCommandController {
 
     private final VoteCreateUseCase voteCreateUseCase;
+    private final VoteUseCase voteUseCase;
 
     @Operation(
             summary = "투표 생성",
@@ -35,5 +42,22 @@ public class VoteCommandController {
         return BaseResponse.ok(VoteCreateResponse.of(
                 voteCreateUseCase.createVote(request.toCommand(userId, roomId))
         ));
+    }
+
+    // 투표하기
+    @Operation(
+            summary = "투표하기",
+            description = "특정 투표에 대해 사용자가 투표를 진행합니다. type이 true이면 투표하기, false이면 투표 취소입니다."
+    )
+    @ExceptionDescription(VOTE)
+    @PostMapping("/rooms/{roomId}/vote/{voteId}")
+    public BaseResponse<VoteResponse> vote(
+            @Parameter(hidden = true) @UserId Long userId,
+            @Parameter(description = "투표를 진행할 방 ID", example = "1") @PathVariable Long roomId,
+            @Parameter(description = "투표할 투표 ID", example = "1") @PathVariable Long voteId,
+            @Valid @RequestBody VoteRequest request) {
+        return BaseResponse.ok(VoteResponse.of(
+                        voteUseCase.vote(request.toCommand(userId, roomId, voteId)))
+        );
     }
 }

--- a/src/main/java/konkuk/thip/vote/adapter/in/web/VoteCommandController.java
+++ b/src/main/java/konkuk/thip/vote/adapter/in/web/VoteCommandController.java
@@ -44,7 +44,6 @@ public class VoteCommandController {
         ));
     }
 
-    // 투표하기
     @Operation(
             summary = "투표하기",
             description = "특정 투표에 대해 사용자가 투표를 진행합니다. type이 true이면 투표하기, false이면 투표 취소입니다."

--- a/src/main/java/konkuk/thip/vote/adapter/in/web/request/VoteRequest.java
+++ b/src/main/java/konkuk/thip/vote/adapter/in/web/request/VoteRequest.java
@@ -1,6 +1,7 @@
 package konkuk.thip.vote.adapter.in.web.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import konkuk.thip.vote.application.service.dto.VoteCommand;
 
 @Schema(
@@ -11,11 +12,13 @@ public record VoteRequest(
                 description = "투표하려는 투표 항목 ID",
                 example = "1"
         )
+        @NotNull(message = "voteItemId는 필수입니다.")
         Long voteItemId,
         @Schema(
                 description = "투표 유형 (true: 투표하기, false: 투표 취소하기)",
                 example = "true"
         )
+        @NotNull(message = "type은 필수입니다.")
         Boolean type
 ) {
     public VoteCommand toCommand(Long userId, Long roomId, Long voteId) {

--- a/src/main/java/konkuk/thip/vote/adapter/in/web/request/VoteRequest.java
+++ b/src/main/java/konkuk/thip/vote/adapter/in/web/request/VoteRequest.java
@@ -1,0 +1,24 @@
+package konkuk.thip.vote.adapter.in.web.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import konkuk.thip.vote.application.service.dto.VoteCommand;
+
+@Schema(
+        description = "투표하기 요청 DTO 정보"
+)
+public record VoteRequest(
+        @Schema(
+                description = "투표하려는 투표 항목 ID",
+                example = "1"
+        )
+        Long voteItemId,
+        @Schema(
+                description = "투표 유형 (true: 투표하기, false: 투표 취소하기)",
+                example = "true"
+        )
+        Boolean type
+) {
+    public VoteCommand toCommand(Long userId, Long roomId, Long voteId) {
+        return new VoteCommand(userId, roomId, voteId, voteItemId, type);
+    }
+}

--- a/src/main/java/konkuk/thip/vote/adapter/in/web/response/VoteResponse.java
+++ b/src/main/java/konkuk/thip/vote/adapter/in/web/response/VoteResponse.java
@@ -1,0 +1,13 @@
+package konkuk.thip.vote.adapter.in.web.response;
+
+import konkuk.thip.vote.application.service.dto.VoteResult;
+
+public record VoteResponse(
+        Long voteItemId,
+        Long roomId,
+        Boolean type
+) {
+    public static VoteResponse of(VoteResult voteResult) {
+        return new VoteResponse(voteResult.voteItemId(), voteResult.roomId(), voteResult.type());
+    }
+}

--- a/src/main/java/konkuk/thip/vote/adapter/out/jpa/VoteItemJpaEntity.java
+++ b/src/main/java/konkuk/thip/vote/adapter/out/jpa/VoteItemJpaEntity.java
@@ -2,6 +2,7 @@ package konkuk.thip.vote.adapter.out.jpa;
 
 import jakarta.persistence.*;
 import konkuk.thip.common.entity.BaseJpaEntity;
+import konkuk.thip.vote.domain.VoteItem;
 import lombok.*;
 
 @Entity
@@ -28,4 +29,9 @@ public class VoteItemJpaEntity extends BaseJpaEntity {
     @JoinColumn(name = "post_id")
     private VoteJpaEntity voteJpaEntity;
 
+    public VoteItemJpaEntity updateFrom(VoteItem voteItem) {
+        this.itemName = voteItem.getItemName();
+        this.count = voteItem.getCount();
+        return this;
+    }
 }

--- a/src/main/java/konkuk/thip/vote/adapter/out/jpa/VoteParticipantJpaEntity.java
+++ b/src/main/java/konkuk/thip/vote/adapter/out/jpa/VoteParticipantJpaEntity.java
@@ -26,4 +26,9 @@ public class VoteParticipantJpaEntity extends BaseJpaEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "vote_item_id")
     private VoteItemJpaEntity voteItemJpaEntity;
+
+    public VoteParticipantJpaEntity updateVoteItem(VoteItemJpaEntity voteItemJpaEntity) {
+        this.voteItemJpaEntity = voteItemJpaEntity;
+        return this;
+    }
 }

--- a/src/main/java/konkuk/thip/vote/adapter/out/persistence/VoteCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/vote/adapter/out/persistence/VoteCommandPersistenceAdapter.java
@@ -76,6 +76,12 @@ public class VoteCommandPersistenceAdapter implements VoteCommandPort {
     }
 
     @Override
+    public Optional<VoteItem> findVoteItemById(Long id) {
+        return voteItemJpaRepository.findById(id)
+                .map(voteItemMapper::toDomainEntity);
+    }
+
+    @Override
     public Optional<VoteParticipant> findVoteParticipantByUserIdAndVoteId(Long userId, Long voteId) {
         return voteParticipantJpaRepository.findVoteParticipantByUserIdAndVoteId(userId, voteId)
                 .map(voteParticipantMapper::toDomainEntity);
@@ -88,7 +94,7 @@ public class VoteCommandPersistenceAdapter implements VoteCommandPort {
     }
 
     @Override
-    public void updateVoteItemFromVoteParticipant(VoteParticipant voteParticipant) {
+    public void updateVoteParticipant(VoteParticipant voteParticipant) {
         VoteParticipantJpaEntity voteParticipantJpaEntity = voteParticipantJpaRepository.findById(voteParticipant.getId()).orElseThrow(
                 () -> new EntityNotFoundException(VOTE_PARTICIPANT_NOT_FOUND)
         );
@@ -118,6 +124,15 @@ public class VoteCommandPersistenceAdapter implements VoteCommandPort {
     public void deleteVoteParticipant(VoteParticipant voteParticipant) {
         // 앞에서 이미 존재 여부를 확인했으므로, 여기서는 ID로 삭제
         voteParticipantJpaRepository.deleteById(voteParticipant.getId());
+    }
+
+    @Override
+    public void updateVoteItem(VoteItem voteItem) {
+        VoteItemJpaEntity voteItemJpaEntity = voteItemJpaRepository.findById(voteItem.getId()).orElseThrow(
+                () -> new EntityNotFoundException(VOTE_ITEM_NOT_FOUND)
+        );
+
+        voteItemJpaRepository.save(voteItemJpaEntity.updateFrom(voteItem));
     }
 
 

--- a/src/main/java/konkuk/thip/vote/adapter/out/persistence/VoteCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/vote/adapter/out/persistence/VoteCommandPersistenceAdapter.java
@@ -7,13 +7,17 @@ import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
 import konkuk.thip.vote.adapter.out.jpa.VoteItemJpaEntity;
 import konkuk.thip.vote.adapter.out.jpa.VoteJpaEntity;
+import konkuk.thip.vote.adapter.out.jpa.VoteParticipantJpaEntity;
 import konkuk.thip.vote.adapter.out.mapper.VoteItemMapper;
 import konkuk.thip.vote.adapter.out.mapper.VoteMapper;
+import konkuk.thip.vote.adapter.out.mapper.VoteParticipantMapper;
 import konkuk.thip.vote.adapter.out.persistence.repository.VoteItemJpaRepository;
 import konkuk.thip.vote.adapter.out.persistence.repository.VoteJpaRepository;
+import konkuk.thip.vote.adapter.out.persistence.repository.VoteParticipantJpaRepository;
 import konkuk.thip.vote.application.port.out.VoteCommandPort;
 import konkuk.thip.vote.domain.Vote;
 import konkuk.thip.vote.domain.VoteItem;
+import konkuk.thip.vote.domain.VoteParticipant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -30,9 +34,11 @@ public class VoteCommandPersistenceAdapter implements VoteCommandPort {
     private final VoteItemJpaRepository voteItemJpaRepository;
     private final UserJpaRepository userJpaRepository;
     private final RoomJpaRepository roomJpaRepository;
+    private final VoteParticipantJpaRepository voteParticipantJpaRepository;
 
     private final VoteMapper voteMapper;
     private final VoteItemMapper voteItemMapper;
+    private final VoteParticipantMapper voteParticipantMapper;
 
     @Override
     public Long saveVote(Vote vote) {
@@ -67,6 +73,51 @@ public class VoteCommandPersistenceAdapter implements VoteCommandPort {
     public Optional<Vote> findById(Long id) {
         return voteJpaRepository.findById(id)
                 .map(voteMapper::toDomainEntity);
+    }
+
+    @Override
+    public Optional<VoteParticipant> findVoteParticipantByUserIdAndVoteId(Long userId, Long voteId) {
+        return voteParticipantJpaRepository.findVoteParticipantByUserIdAndVoteId(userId, voteId)
+                .map(voteParticipantMapper::toDomainEntity);
+    }
+
+    @Override
+    public Optional<VoteParticipant> findVoteParticipantByUserIdAndVoteItemId(Long userId, Long voteItemId) {
+        return voteParticipantJpaRepository.findVoteParticipantByUserIdAndVoteItemId(userId, voteItemId)
+                .map(voteParticipantMapper::toDomainEntity);
+    }
+
+    @Override
+    public void updateVoteItemFromVoteParticipant(VoteParticipant voteParticipant) {
+        VoteParticipantJpaEntity voteParticipantJpaEntity = voteParticipantJpaRepository.findById(voteParticipant.getId()).orElseThrow(
+                () -> new EntityNotFoundException(VOTE_PARTICIPANT_NOT_FOUND)
+        );
+
+        VoteItemJpaEntity voteItemJpaEntity = voteItemJpaRepository.findById(voteParticipant.getVoteItemId()).orElseThrow(
+                () -> new EntityNotFoundException(VOTE_ITEM_NOT_FOUND)
+        );
+
+        voteParticipantJpaRepository.save(voteParticipantJpaEntity.updateVoteItem(voteItemJpaEntity));
+    }
+
+    @Override
+    public void saveVoteParticipant(VoteParticipant voteParticipant) {
+        UserJpaEntity userJpaEntity = userJpaRepository.findById(voteParticipant.getUserId()).orElseThrow(
+                () -> new EntityNotFoundException(USER_NOT_FOUND)
+        );
+
+        VoteItemJpaEntity voteItemJpaEntity = voteItemJpaRepository.findById(voteParticipant.getVoteItemId()).orElseThrow(
+                () -> new EntityNotFoundException(VOTE_ITEM_NOT_FOUND)
+        );
+
+        VoteParticipantJpaEntity voteParticipantJpaEntity = voteParticipantMapper.toJpaEntity(userJpaEntity, voteItemJpaEntity);
+        voteParticipantJpaRepository.save(voteParticipantJpaEntity);
+    }
+
+    @Override
+    public void deleteVoteParticipant(VoteParticipant voteParticipant) {
+        // 앞에서 이미 존재 여부를 확인했으므로, 여기서는 ID로 삭제
+        voteParticipantJpaRepository.deleteById(voteParticipant.getId());
     }
 
 

--- a/src/main/java/konkuk/thip/vote/adapter/out/persistence/repository/VoteParticipantJpaRepository.java
+++ b/src/main/java/konkuk/thip/vote/adapter/out/persistence/repository/VoteParticipantJpaRepository.java
@@ -2,7 +2,13 @@ package konkuk.thip.vote.adapter.out.persistence.repository;
 
 import konkuk.thip.vote.adapter.out.jpa.VoteParticipantJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
-public interface VoteParticipantJpaRepository extends JpaRepository<VoteParticipantJpaEntity, Long> {
-    boolean existsByUserJpaEntity_UserIdAndVoteItemJpaEntity_VoteItemId(Long userId, Long voteItemId);
+import java.util.Optional;
+
+@Repository
+public interface VoteParticipantJpaRepository extends JpaRepository<VoteParticipantJpaEntity, Long>, VoteParticipantQueryRepository {
+    @Query("SELECT vp FROM VoteParticipantJpaEntity vp WHERE vp.userJpaEntity.userId = :userId AND vp.voteItemJpaEntity.voteItemId = :voteItemId")
+    Optional<VoteParticipantJpaEntity> findVoteParticipantByUserIdAndVoteItemId(Long userId, Long voteItemId);
 }

--- a/src/main/java/konkuk/thip/vote/adapter/out/persistence/repository/VoteParticipantQueryRepository.java
+++ b/src/main/java/konkuk/thip/vote/adapter/out/persistence/repository/VoteParticipantQueryRepository.java
@@ -1,0 +1,10 @@
+package konkuk.thip.vote.adapter.out.persistence.repository;
+
+import konkuk.thip.vote.adapter.out.jpa.VoteParticipantJpaEntity;
+
+import java.util.Optional;
+
+public interface VoteParticipantQueryRepository {
+
+    Optional<VoteParticipantJpaEntity> findVoteParticipantByUserIdAndVoteId(Long userId, Long voteId);
+}

--- a/src/main/java/konkuk/thip/vote/adapter/out/persistence/repository/VoteParticipantQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/vote/adapter/out/persistence/repository/VoteParticipantQueryRepositoryImpl.java
@@ -1,0 +1,42 @@
+package konkuk.thip.vote.adapter.out.persistence.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import konkuk.thip.vote.adapter.out.jpa.QVoteItemJpaEntity;
+import konkuk.thip.vote.adapter.out.jpa.QVoteJpaEntity;
+import konkuk.thip.vote.adapter.out.jpa.QVoteParticipantJpaEntity;
+import konkuk.thip.vote.adapter.out.jpa.VoteParticipantJpaEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+import static konkuk.thip.common.entity.StatusType.ACTIVE;
+
+@Repository
+@RequiredArgsConstructor
+public class VoteParticipantQueryRepositoryImpl implements VoteParticipantQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    private final QVoteParticipantJpaEntity voteParticipant = QVoteParticipantJpaEntity.voteParticipantJpaEntity;
+    private final QVoteItemJpaEntity voteItem = QVoteItemJpaEntity.voteItemJpaEntity;
+    private final QVoteJpaEntity vote = QVoteJpaEntity.voteJpaEntity;
+
+    /**
+     * 사용자가 해당 투표에서 어떤 투표 항목에 투표했는지 확인하는 쿼리
+     */
+    @Override
+    public Optional<VoteParticipantJpaEntity> findVoteParticipantByUserIdAndVoteId(Long userId, Long voteId) {
+        return Optional.ofNullable(jpaQueryFactory
+                .selectFrom(voteParticipant)
+                .join(voteParticipant.voteItemJpaEntity, voteItem).fetchJoin()
+                .join(voteItem.voteJpaEntity, vote).fetchJoin()
+                .where(
+                        voteParticipant.userJpaEntity.userId.eq(userId),
+                        vote.postId.eq(voteId),
+                        vote.status.eq(ACTIVE)
+                )
+                .fetchOne());
+
+    }
+}

--- a/src/main/java/konkuk/thip/vote/application/port/in/VoteUseCase.java
+++ b/src/main/java/konkuk/thip/vote/application/port/in/VoteUseCase.java
@@ -1,0 +1,8 @@
+package konkuk.thip.vote.application.port.in;
+
+import konkuk.thip.vote.application.service.dto.VoteCommand;
+import konkuk.thip.vote.application.service.dto.VoteResult;
+
+public interface VoteUseCase {
+    VoteResult vote(VoteCommand command);
+}

--- a/src/main/java/konkuk/thip/vote/application/port/out/VoteCommandPort.java
+++ b/src/main/java/konkuk/thip/vote/application/port/out/VoteCommandPort.java
@@ -25,13 +25,22 @@ public interface VoteCommandPort {
                 .orElseThrow(() -> new EntityNotFoundException(VOTE_NOT_FOUND));
     }
 
+    Optional<VoteItem> findVoteItemById(Long id);
+
+    default VoteItem getVoteItemByIdOrThrow(Long id) {
+        return findVoteItemById(id)
+                .orElseThrow(() -> new EntityNotFoundException(VOTE_NOT_FOUND));
+    }
+
     Optional<VoteParticipant> findVoteParticipantByUserIdAndVoteId(Long userId, Long voteId);
 
     Optional<VoteParticipant> findVoteParticipantByUserIdAndVoteItemId(Long userId, Long voteItemId);
 
-    void updateVoteItemFromVoteParticipant(VoteParticipant voteParticipant);
+    void updateVoteParticipant(VoteParticipant voteParticipant);
 
     void saveVoteParticipant(VoteParticipant voteParticipant);
 
     void deleteVoteParticipant(VoteParticipant voteParticipant);
+
+    void updateVoteItem(VoteItem voteItem);
 }

--- a/src/main/java/konkuk/thip/vote/application/port/out/VoteCommandPort.java
+++ b/src/main/java/konkuk/thip/vote/application/port/out/VoteCommandPort.java
@@ -3,6 +3,7 @@ package konkuk.thip.vote.application.port.out;
 import konkuk.thip.common.exception.EntityNotFoundException;
 import konkuk.thip.vote.domain.Vote;
 import konkuk.thip.vote.domain.VoteItem;
+import konkuk.thip.vote.domain.VoteParticipant;
 
 import java.util.List;
 import java.util.Optional;
@@ -23,4 +24,14 @@ public interface VoteCommandPort {
         return findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(VOTE_NOT_FOUND));
     }
+
+    Optional<VoteParticipant> findVoteParticipantByUserIdAndVoteId(Long userId, Long voteId);
+
+    Optional<VoteParticipant> findVoteParticipantByUserIdAndVoteItemId(Long userId, Long voteItemId);
+
+    void updateVoteItemFromVoteParticipant(VoteParticipant voteParticipant);
+
+    void saveVoteParticipant(VoteParticipant voteParticipant);
+
+    void deleteVoteParticipant(VoteParticipant voteParticipant);
 }

--- a/src/main/java/konkuk/thip/vote/application/service/VoteService.java
+++ b/src/main/java/konkuk/thip/vote/application/service/VoteService.java
@@ -9,10 +9,8 @@ import konkuk.thip.vote.application.service.dto.VoteCommand;
 import konkuk.thip.vote.application.service.dto.VoteResult;
 import konkuk.thip.vote.domain.VoteParticipant;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class VoteService implements VoteUseCase {
@@ -23,16 +21,14 @@ public class VoteService implements VoteUseCase {
 
     @Override
     public VoteResult vote(VoteCommand command) {
-        log.info("VoteService.vote() - userId: {}, roomId: {}, voteId: {}, voteItemId: {}, type: {}",
-                command.userId(), command.roomId(), command.voteId(), command.voteItemId(), command.type());
         // 1. 방 참가자 검증
         roomParticipantValidator.validateUserIsRoomMember(command.roomId(), command.userId());
 
         if (command.type()) {
-            // 2. 투표 아이템에 투표하기
+            // 투표하기
             handleVote(command.userId(), command.voteId(), command.voteItemId());
         } else {
-            // 2. 투표 아이템에 투표 취소하기
+            // 투표 취소하기
             handleVoteCancel(command);
         }
 

--- a/src/main/java/konkuk/thip/vote/application/service/VoteService.java
+++ b/src/main/java/konkuk/thip/vote/application/service/VoteService.java
@@ -36,7 +36,7 @@ public class VoteService implements VoteUseCase {
     }
 
     private void voteOrUpdate(Long userId, Long voteId, Long voteItemId) {
-        // 사용자가 해당 투표 항목에 참여했는지 확인
+        // 사용자가 해당 투표에 참여했는지 확인
         voteCommandPort.findVoteParticipantByUserIdAndVoteId(userId, voteId)
                 .ifPresentOrElse(
                         // 투표를 이미 한 경우

--- a/src/main/java/konkuk/thip/vote/application/service/VoteService.java
+++ b/src/main/java/konkuk/thip/vote/application/service/VoteService.java
@@ -1,0 +1,68 @@
+package konkuk.thip.vote.application.service;
+
+import konkuk.thip.common.exception.BusinessException;
+import konkuk.thip.common.exception.code.ErrorCode;
+import konkuk.thip.room.application.service.validator.RoomParticipantValidator;
+import konkuk.thip.vote.application.port.in.VoteUseCase;
+import konkuk.thip.vote.application.port.out.VoteCommandPort;
+import konkuk.thip.vote.application.service.dto.VoteCommand;
+import konkuk.thip.vote.application.service.dto.VoteResult;
+import konkuk.thip.vote.domain.VoteParticipant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VoteService implements VoteUseCase {
+
+    private final VoteCommandPort voteCommandPort;
+
+    private final RoomParticipantValidator roomParticipantValidator;
+
+    @Override
+    public VoteResult vote(VoteCommand command) {
+        log.info("VoteService.vote() - userId: {}, roomId: {}, voteId: {}, voteItemId: {}, type: {}",
+                command.userId(), command.roomId(), command.voteId(), command.voteItemId(), command.type());
+        // 1. 방 참가자 검증
+        roomParticipantValidator.validateUserIsRoomMember(command.roomId(), command.userId());
+
+        if (command.type()) {
+            // 2. 투표 아이템에 투표하기
+            handleVote(command.userId(), command.voteId(), command.voteItemId());
+        } else {
+            // 2. 투표 아이템에 투표 취소하기
+            handleVoteCancel(command);
+        }
+
+        return VoteResult.of(command.voteItemId(), command.roomId(), command.type());
+    }
+
+    private void handleVote(Long userId, Long voteId, Long voteItemId) {
+        //
+        voteCommandPort.findVoteParticipantByUserIdAndVoteId(userId, voteId)
+            .ifPresentOrElse(
+                    voteParticipant -> { // 이미 투표를 했던 적이 있는 경우
+                        voteParticipant.changeVoteItem(voteItemId);
+                        voteCommandPort.updateVoteItemFromVoteParticipant(voteParticipant);
+                    },
+                    () -> {  // 투표를 처음 하는 경우
+                        voteCommandPort.saveVoteParticipant(VoteParticipant.withoutId(userId, voteItemId));
+                    }
+            );
+    }
+
+    private void handleVoteCancel(VoteCommand command) {
+        // 사용자가 해당 투표 항목에 참여했는지 확인
+        voteCommandPort.findVoteParticipantByUserIdAndVoteItemId(command.userId(), command.voteItemId())
+            .ifPresentOrElse(
+                    // 투표 항목을 변경하여 투표 취소
+                    voteCommandPort::deleteVoteParticipant,
+                    () -> {
+                        // 투표를 하지 않은 경우 예외 처리
+                        throw new BusinessException(ErrorCode.VOTE_ITEM_NOT_VOTED_CANNOT_CANCEL);
+                    }
+            );
+    }
+}

--- a/src/main/java/konkuk/thip/vote/application/service/VoteService.java
+++ b/src/main/java/konkuk/thip/vote/application/service/VoteService.java
@@ -65,16 +65,16 @@ public class VoteService implements VoteUseCase {
     }
 
     private void createVote(Long userId, Long voteItemId) {
-        modifyVoteCount(voteItemId, true);
+        updateVoteCount(voteItemId, true);
         voteCommandPort.saveVoteParticipant(VoteParticipant.withoutId(userId, voteItemId));
     }
 
     private void removeVote(VoteParticipant participant, Long voteItemId) {
-        modifyVoteCount(voteItemId, false);
+        updateVoteCount(voteItemId, false);
         voteCommandPort.deleteVoteParticipant(participant);
     }
 
-    private void modifyVoteCount(Long voteItemId, boolean isIncrease) {
+    private void updateVoteCount(Long voteItemId, boolean isIncrease) {
         VoteItem voteItem = voteCommandPort.getVoteItemByIdOrThrow(voteItemId);
         if (isIncrease) {
             voteItem.increaseCount();

--- a/src/main/java/konkuk/thip/vote/application/service/dto/VoteCommand.java
+++ b/src/main/java/konkuk/thip/vote/application/service/dto/VoteCommand.java
@@ -1,0 +1,10 @@
+package konkuk.thip.vote.application.service.dto;
+
+public record VoteCommand(
+        Long userId,
+        Long roomId,
+        Long voteId,
+        Long voteItemId,
+        Boolean type
+) {
+}

--- a/src/main/java/konkuk/thip/vote/application/service/dto/VoteResult.java
+++ b/src/main/java/konkuk/thip/vote/application/service/dto/VoteResult.java
@@ -1,0 +1,11 @@
+package konkuk.thip.vote.application.service.dto;
+
+public record VoteResult(
+        Long voteItemId,
+        Long roomId,
+        Boolean type
+) {
+    public static VoteResult of(Long voteItemId, Long roomId, Boolean type) {
+        return new VoteResult(voteItemId, roomId, type);
+    }
+}

--- a/src/main/java/konkuk/thip/vote/domain/VoteItem.java
+++ b/src/main/java/konkuk/thip/vote/domain/VoteItem.java
@@ -1,6 +1,8 @@
 package konkuk.thip.vote.domain;
 
 import konkuk.thip.common.entity.BaseDomainEntity;
+import konkuk.thip.common.exception.InvalidStateException;
+import konkuk.thip.common.exception.code.ErrorCode;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
@@ -73,5 +75,16 @@ public class VoteItem extends BaseDomainEntity {
         }
 
         return result;
+    }
+
+    public void increaseCount() {
+        this.count++;
+    }
+
+    public void decreaseCount() {
+        if(this.count == 0) {
+            throw new InvalidStateException(ErrorCode.VOTE_ITEM_COUNT_CANNOT_BE_NEGATIVE);
+        }
+        this.count--;
     }
 }

--- a/src/main/java/konkuk/thip/vote/domain/VoteParticipant.java
+++ b/src/main/java/konkuk/thip/vote/domain/VoteParticipant.java
@@ -1,6 +1,8 @@
 package konkuk.thip.vote.domain;
 
 import konkuk.thip.common.entity.BaseDomainEntity;
+import konkuk.thip.common.exception.InvalidStateException;
+import konkuk.thip.common.exception.code.ErrorCode;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
@@ -13,4 +15,21 @@ public class VoteParticipant extends BaseDomainEntity {
     private Long userId;
 
     private Long voteItemId;
+
+    public static VoteParticipant withoutId(Long userId, Long voteItemId) {
+        return VoteParticipant.builder()
+                .id(null)
+                .userId(userId)
+                .voteItemId(voteItemId)
+                .build();
+    }
+
+    public void changeVoteItem(Long voteItemId) {
+        // 같은 항목을 투표하려고 하는 경우 예외처리
+        if(this.voteItemId.equals(voteItemId)) {
+            throw new InvalidStateException(ErrorCode.VOTE_ITEM_ALREADY_VOTED);
+        }
+        // 투표 항목 변경
+        this.voteItemId = voteItemId;
+    }
 }

--- a/src/test/java/konkuk/thip/common/util/TestEntityFactory.java
+++ b/src/test/java/konkuk/thip/common/util/TestEntityFactory.java
@@ -21,7 +21,9 @@ import konkuk.thip.user.adapter.out.jpa.FollowingJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.UserRole;
 import konkuk.thip.user.domain.Alias;
+import konkuk.thip.vote.adapter.out.jpa.VoteItemJpaEntity;
 import konkuk.thip.vote.adapter.out.jpa.VoteJpaEntity;
+import konkuk.thip.vote.adapter.out.jpa.VoteParticipantJpaEntity;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -290,6 +292,13 @@ public class TestEntityFactory {
         return SavedFeedJpaEntity.builder()
                 .feedJpaEntity(feed)
                 .userJpaEntity(user)
+                .build();
+    }
+
+    public static VoteParticipantJpaEntity createVoteParticipant(UserJpaEntity user, VoteItemJpaEntity item) {
+        return VoteParticipantJpaEntity.builder()
+                .userJpaEntity(user)
+                .voteItemJpaEntity(item)
                 .build();
     }
 }

--- a/src/test/java/konkuk/thip/vote/adapter/in/web/VoteApiTest.java
+++ b/src/test/java/konkuk/thip/vote/adapter/in/web/VoteApiTest.java
@@ -1,0 +1,209 @@
+package konkuk.thip.vote.adapter.in.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.adapter.out.persistence.repository.BookJpaRepository;
+import konkuk.thip.common.util.TestEntityFactory;
+import konkuk.thip.room.adapter.out.jpa.CategoryJpaEntity;
+import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
+import konkuk.thip.room.adapter.out.jpa.RoomParticipantRole;
+import konkuk.thip.room.adapter.out.persistence.repository.RoomJpaRepository;
+import konkuk.thip.room.adapter.out.persistence.repository.category.CategoryJpaRepository;
+import konkuk.thip.room.adapter.out.persistence.repository.roomparticipant.RoomParticipantJpaRepository;
+import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.repository.alias.AliasJpaRepository;
+import konkuk.thip.vote.adapter.in.web.request.VoteRequest;
+import konkuk.thip.vote.adapter.out.jpa.VoteItemJpaEntity;
+import konkuk.thip.vote.adapter.out.jpa.VoteJpaEntity;
+import konkuk.thip.vote.adapter.out.persistence.repository.VoteItemJpaRepository;
+import konkuk.thip.vote.adapter.out.persistence.repository.VoteJpaRepository;
+import konkuk.thip.vote.adapter.out.persistence.repository.VoteParticipantJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static konkuk.thip.common.exception.code.ErrorCode.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+@Transactional
+@DisplayName("[통합] 투표하기 API 통합 테스트")
+class VoteApiTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private AliasJpaRepository aliasJpaRepository;
+    @Autowired private UserJpaRepository userJpaRepository;
+    @Autowired private CategoryJpaRepository categoryJpaRepository;
+    @Autowired private RoomJpaRepository roomJpaRepository;
+    @Autowired private RoomParticipantJpaRepository roomParticipantJpaRepository;
+    @Autowired private VoteJpaRepository voteJpaRepository;
+    @Autowired private VoteItemJpaRepository voteItemJpaRepository;
+    @Autowired private VoteParticipantJpaRepository voteParticipantJpaRepository;
+
+    private AliasJpaEntity alias;
+    private UserJpaEntity user;
+    private CategoryJpaEntity category;
+    private RoomJpaEntity room;
+    private VoteJpaEntity vote;
+    @Autowired
+    private BookJpaRepository bookJpaRepository;
+
+    @BeforeEach
+    void setUp() {
+        alias = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        user = userJpaRepository.save(TestEntityFactory.createUser(alias));
+        category = categoryJpaRepository.save(TestEntityFactory.createScienceCategory(alias));
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBook());
+        room = roomJpaRepository.save(TestEntityFactory.createRoom(book, category));
+        vote = voteJpaRepository.save(TestEntityFactory.createVote(user, room));
+        roomParticipantJpaRepository.save(TestEntityFactory.createRoomParticipant(room, user, RoomParticipantRole.MEMBER, 0));
+    }
+
+    @Test
+    @DisplayName("처음 투표 성공")
+    void vote_first_success() throws Exception {
+        VoteItemJpaEntity item = voteItemJpaRepository.save(
+                VoteItemJpaEntity.builder()
+                        .itemName("항목1")
+                        .count(0)
+                        .voteJpaEntity(vote)
+                        .build()
+        );
+
+        VoteRequest request = new VoteRequest(item.getVoteItemId(), true);
+
+        mockMvc.perform(post("/rooms/{roomId}/vote/{voteId}", room.getRoomId(), vote.getPostId())
+                        .requestAttr("userId", user.getUserId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        assertThat(voteParticipantJpaRepository.findAll())
+                .hasSize(1)
+                .allMatch(vp -> vp.getVoteItemJpaEntity().getVoteItemId().equals(item.getVoteItemId()));
+
+        voteItemJpaRepository.findById(item.getVoteItemId())
+                .ifPresent(voteItem -> assertThat(voteItem.getCount()).isEqualTo(1));
+    }
+
+    @Test
+    @DisplayName("이미 투표한 경우 다른 항목으로 변경 성공")
+    void vote_alreadyVoted_change_success() throws Exception {
+        VoteItemJpaEntity item1 = voteItemJpaRepository.save(
+                VoteItemJpaEntity.builder().itemName("항목1").count(0).voteJpaEntity(vote).build()
+        );
+        VoteItemJpaEntity item2 = voteItemJpaRepository.save(
+                VoteItemJpaEntity.builder().itemName("항목2").count(0).voteJpaEntity(vote).build()
+        );
+
+        voteParticipantJpaRepository.save(
+                TestEntityFactory.createVoteParticipant(user, item1)
+        );
+
+        VoteRequest request = new VoteRequest(item2.getVoteItemId(), true);
+
+        mockMvc.perform(post("/rooms/{roomId}/vote/{voteId}", room.getRoomId(), vote.getPostId())
+                        .requestAttr("userId", user.getUserId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        assertThat(voteParticipantJpaRepository.findAll())
+                .hasSize(1)
+                .allMatch(vp -> vp.getVoteItemJpaEntity().getVoteItemId().equals(item2.getVoteItemId()));
+
+        voteItemJpaRepository.findById(item1.getVoteItemId())
+                .ifPresent(voteItem -> assertThat(voteItem.getCount()).isEqualTo(0));
+    }
+
+    @Test
+    @DisplayName("같은 항목으로 다시 투표 시 예외")
+    void vote_alreadyVoted_same_fail() throws Exception {
+        VoteItemJpaEntity item1 = voteItemJpaRepository.save(
+                VoteItemJpaEntity.builder().itemName("항목1").count(0).voteJpaEntity(vote).build()
+        );
+
+        voteParticipantJpaRepository.save(TestEntityFactory.createVoteParticipant(user, item1));
+
+        VoteRequest request = new VoteRequest(item1.getVoteItemId(), true);
+
+        mockMvc.perform(post("/rooms/{roomId}/vote/{voteId}", room.getRoomId(), vote.getPostId())
+                        .requestAttr("userId", user.getUserId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(VOTE_ITEM_ALREADY_VOTED.getCode()));
+    }
+
+    @Test
+    @DisplayName("투표 취소 성공")
+    void vote_cancel_success() throws Exception {
+        VoteItemJpaEntity item = voteItemJpaRepository.save(
+                VoteItemJpaEntity.builder().itemName("항목1").count(1).voteJpaEntity(vote).build()
+        );
+
+        voteParticipantJpaRepository.save(TestEntityFactory.createVoteParticipant(user, item));
+
+        VoteRequest request = new VoteRequest(item.getVoteItemId(), false);
+
+        mockMvc.perform(post("/rooms/{roomId}/vote/{voteId}", room.getRoomId(), vote.getPostId())
+                        .requestAttr("userId", user.getUserId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        assertThat(voteParticipantJpaRepository.findAll()).isEmpty();
+        voteItemJpaRepository.findById(item.getVoteItemId())
+                .ifPresent(voteItem -> assertThat(voteItem.getCount()).isEqualTo(0));
+    }
+
+    @Test
+    @DisplayName("투표 취소 실패 - 기존 투표 기록 없음")
+    void vote_cancel_withoutVote_fail() throws Exception {
+        VoteItemJpaEntity item = voteItemJpaRepository.save(
+                VoteItemJpaEntity.builder().itemName("항목1").count(0).voteJpaEntity(vote).build()
+        );
+
+        VoteRequest request = new VoteRequest(item.getVoteItemId(), false);
+
+        mockMvc.perform(post("/rooms/{roomId}/vote/{voteId}", room.getRoomId(), vote.getPostId())
+                        .requestAttr("userId", user.getUserId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(VOTE_ITEM_NOT_VOTED_CANNOT_CANCEL.getCode()));
+    }
+
+    @Test
+    @DisplayName("방에 속하지 않은 사용자가 투표 시 예외")
+    void vote_userNotRoomMember_fail() throws Exception {
+        UserJpaEntity outsider = userJpaRepository.save(TestEntityFactory.createUser(alias));
+        VoteItemJpaEntity item = voteItemJpaRepository.save(
+                VoteItemJpaEntity.builder().itemName("항목1").count(0).voteJpaEntity(vote).build()
+        );
+
+        VoteRequest request = new VoteRequest(item.getVoteItemId(), true);
+
+        mockMvc.perform(post("/rooms/{roomId}/vote/{voteId}", room.getRoomId(), vote.getPostId())
+                        .requestAttr("userId", outsider.getUserId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(ROOM_ACCESS_FORBIDDEN.getCode()));
+    }
+}

--- a/src/test/java/konkuk/thip/vote/application/service/VoteServiceTest.java
+++ b/src/test/java/konkuk/thip/vote/application/service/VoteServiceTest.java
@@ -1,0 +1,113 @@
+package konkuk.thip.vote.application.service;
+
+import konkuk.thip.common.exception.BusinessException;
+import konkuk.thip.common.exception.InvalidStateException;
+import konkuk.thip.common.exception.code.ErrorCode;
+import konkuk.thip.room.application.service.validator.RoomParticipantValidator;
+import konkuk.thip.vote.application.port.out.VoteCommandPort;
+import konkuk.thip.vote.application.service.dto.VoteCommand;
+import konkuk.thip.vote.application.service.dto.VoteResult;
+import konkuk.thip.vote.domain.VoteParticipant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+class VoteServiceTest {
+
+    private VoteCommandPort voteCommandPort;
+    private RoomParticipantValidator roomParticipantValidator;
+    private VoteService voteService;
+
+    @BeforeEach
+    void setUp() {
+        voteCommandPort = mock(VoteCommandPort.class);
+        roomParticipantValidator = mock(RoomParticipantValidator.class);
+        voteService = new VoteService(voteCommandPort, roomParticipantValidator);
+    }
+
+    @Test
+    @DisplayName("처음 투표하는 경우 - 새로운 VoteParticipant 저장")
+    void vote_firstTimeVote_success() {
+        // given
+        VoteCommand command = new VoteCommand(1L, 1L, 1L, 100L, true);
+        when(voteCommandPort.findVoteParticipantByUserIdAndVoteId(1L, 1L))
+                .thenReturn(Optional.empty());
+
+        // when
+        VoteResult result = voteService.vote(command);
+
+        // then
+        assertThat(result.voteItemId()).isEqualTo(100L);
+        verify(roomParticipantValidator).validateUserIsRoomMember(1L, 1L);
+        verify(voteCommandPort).saveVoteParticipant(any(VoteParticipant.class));
+    }
+
+    @Test
+    @DisplayName("이미 투표한 경우 - 다른 voteItemId로 변경 성공")
+    void vote_alreadyVoted_changeVoteItem_success() {
+        // given
+        VoteCommand command = new VoteCommand(1L, 1L, 1L, 200L, true);
+        VoteParticipant existing = VoteParticipant.withoutId(1L, 100L);
+        when(voteCommandPort.findVoteParticipantByUserIdAndVoteId(1L, 1L))
+                .thenReturn(Optional.of(existing));
+
+        // when
+        VoteResult result = voteService.vote(command);
+
+        // then
+        assertThat(result.voteItemId()).isEqualTo(200L);
+        verify(voteCommandPort).updateVoteItemFromVoteParticipant(existing);
+    }
+
+    @Test
+    @DisplayName("이미 투표한 경우 - 같은 voteItemId로 변경 시 예외 발생")
+    void vote_alreadyVoted_sameVoteItem_throwsException() {
+        // given
+        VoteCommand command = new VoteCommand(1L, 1L, 1L, 100L, true);
+        VoteParticipant existing = VoteParticipant.withoutId(1L, 100L);
+        when(voteCommandPort.findVoteParticipantByUserIdAndVoteId(1L, 1L))
+                .thenReturn(Optional.of(existing));
+
+        // then
+        assertThatThrownBy(() -> voteService.vote(command))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessageContaining(ErrorCode.VOTE_ITEM_ALREADY_VOTED.getMessage());
+    }
+
+    @Test
+    @DisplayName("투표 취소 - 해당 voteItem에 투표한 적이 있으면 삭제")
+    void vote_cancelVote_success() {
+        // given
+        VoteCommand command = new VoteCommand(1L, 1L, 1L, 300L, false);
+        VoteParticipant existing = VoteParticipant.withoutId(1L, 300L);
+        when(voteCommandPort.findVoteParticipantByUserIdAndVoteItemId(1L, 300L))
+                .thenReturn(Optional.of(existing));
+
+        // when
+        VoteResult result = voteService.vote(command);
+
+        // then
+        assertThat(result.type()).isFalse();
+        verify(voteCommandPort).deleteVoteParticipant(existing);
+    }
+
+    @Test
+    @DisplayName("투표 취소 - 투표한 적이 없는 경우 예외 발생")
+    void vote_cancelVote_withoutExistingVote_throwsException() {
+        // given
+        VoteCommand command = new VoteCommand(1L, 1L, 1L, 300L, false);
+        when(voteCommandPort.findVoteParticipantByUserIdAndVoteItemId(1L, 300L))
+                .thenReturn(Optional.empty());
+
+        // then
+        assertThatThrownBy(() -> voteService.vote(command))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.VOTE_ITEM_NOT_VOTED_CANNOT_CANCEL.getMessage());
+    }
+}

--- a/src/test/java/konkuk/thip/vote/domain/VoteParticipantTest.java
+++ b/src/test/java/konkuk/thip/vote/domain/VoteParticipantTest.java
@@ -1,0 +1,43 @@
+package konkuk.thip.vote.domain;
+
+import konkuk.thip.common.exception.InvalidStateException;
+import konkuk.thip.common.exception.code.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@DisplayName("[단위] VoteParticipant 도메인 테스트")
+class VoteParticipantTest {
+
+    @Test
+    @DisplayName("같은 voteItemId로 변경 시 예외 발생")
+    void changeVoteItem_throwException_whenVoteItemIdIsSame() {
+        // given
+        Long userId = 1L;
+        Long originalVoteItemId = 10L;
+        VoteParticipant voteParticipant = VoteParticipant.withoutId(userId, originalVoteItemId);
+
+        // when & then
+        assertThatThrownBy(() -> voteParticipant.changeVoteItem(originalVoteItemId))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessageContaining(ErrorCode.VOTE_ITEM_ALREADY_VOTED.getMessage());
+    }
+
+    @Test
+    @DisplayName("다른 voteItemId로 변경 시 성공")
+    void changeVoteItem_success_whenVoteItemIdIsDifferent() {
+        // given
+        Long userId = 1L;
+        Long originalVoteItemId = 10L;
+        Long newVoteItemId = 20L;
+        VoteParticipant voteParticipant = VoteParticipant.withoutId(userId, originalVoteItemId);
+
+        // when
+        voteParticipant.changeVoteItem(newVoteItemId);
+
+        // then
+        assertThat(voteParticipant.getVoteItemId()).isEqualTo(newVoteItemId);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #125 

## 📝 작업 내용

api 흐름은 다음과 같습니다.
1. 방 참가자인지 검증
2. type에 따른 분기처리
- 투표하기 인 경우
  - 사용자가 해당 투표에 참여했는지 확인
    - 이미 투표한 경우 -> RoomParticipant에서 voteItem fk 수정 (같은 투표 항목인 경우 예외처리) => VoteItem의 count 그대로
    - 투표 처음하는 경우 -> 새로운 RoomParticipant 생성                                                               => VoteItem의 count 증가
- 투표 취소하기 인 경우
  - 사용자가 해당 투표 항목에 참여했는지 확인
    - 투표 하지 않은 경우 예외처리
    - 투표한 경우 RoomParticipant 삭제                                                                                           => VoteItem의 count 감소
## 📸 스크린샷

## 💬 리뷰 요구사항

- 로직이 복잡하니 제가 제대로 상태 유효성 검증 또는 변경을 수행했는지 검토해주시면 감사할게요 😅

- 추가적으로 RoomParticipantValidator에 existByUserIdAndRoomId 쿼리에 파라미터의 순서를 바꿔서 전달하고 있는 오류를 수정했습니다. 지금까지 테스트가 어떻게 통과되고 있었는지 의문이네요 하핳,,

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
