### PR TITLE
[feat] 반응 조회 api 구현

### DIFF
--- a/src/main/java/konkuk/thip/common/util/CursorBasedList.java
+++ b/src/main/java/konkuk/thip/common/util/CursorBasedList.java
@@ -13,4 +13,8 @@ public record CursorBasedList<T>(
         String nextCursor = hasNext ? extractor.extractCursor(contents.get(size - 1)) : null;
         return new CursorBasedList<>(contents, nextCursor, hasNext);
     }
+
+    public boolean isLast() {
+        return !hasNext;
+    }
 }

--- a/src/main/java/konkuk/thip/post/adapter/out/jpa/PostJpaEntity.java
+++ b/src/main/java/konkuk/thip/post/adapter/out/jpa/PostJpaEntity.java
@@ -27,6 +27,10 @@ public abstract class PostJpaEntity extends BaseJpaEntity {
 
     protected Integer commentCount = 0;
 
+    // type 구분을 위한 조회용 컬럼
+    @Column(name = "dtype", insertable = false, updatable = false)
+    private String dtype;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private UserJpaEntity userJpaEntity;

--- a/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
@@ -124,6 +124,10 @@ public class UserQueryController {
         return BaseResponse.ok(userSearchUsecase.searchUsers(UserSearchQuery.of(keyword, userId, size)));
     }
 
+    @Operation(
+            summary = "사용자 반응 조회",
+            description = "사용자가 남긴 반응(좋아요, 댓글)을 조회합니다."
+    )
     @GetMapping("/users/reactions")
     public BaseResponse<UserReactionResponse> showUserReaction(
             @Parameter(hidden = true) @UserId final Long userId,

--- a/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import konkuk.thip.common.dto.BaseResponse;
 import konkuk.thip.common.security.annotation.UserId;
+import konkuk.thip.user.application.port.in.dto.UserReactionType;
 import konkuk.thip.user.adapter.in.web.response.*;
 import konkuk.thip.common.swagger.annotation.ExceptionDescription;
 import konkuk.thip.user.adapter.in.web.request.UserVerifyNicknameRequest;
@@ -23,6 +24,7 @@ import konkuk.thip.user.application.port.in.UserIsFollowingUsecase;
 import konkuk.thip.user.application.port.in.UserSearchUsecase;
 import konkuk.thip.user.application.port.in.UserViewAliasChoiceUseCase;
 import konkuk.thip.user.application.port.in.dto.UserSearchQuery;
+import konkuk.thip.user.application.port.in.UserMyPageUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -45,6 +47,7 @@ public class UserQueryController {
     private final UserIsFollowingUsecase userIsFollowingUsecase;
     private final UserVerifyNicknameUseCase userVerifyNicknameUseCase;
     private final UserSearchUsecase userSearchUsecase;
+    private final UserMyPageUseCase userMyPageUseCase;
 
     @Operation(
             summary = "닉네임 중복 확인",
@@ -119,5 +122,17 @@ public class UserQueryController {
             @Parameter(description = "단일 검색 결과 페이지 크기 (1~30) / default : 30", example = "30") @RequestParam(required = false, defaultValue = "30") @Min(1) @Max(30) final Integer size,
             @Parameter(hidden = true) @UserId final Long userId) {
         return BaseResponse.ok(userSearchUsecase.searchUsers(UserSearchQuery.of(keyword, userId, size)));
+    }
+
+    @GetMapping("/users/reactions")
+    public BaseResponse<UserReactionResponse> showUserReaction(
+            @Parameter(hidden = true) @UserId final Long userId,
+            @Parameter(description = "반응 타입 (LIKE, COMMENT) / default : 둘다", example = "LIKE")
+            @RequestParam(required = false, defaultValue = "BOTH") final String type,
+            @Parameter(description = "단일 요청 페이지 크기 (1~10) / default : 10", example = "10")
+            @RequestParam(defaultValue = "10") @Max(value = 10) @Min(value = 1) final int size,
+            @Parameter(description = "커서 (첫번째 요청시 : null, 다음 요청시 : 이전 요청에서 반환받은 nextCursor 값)")
+            @RequestParam(required = false) final String cursor) {
+        return BaseResponse.ok(userMyPageUseCase.getUserReaction(userId, UserReactionType.from(type), size, cursor));
     }
 }

--- a/src/main/java/konkuk/thip/user/adapter/in/web/response/UserProfileResponse.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/response/UserProfileResponse.java
@@ -1,0 +1,4 @@
+package konkuk.thip.user.adapter.in.web.response;
+
+public record UserProfileResponse() {
+}

--- a/src/main/java/konkuk/thip/user/adapter/in/web/response/UserReactionResponse.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/response/UserReactionResponse.java
@@ -1,0 +1,29 @@
+package konkuk.thip.user.adapter.in.web.response;
+
+import java.util.List;
+
+public record UserReactionResponse(
+    List<ReactionDto> reactionList,
+    String nextCursor,
+    Boolean isLast
+) {
+    public record ReactionDto(
+        String label,
+        Long feedId,
+        Long postId,
+        String writer,
+        Long writerId,
+        String type,
+        String content,
+        String postDate
+    ) {
+    }
+
+    public static UserReactionResponse of(
+        List<ReactionDto> reactionList,
+        String nextCursor,
+        Boolean isLast
+    ) {
+        return new UserReactionResponse(reactionList, nextCursor, isLast);
+    }
+}

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/UserQueryPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/UserQueryPersistenceAdapter.java
@@ -1,5 +1,9 @@
 package konkuk.thip.user.adapter.out.persistence;
 
+import konkuk.thip.common.util.Cursor;
+import konkuk.thip.common.util.CursorBasedList;
+import konkuk.thip.user.adapter.out.persistence.function.ReactionQueryFunction;
+import konkuk.thip.user.application.port.out.dto.ReactionQueryDto;
 import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
 import konkuk.thip.user.adapter.out.persistence.repository.alias.AliasJpaRepository;
 import konkuk.thip.user.application.port.in.dto.UserViewAliasChoiceResult;
@@ -8,6 +12,7 @@ import konkuk.thip.user.application.port.out.dto.UserQueryDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -41,5 +46,31 @@ public class UserQueryPersistenceAdapter implements UserQueryPort {
     @Override
     public List<UserQueryDto> findUsersByNicknameOrderByAccuracy(String keyword, Long userId, Integer size) {
         return userJpaRepository.findUsersByNicknameOrderByAccuracy(keyword, userId, size);
+    }
+
+    @Override
+    public CursorBasedList<ReactionQueryDto> findLikeReactionsByUserId(Long userId, Cursor cursor) {
+        return getReactions(userId, cursor, userJpaRepository::findLikeByUserId);
+    }
+
+    @Override
+    public CursorBasedList<ReactionQueryDto> findCommentReactionsByUserId(Long userId, Cursor cursor) {
+        return getReactions(userId, cursor, userJpaRepository::findCommentByUserId);
+    }
+
+    @Override
+    public CursorBasedList<ReactionQueryDto> findBothReactionsByUserId(Long userId, Cursor cursor) {
+        return getReactions(userId, cursor, userJpaRepository::findLikeAndCommentByUserId);
+    }
+
+    private CursorBasedList<ReactionQueryDto> getReactions(Long userId, Cursor cursor, ReactionQueryFunction reactionQueryFunction) {
+        LocalDateTime cursorLocalDateTime = cursor.isFirstRequest() ? null : cursor.getLocalDateTime(0);
+
+        List<ReactionQueryDto> reactionQueryDtos = reactionQueryFunction.fetch(userId, cursorLocalDateTime, cursor.getPageSize());
+
+        return CursorBasedList.of(reactionQueryDtos, cursor.getPageSize(), reactionQueryDto -> {
+            Cursor nextCursor = new Cursor(List.of(reactionQueryDto.createdAt().toString()));
+            return nextCursor.toEncodedString();
+        });
     }
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/function/ReactionQueryFunction.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/function/ReactionQueryFunction.java
@@ -1,0 +1,11 @@
+package konkuk.thip.user.adapter.out.persistence.function;
+
+import konkuk.thip.user.application.port.out.dto.ReactionQueryDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@FunctionalInterface
+public interface ReactionQueryFunction {
+    List<ReactionQueryDto> fetch(Long userId, LocalDateTime cursorDateTime, int size);
+}

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/UserQueryRepository.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/UserQueryRepository.java
@@ -1,7 +1,9 @@
 package konkuk.thip.user.adapter.out.persistence.repository;
 
+import konkuk.thip.user.application.port.out.dto.ReactionQueryDto;
 import konkuk.thip.user.application.port.out.dto.UserQueryDto;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -9,5 +11,11 @@ public interface UserQueryRepository {
     Set<Long> findUserIdsByBookId(Long bookId);
 
     List<UserQueryDto> findUsersByNicknameOrderByAccuracy(String keyword, Long userId, Integer size);
+
+    List<ReactionQueryDto> findLikeByUserId(Long userId, LocalDateTime cursorLocalDateTime, Integer size);
+
+    List<ReactionQueryDto> findCommentByUserId(Long userId, LocalDateTime cursorLocalDateTime, Integer size);
+
+    List<ReactionQueryDto> findLikeAndCommentByUserId(Long userId, LocalDateTime cursorLocalDateTime, Integer size);
 
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/UserQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/UserQueryRepositoryImpl.java
@@ -1,21 +1,31 @@
 package konkuk.thip.user.adapter.out.persistence.repository;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import konkuk.thip.comment.adapter.out.jpa.QCommentJpaEntity;
 import konkuk.thip.common.entity.StatusType;
+import konkuk.thip.post.adapter.out.jpa.QPostJpaEntity;
+import konkuk.thip.post.adapter.out.jpa.QPostLikeJpaEntity;
 import konkuk.thip.room.adapter.out.jpa.QRoomJpaEntity;
 import konkuk.thip.room.adapter.out.jpa.QRoomParticipantJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.QAliasJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.QUserJpaEntity;
+import konkuk.thip.user.application.port.out.dto.QReactionQueryDto;
 import konkuk.thip.user.application.port.out.dto.QUserQueryDto;
+import konkuk.thip.user.application.port.out.dto.ReactionQueryDto;
 import konkuk.thip.user.application.port.out.dto.UserQueryDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 @Repository
 @RequiredArgsConstructor
@@ -70,6 +80,83 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
                 .orderBy(priority.desc(), user.nickname.asc())
                 .limit(size)
                 .fetch();
+    }
+
+    @Override
+    public List<ReactionQueryDto> findLikeByUserId(Long userId, LocalDateTime cursorLocalDateTime, Integer size) {
+        QUserJpaEntity user = QUserJpaEntity.userJpaEntity;
+        QPostLikeJpaEntity postLike = QPostLikeJpaEntity.postLikeJpaEntity;
+        QPostJpaEntity post = QPostJpaEntity.postJpaEntity;
+
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(user.userId.eq(userId))
+                .and(post.status.eq(StatusType.ACTIVE))
+                .and(postLike.status.eq(StatusType.ACTIVE));
+        if (cursorLocalDateTime != null) {
+            where.and(postLike.createdAt.lt(cursorLocalDateTime));
+        }
+
+        return queryFactory
+                .select(new QReactionQueryDto(
+                        Expressions.constant("좋아요"),
+                        post.postId,
+                        post.userJpaEntity.nickname,
+                        post.userJpaEntity.userId,
+                        post.dtype,
+                        post.content,
+                        postLike.createdAt
+                ))
+                .from(postLike)
+                .join(postLike.postJpaEntity, post)
+                .join(postLike.userJpaEntity, user)
+                .where(where)
+                .orderBy(postLike.createdAt.desc())
+                .limit(size + 1)
+                .fetch();
+    }
+
+    @Override
+    public List<ReactionQueryDto> findCommentByUserId(Long userId, LocalDateTime cursorLocalDateTime, Integer size) {
+        QUserJpaEntity user = QUserJpaEntity.userJpaEntity;
+        QPostJpaEntity post = QPostJpaEntity.postJpaEntity;
+        QCommentJpaEntity comment = QCommentJpaEntity.commentJpaEntity;
+
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(user.userId.eq(userId))
+                .and(post.status.eq(StatusType.ACTIVE))
+                .and(comment.status.eq(StatusType.ACTIVE));
+        if (cursorLocalDateTime != null) {
+            where.and(comment.createdAt.lt(cursorLocalDateTime));
+        }
+
+        return queryFactory
+                .select(new QReactionQueryDto(
+                        Expressions.constant("댓글"),
+                        post.postId,
+                        post.userJpaEntity.nickname,
+                        post.userJpaEntity.userId,
+                        post.dtype,
+                        post.content, // 일단은 post의 content를 사용 (추후에 댓글 content로 수정 가능)
+                        comment.createdAt
+                ))
+                .from(comment)
+                .join(comment.userJpaEntity, user)
+                .join(comment.postJpaEntity, post)
+                .where(where)
+                .orderBy(comment.createdAt.desc())
+                .limit(size + 1)
+                .fetch();
+    }
+
+    @Override
+    public List<ReactionQueryDto> findLikeAndCommentByUserId(Long userId, LocalDateTime cursor, Integer size) {
+        List<ReactionQueryDto> likes = findLikeByUserId(userId, cursor, size);
+        List<ReactionQueryDto> comments = findCommentByUserId(userId, cursor, size);
+
+        return Stream.concat(likes.stream(), comments.stream())
+                .sorted(Comparator.comparing(ReactionQueryDto::createdAt).reversed())
+                .limit(size + 1)
+                .toList();
     }
 
 

--- a/src/main/java/konkuk/thip/user/application/mapper/ReactionQueryMapper.java
+++ b/src/main/java/konkuk/thip/user/application/mapper/ReactionQueryMapper.java
@@ -1,0 +1,39 @@
+package konkuk.thip.user.application.mapper;
+
+import konkuk.thip.common.util.DateUtil;
+import konkuk.thip.user.adapter.in.web.response.UserReactionResponse;
+import konkuk.thip.user.application.port.out.dto.ReactionQueryDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+import java.util.List;
+
+import static konkuk.thip.common.post.PostType.*;
+
+@Mapper(componentModel = "spring")
+public interface ReactionQueryMapper {
+
+    @Mapping(target = "feedId", source = ".", qualifiedByName = "mapFeedId")
+    @Mapping(target = "postId", source = ".", qualifiedByName = "mapPostId")
+    @Mapping(target = "writerId", source = "userId")
+    @Mapping(target = "postDate", source = ".", qualifiedByName = "mapPostDate")
+    UserReactionResponse.ReactionDto toReactionDto(ReactionQueryDto dto);
+
+    List<UserReactionResponse.ReactionDto> toReactionDtoList(List<ReactionQueryDto> dtoList);
+
+    @Named("mapFeedId")
+    default Long mapFeedId(ReactionQueryDto dto) {
+        return FEED.getType().equals(dto.type()) ? dto.id() : null;
+    }
+
+    @Named("mapPostId")
+    default Long mapPostId(ReactionQueryDto dto) {
+        return (VOTE.getType().equals(dto.type()) || RECORD.getType().equals(dto.type())) ? dto.id() : null;
+    }
+
+    @Named("mapPostDate")
+    default String mapPostDate(ReactionQueryDto dto) {
+        return DateUtil.formatBeforeTime(dto.createdAt());
+    }
+}

--- a/src/main/java/konkuk/thip/user/application/mapper/UserQueryMapper.java
+++ b/src/main/java/konkuk/thip/user/application/mapper/UserQueryMapper.java
@@ -12,4 +12,6 @@ public interface UserQueryMapper {
     // List<QueryDto> -> List<DTO>
     List<UserSearchResponse.UserDto> toUserDtoList(List<UserQueryDto> userQueryDtos);
 
+
+
 }

--- a/src/main/java/konkuk/thip/user/application/port/in/UserMyPageUseCase.java
+++ b/src/main/java/konkuk/thip/user/application/port/in/UserMyPageUseCase.java
@@ -1,0 +1,19 @@
+package konkuk.thip.user.application.port.in;
+
+import konkuk.thip.user.application.port.in.dto.UserReactionType;
+import konkuk.thip.user.adapter.in.web.response.UserProfileResponse;
+import konkuk.thip.user.adapter.in.web.response.UserReactionResponse;
+
+public interface UserMyPageUseCase {
+
+    /**
+     * 사용자 반응 조회
+     */
+    UserReactionResponse getUserReaction(Long userId, UserReactionType userReactionType,
+                                         int size, String cursor);
+
+    /**
+     * 사용자 마이페이지 조회
+     */
+    UserProfileResponse getUserProfile(Long userId);
+}

--- a/src/main/java/konkuk/thip/user/application/port/in/dto/UserReactionType.java
+++ b/src/main/java/konkuk/thip/user/application/port/in/dto/UserReactionType.java
@@ -1,0 +1,28 @@
+package konkuk.thip.user.application.port.in.dto;
+
+import konkuk.thip.common.exception.InvalidStateException;
+import konkuk.thip.common.exception.code.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public enum UserReactionType {
+    LIKE("LIKE"),
+    COMMENT("COMMENT"),
+    BOTH("BOTH");
+
+    private final String type;
+
+    UserReactionType(String type) {
+        this.type = type;
+    }
+
+    public static UserReactionType from(String type) {
+        for (UserReactionType reactionType : UserReactionType.values()) {
+            if (reactionType.getType().equalsIgnoreCase(type)) {
+                return reactionType;
+            }
+        }
+        throw new InvalidStateException(ErrorCode.API_INVALID_PARAM,
+            new IllegalArgumentException("유효하지 않은 사용자 반응 타입: " + type));
+    }
+}

--- a/src/main/java/konkuk/thip/user/application/port/out/UserQueryPort.java
+++ b/src/main/java/konkuk/thip/user/application/port/out/UserQueryPort.java
@@ -1,5 +1,8 @@
 package konkuk.thip.user.application.port.out;
 
+import konkuk.thip.common.util.Cursor;
+import konkuk.thip.common.util.CursorBasedList;
+import konkuk.thip.user.application.port.out.dto.ReactionQueryDto;
 import konkuk.thip.user.application.port.in.dto.UserViewAliasChoiceResult;
 import konkuk.thip.user.application.port.out.dto.UserQueryDto;
 
@@ -16,4 +19,10 @@ public interface UserQueryPort {
     UserViewAliasChoiceResult getAllAliasesAndCategories();
 
     List<UserQueryDto> findUsersByNicknameOrderByAccuracy(String keyword, Long userId, Integer size);
+
+    CursorBasedList<ReactionQueryDto> findLikeReactionsByUserId(Long userId, Cursor cursor);
+
+    CursorBasedList<ReactionQueryDto> findCommentReactionsByUserId(Long userId, Cursor cursor);
+
+    CursorBasedList<ReactionQueryDto> findBothReactionsByUserId(Long userId, Cursor cursor);
 }

--- a/src/main/java/konkuk/thip/user/application/port/out/dto/ReactionQueryDto.java
+++ b/src/main/java/konkuk/thip/user/application/port/out/dto/ReactionQueryDto.java
@@ -1,0 +1,27 @@
+package konkuk.thip.user.application.port.out.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import org.springframework.util.Assert;
+
+import java.time.LocalDateTime;
+
+public record ReactionQueryDto(
+    String label,
+    Long id, // feedId 또는 postId
+    String writer,
+    Long userId,
+    String type,
+    String content,
+    LocalDateTime createdAt
+) {
+    @QueryProjection
+    public ReactionQueryDto {
+        Assert.notNull(label, "label must not be null");
+        Assert.notNull(id, "id must not be null");
+        Assert.notNull(writer, "writer must not be null");
+        Assert.notNull(userId, "userId must not be null");
+        Assert.notNull(type, "type must not be null");
+        Assert.notNull(content, "content must not be null");
+        Assert.notNull(createdAt, "createdAt must not be null");
+    }
+}

--- a/src/main/java/konkuk/thip/user/application/service/UserMyPageService.java
+++ b/src/main/java/konkuk/thip/user/application/service/UserMyPageService.java
@@ -1,0 +1,48 @@
+package konkuk.thip.user.application.service;
+
+import konkuk.thip.common.util.Cursor;
+import konkuk.thip.common.util.CursorBasedList;
+import konkuk.thip.user.adapter.in.web.response.UserProfileResponse;
+import konkuk.thip.user.adapter.in.web.response.UserReactionResponse;
+import konkuk.thip.user.application.mapper.ReactionQueryMapper;
+import konkuk.thip.user.application.port.in.UserMyPageUseCase;
+import konkuk.thip.user.application.port.in.dto.UserReactionType;
+import konkuk.thip.user.application.port.out.UserQueryPort;
+import konkuk.thip.user.application.port.out.dto.ReactionQueryDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserMyPageService implements UserMyPageUseCase {
+
+    private final UserQueryPort userQueryPort;
+
+    private final ReactionQueryMapper reactionQueryMapper;
+
+    @Override
+    public UserReactionResponse getUserReaction(Long userId, UserReactionType userReactionType, int size, String cursorStr) {
+
+        Cursor cursor = Cursor.from(cursorStr, size);
+
+        CursorBasedList<ReactionQueryDto> reactionQueryDtoList = switch (userReactionType) {
+            case LIKE -> userQueryPort.findLikeReactionsByUserId(userId, cursor);
+            case COMMENT -> userQueryPort.findCommentReactionsByUserId(userId, cursor);
+            case BOTH -> userQueryPort.findBothReactionsByUserId(userId, cursor);
+        };
+
+        List<UserReactionResponse.ReactionDto> reactionDtoList = reactionQueryMapper.toReactionDtoList(reactionQueryDtoList.contents());
+        return UserReactionResponse.of(
+                reactionDtoList,
+                reactionQueryDtoList.nextCursor(),
+                reactionQueryDtoList.isLast()
+        );
+    }
+
+    @Override
+    public UserProfileResponse getUserProfile(Long userId) {
+        return null;
+    }
+}

--- a/src/test/java/konkuk/thip/user/adapter/in/web/UserReactionApiTest.java
+++ b/src/test/java/konkuk/thip/user/adapter/in/web/UserReactionApiTest.java
@@ -1,0 +1,212 @@
+package konkuk.thip.user.adapter.in.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.adapter.out.persistence.repository.BookJpaRepository;
+import konkuk.thip.comment.adapter.out.jpa.CommentJpaEntity;
+import konkuk.thip.comment.adapter.out.persistence.repository.CommentJpaRepository;
+import konkuk.thip.common.util.TestEntityFactory;
+import konkuk.thip.feed.adapter.out.jpa.FeedJpaEntity;
+import konkuk.thip.feed.adapter.out.persistence.repository.FeedJpaRepository;
+import konkuk.thip.post.adapter.out.jpa.PostLikeJpaEntity;
+import konkuk.thip.post.adapter.out.persistence.PostLikeJpaRepository;
+import konkuk.thip.record.adapter.out.jpa.RecordJpaEntity;
+import konkuk.thip.record.adapter.out.persistence.repository.RecordJpaRepository;
+import konkuk.thip.room.adapter.out.jpa.CategoryJpaEntity;
+import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
+import konkuk.thip.room.adapter.out.jpa.RoomParticipantRole;
+import konkuk.thip.room.adapter.out.persistence.repository.RoomJpaRepository;
+import konkuk.thip.room.adapter.out.persistence.repository.category.CategoryJpaRepository;
+import konkuk.thip.room.adapter.out.persistence.repository.roomparticipant.RoomParticipantJpaRepository;
+import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.repository.alias.AliasJpaRepository;
+import konkuk.thip.vote.adapter.out.jpa.VoteJpaEntity;
+import konkuk.thip.vote.adapter.out.persistence.repository.VoteJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static konkuk.thip.common.post.PostType.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+@Transactional
+@DisplayName("[통합] 사용자 반응 조회 API 통합 테스트")
+class UserReactionApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private AliasJpaRepository aliasJpaRepository;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private CategoryJpaRepository categoryJpaRepository;
+
+    @Autowired
+    private BookJpaRepository bookJpaRepository;
+
+    @Autowired
+    private RoomJpaRepository roomJpaRepository;
+
+    @Autowired
+    private RoomParticipantJpaRepository roomParticipantJpaRepository;
+
+    @Autowired
+    private FeedJpaRepository feedJpaRepository;
+
+    @Autowired
+    private RecordJpaRepository recordJpaRepository;
+
+    @Autowired
+    private VoteJpaRepository voteJpaRepository;
+
+    @Autowired
+    private CommentJpaRepository commentJpaRepository;
+
+    @Autowired
+    private PostLikeJpaRepository postLikeJpaRepository;
+
+    private AliasJpaEntity alias;
+    private UserJpaEntity user;
+    private CategoryJpaEntity category;
+    private BookJpaEntity book;
+    private RoomJpaEntity room;
+    private FeedJpaEntity feed;
+    private RecordJpaEntity record;
+    private VoteJpaEntity vote;
+
+    @BeforeEach
+    void setUp() {
+        alias = aliasJpaRepository.save(TestEntityFactory.createLiteratureAlias());
+        user = userJpaRepository.save(TestEntityFactory.createUser(alias));
+        category = categoryJpaRepository.save(TestEntityFactory.createLiteratureCategory(alias));
+        book = bookJpaRepository.save(TestEntityFactory.createBookWithISBN("9788954682152"));
+        room = roomJpaRepository.save(TestEntityFactory.createRoom(book, category));
+        feed = feedJpaRepository.save(TestEntityFactory.createFeed(user, book, true));
+        record = recordJpaRepository.save(TestEntityFactory.createRecord(user, room));
+        vote = voteJpaRepository.save(TestEntityFactory.createVote(user, room));
+        roomParticipantJpaRepository.save(
+                TestEntityFactory.createRoomParticipant(room, user, RoomParticipantRole.HOST, 0.0)
+        );
+    }
+
+    @Test
+    @DisplayName("좋아요 반응만 조회 성공")
+    void showUserReaction_onlyLikes_success() throws Exception {
+        // given
+        postLikeJpaRepository.save(PostLikeJpaEntity.builder()
+                .postJpaEntity(feed)
+                .userJpaEntity(user)
+                .build());
+
+        // when & then
+        mockMvc.perform(get("/users/reactions")
+                        .param("type", "LIKE")
+                        .param("size", "10")
+                        .requestAttr("userId", user.getUserId()))
+                .andExpect(status().isOk())
+                // 리스트 존재
+                .andExpect(jsonPath("$.data.reactionList").isArray())
+                .andExpect(jsonPath("$.data.reactionList.length()").value(1))
+                // 첫 번째 항목 검증
+                .andExpect(jsonPath("$.data.reactionList[0].label").value("좋아요"))
+                .andExpect(jsonPath("$.data.reactionList[0].type").value("FEED"))
+                .andExpect(jsonPath("$.data.reactionList[0].writer").value(user.getNickname()))
+                .andExpect(jsonPath("$.data.reactionList[0].content").isString())
+                .andExpect(jsonPath("$.data.reactionList[0].feedId").value(feed.getPostId()));
+    }
+
+    @Test
+    @DisplayName("댓글 반응만 조회 성공")
+    void showUserReaction_onlyComments_success() throws Exception {
+        commentJpaRepository.save(TestEntityFactory.createComment(feed, user, FEED));
+
+        mockMvc.perform(get("/users/reactions")
+                        .param("type", "COMMENT")
+                        .param("size", "10")
+                        .requestAttr("userId", user.getUserId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reactionList").isArray())
+                .andExpect(jsonPath("$.data.reactionList.length()").value(1))
+                .andExpect(jsonPath("$.data.reactionList[0].label").value("댓글"))
+                .andExpect(jsonPath("$.data.reactionList[0].type").value("FEED"))
+                .andExpect(jsonPath("$.data.reactionList[0].writer").value(user.getNickname()))
+                .andExpect(jsonPath("$.data.reactionList[0].content").isString())
+                .andExpect(jsonPath("$.data.reactionList[0].feedId").value(feed.getPostId()));
+    }
+
+    @Test
+    @DisplayName("좋아요+댓글 반응 모두 조회 성공")
+    void showUserReaction_both_success() throws Exception {
+        postLikeJpaRepository.save(PostLikeJpaEntity.builder()
+                .postJpaEntity(feed)
+                .userJpaEntity(user)
+                .build());
+        commentJpaRepository.save(TestEntityFactory.createComment(feed, user, FEED));
+
+        mockMvc.perform(get("/users/reactions")
+                        .param("type", "BOTH")
+                        .param("size", "10")
+                        .requestAttr("userId", user.getUserId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reactionList").isArray())
+                .andExpect(jsonPath("$.data.reactionList.length()").value(2))
+                .andExpect(jsonPath("$.data.reactionList[0].label").value("댓글"))
+                .andExpect(jsonPath("$.data.reactionList[1].label").value("좋아요"));
+    }
+
+    @Test
+    @DisplayName("커서 기반 페이징 정상 동작 확인")
+    void showUserReaction_cursorPaging_success() throws Exception {
+        List<CommentJpaEntity> comments = IntStream.rangeClosed(1, 15)
+                .mapToObj(i -> TestEntityFactory.createComment(feed, user, FEED))
+                .toList();
+        commentJpaRepository.saveAll(comments);
+
+        String jsonResponse = mockMvc.perform(get("/users/reactions")
+                        .param("type", "COMMENT")
+                        .param("size", "10")
+                        .requestAttr("userId", user.getUserId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reactionList.length()").value(10))
+                .andExpect(jsonPath("$.data.nextCursor").exists())
+                .andExpect(jsonPath("$.data.isLast").value(false))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        String nextCursor = objectMapper.readTree(jsonResponse)
+                .path("data").path("nextCursor").asText();
+
+        mockMvc.perform(get("/users/reactions")
+                        .param("type", "COMMENT")
+                        .param("size", "10")
+                        .param("cursor", nextCursor)
+                        .requestAttr("userId", user.getUserId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reactionList.length()").value(5))
+                .andExpect(jsonPath("$.data.isLast").value(true));
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #123 

## 📝 작업 내용

반응 조회 api 흐름은 다음과 같습니다.
- type : LIKE => 로그인한 사용자가 좋아요한 피드 또는 모임 게시글을 최신순 조회
- type : COMMENT => 로그인한 사용자가 댓글을 남긴 피드 또는 모임 게시글을 최신순 조회
- type : BOTH => 로그인한 사용자가 좋아요 또는 댓글을 남긴 피드 또는 모임 게시글을 최신순 조회

## 📸 스크린샷

## 💬 리뷰 요구사항

추가적으로 PostJpaEntity에 조회용 dtype 필드를 추가했습니다! insertable과 updatable을 모두 false로 둬서 오직 getter를 통해 불러오는 것만 가능한 필드입니다! `@DiscriminatorValue`에 설정해둔 FEED, VOTE, RECORD 이런식으로 반환됩니다.

추후에 상속 구조를 없애는 걸로 되어있었는데 찾아보니 상속 전략에 JOINED 전략과 SIGNLE_TABLE 전략이 있더라구요. 자동 join이 발생하는 것을 방지하고 싶으면 상속 구조를 아예 없애는 것보다 SINGLE_TABLE 전략을 고려해보는 것이 더 좋은 선택일 것 같다는 생각이 듭니다!


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
