### PR TITLE
[hotfix] 기록장 조회시 isbn 반환 / 마감임박,인기방 조회시 recruitCount 반환

### DIFF
--- a/src/main/java/konkuk/thip/record/adapter/in/web/response/RecordSearchResponse.java
+++ b/src/main/java/konkuk/thip/record/adapter/in/web/response/RecordSearchResponse.java
@@ -8,6 +8,7 @@ import java.util.List;
 public record RecordSearchResponse(
     List<PostDto> postList,
     Long roomId,
+    String isbn,
     String nextCursor,
     Boolean isLast
 ){

--- a/src/main/java/konkuk/thip/record/application/service/RecordSearchService.java
+++ b/src/main/java/konkuk/thip/record/application/service/RecordSearchService.java
@@ -105,6 +105,7 @@ public class RecordSearchService implements RecordSearchUseCase {
         // RecordSearchResponse 생성
         return RecordSearchResponse.builder()
                 .roomId(roomId)
+                .isbn(book.getIsbn())
                 .postList(postDtos)
                 .nextCursor(cursorBasedList.nextCursor())
                 .isLast(!cursorBasedList.hasNext())

--- a/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomGetDeadlinePopularResponse.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomGetDeadlinePopularResponse.java
@@ -10,6 +10,7 @@ public record RoomGetDeadlinePopularResponse(
             Long roomId,
             String bookImageUrl,
             String roomName,
+            int recruitCount, // 방 최대 인원 수
             int memberCount,
             String deadlineDate
     ) {

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomQueryRepositoryImpl.java
@@ -343,6 +343,7 @@ public class RoomQueryRepositoryImpl implements RoomQueryRepository {
                         room.roomId,
                         book.imageUrl,
                         room.title,
+                        room.recruitCount,
                         room.memberCount,
                         room.startDate
                 ))
@@ -362,6 +363,7 @@ public class RoomQueryRepositoryImpl implements RoomQueryRepository {
                         room.roomId,
                         book.imageUrl,
                         room.title,
+                        room.recruitCount,
                         room.memberCount,
                         room.startDate
                 ))
@@ -425,6 +427,7 @@ public class RoomQueryRepositoryImpl implements RoomQueryRepository {
                         room.roomId,
                         book.imageUrl,
                         room.title,
+                        room.recruitCount,
                         room.memberCount,
                         cursorExpr
                 ))

--- a/src/main/java/konkuk/thip/room/application/port/out/dto/RoomQueryDto.java
+++ b/src/main/java/konkuk/thip/room/application/port/out/dto/RoomQueryDto.java
@@ -11,6 +11,7 @@ public record RoomQueryDto(
         Long roomId,
         String bookImageUrl,
         String roomName,
+        int recruitCount, // 방 최대 인원 수
         int memberCount,
         LocalDate endDate       // 방 진행 마감일 or 방 모집 마감일
 ) {
@@ -20,6 +21,7 @@ public record RoomQueryDto(
         Assert.notNull(bookImageUrl, "bookImageUrl must not be null");
         Assert.notNull(roomName, "roomName must not be null");
         Assert.notNull(endDate, "endDate must not be null");
+        Assert.isTrue(recruitCount > 0, "recruitCount must be greater than 0");
         Assert.isTrue(memberCount >= 0, "memberCount must be greater than or equal to 0");
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #137 
## 📝 작업 내용

- 피드 작성시 화면 조회 api 통합을 위해 기록장 -> 피드 작성 화면으로 넘어갈때 책 상세정보를 받아오기 위해 기록장 조회에서 isbn을 반환합니다.
- 마감임박/인기방 조회시 최대 방 인원수를 의미하는 recruitCount를 반환합니다. (@rbqks529 님의 요청)

## 📸 스크린샷

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 검색 결과에 ISBN 정보가 추가되었습니다.
  * 인기 마감 임박 방 목록 및 관련 데이터에 최대 모집 인원(recruitCount) 정보가 표시됩니다.

* **버그 수정**
  * 최대 모집 인원(recruitCount)이 0보다 큰 값만 허용되도록 검증이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->