### PR TITLE
[Refactor] 비공개 방 비밀번호 입력 검증시 반환값 수정

### DIFF
--- a/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
@@ -85,7 +85,6 @@ public enum ErrorCode implements ResponseCode {
      */
     ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, 100000, "존재하지 않는 ROOM 입니다."),
     INVALID_ROOM_CREATE(HttpStatus.BAD_REQUEST, 100001, "유효하지 않은 ROOM 생성 요청 입니다."),
-    ROOM_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, 100002, "비밀번호가 일치하지 않습니다."),
     ROOM_PASSWORD_NOT_REQUIRED(HttpStatus.BAD_REQUEST, 100003, "공개방은 비밀번호가 필요하지 않습니다."),
     ROOM_RECRUITMENT_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, 100004, "모집기간이 만료된 방입니다."),
     INVALID_ROOM_SEARCH_SORT(HttpStatus.BAD_REQUEST, 100005, "방 검색 시 정렬 조건이 잘못되었습니다."),

--- a/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
@@ -79,7 +79,6 @@ public enum SwaggerResponseDescription {
     ))),
     ROOM_PASSWORD_CHECK(new LinkedHashSet<>(Set.of(
             ROOM_NOT_FOUND,
-            ROOM_PASSWORD_MISMATCH,
             ROOM_RECRUITMENT_PERIOD_EXPIRED,
             ROOM_PASSWORD_NOT_REQUIRED
     ))),

--- a/src/main/java/konkuk/thip/room/adapter/in/web/RoomQueryController.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/RoomQueryController.java
@@ -52,7 +52,7 @@ public class RoomQueryController {
     )
     @ExceptionDescription(ROOM_PASSWORD_CHECK)
     @PostMapping("/rooms/{roomId}/password")
-    public BaseResponse<Void> verifyRoomPassword(
+    public BaseResponse<RoomVerifyPasswordResponse> verifyRoomPassword(
             @Parameter(description = "비밀번호 검증하려는 비공개 방 ID", example = "1") @PathVariable("roomId") final Long roomId,
             @Valid @RequestBody final RoomVerifyPasswordRequest roomVerifyPasswordRequest
     ) {

--- a/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomVerifyPasswordResponse.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomVerifyPasswordResponse.java
@@ -1,0 +1,11 @@
+package konkuk.thip.room.adapter.in.web.response;
+
+public record RoomVerifyPasswordResponse(
+        boolean matched,
+        Long roomId
+)
+{
+    public static RoomVerifyPasswordResponse of(boolean matched,Long roomId) {
+        return new RoomVerifyPasswordResponse(matched,roomId);
+    }
+}

--- a/src/main/java/konkuk/thip/room/application/port/in/RoomVerifyPasswordUseCase.java
+++ b/src/main/java/konkuk/thip/room/application/port/in/RoomVerifyPasswordUseCase.java
@@ -1,7 +1,8 @@
 package konkuk.thip.room.application.port.in;
 
+import konkuk.thip.room.adapter.in.web.response.RoomVerifyPasswordResponse;
 import konkuk.thip.room.application.port.in.dto.RoomVerifyPasswordQuery;
 
 public interface RoomVerifyPasswordUseCase {
-    Void verifyRoomPassword(RoomVerifyPasswordQuery query);
+    RoomVerifyPasswordResponse verifyRoomPassword(RoomVerifyPasswordQuery query);
 }

--- a/src/main/java/konkuk/thip/room/application/service/RoomVerifyPasswordService.java
+++ b/src/main/java/konkuk/thip/room/application/service/RoomVerifyPasswordService.java
@@ -1,5 +1,6 @@
 package konkuk.thip.room.application.service;
 
+import konkuk.thip.room.adapter.in.web.response.RoomVerifyPasswordResponse;
 import konkuk.thip.room.application.port.in.RoomVerifyPasswordUseCase;
 import konkuk.thip.room.application.port.in.dto.RoomVerifyPasswordQuery;
 import konkuk.thip.room.application.port.out.RoomCommandPort;
@@ -17,13 +18,13 @@ public class RoomVerifyPasswordService implements RoomVerifyPasswordUseCase {
 
     @Override
     @Transactional(readOnly = true)
-    public Void verifyRoomPassword(RoomVerifyPasswordQuery query) {
+    public RoomVerifyPasswordResponse verifyRoomPassword(RoomVerifyPasswordQuery query) {
 
         //방 검증
         Room room = roomCommandPort.getByIdOrThrow(query.roomId());
 
         //도메인에서 비밀번호 검증 로직 수행
-        room.verifyPassword(query.password());
-        return null;
+        boolean matched = room.verifyPassword(query.password());
+        return RoomVerifyPasswordResponse.of(matched, room.getId());
     }
 }

--- a/src/main/java/konkuk/thip/room/domain/Room.java
+++ b/src/main/java/konkuk/thip/room/domain/Room.java
@@ -3,7 +3,6 @@ package konkuk.thip.room.domain;
 import konkuk.thip.common.entity.BaseDomainEntity;
 import konkuk.thip.common.exception.InvalidStateException;
 import konkuk.thip.common.entity.StatusType;
-import konkuk.thip.common.exception.BusinessException;
 import konkuk.thip.common.exception.code.ErrorCode;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
@@ -117,7 +116,7 @@ public class Room extends BaseDomainEntity {
         return PASSWORD_ENCODER.matches(rawPassword, this.hashedPassword);
     }
 
-    public void verifyPassword(String rawPassword) {
+    public boolean verifyPassword(String rawPassword) {
 
         validateRoomRecruitExpired();
 
@@ -127,9 +126,7 @@ public class Room extends BaseDomainEntity {
         }
 
         //비밀번호 검증
-        if (!matchesPassword(rawPassword)) {
-            throw new BusinessException(ROOM_PASSWORD_MISMATCH);
-        }
+        return matchesPassword(rawPassword);
     }
 
     public void validateRoomRecruitExpired() {

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomVerifyPasswordAPITest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomVerifyPasswordAPITest.java
@@ -142,11 +142,13 @@ class RoomVerifyPasswordAPITest {
                         .content(objectMapper.writeValueAsString(request))
                 )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.isSuccess").value(true));
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.data.matched").value(true))
+                .andExpect(jsonPath("$.data.roomId").value(privateRoomId));
     }
 
     @Test
-    @DisplayName("모집기간이 만료되지 않은 비공개 방의 비밀번호 입력 검증 [실패]시 400 Bad Request 반환")
+    @DisplayName("모집기간이 만료되지 않은 비공개 방의 비밀번호 입력 검증 [실패]시 matched=false로 200 OK")
     void verifyRoomPassword_mismatch() throws Exception {
 
         // given
@@ -158,10 +160,10 @@ class RoomVerifyPasswordAPITest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
                 )
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.isSuccess").value(false))
-                .andExpect(jsonPath("$.code").value(ROOM_PASSWORD_MISMATCH.getCode()))
-                .andExpect(jsonPath("$.message" , containsString("비밀번호가 일치하지 않습니다.")));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.data.matched").value(false))
+                .andExpect(jsonPath("$.data.roomId").value(privateRoomId));
     }
 
     @Test

--- a/src/test/java/konkuk/thip/room/domain/RoomTest.java
+++ b/src/test/java/konkuk/thip/room/domain/RoomTest.java
@@ -219,25 +219,23 @@ class RoomTest {
     }
 
     @Test
-    @DisplayName("verifyPassword: 비밀번호 불일치 시 BusinessException(ROOM_PASSWORD_MISMATCH) 발생")
+    @DisplayName("verifyPassword: 비밀번호 불일치 시 false 반환")
     void verifyPassword_passwordMismatch() {
         Room room = Room.withoutId(
                 "제목", "설명", false, "1234",
                 START, END, 5, 123L, validCategory
         );
-        BusinessException ex = assertThrows(BusinessException.class,
-                () -> room.verifyPassword("0000"));
-        assertEquals(ErrorCode.ROOM_PASSWORD_MISMATCH, ex.getErrorCode());
+        assertFalse(room.verifyPassword("0000"));
     }
 
     @Test
-    @DisplayName("verifyPassword: 모집기간 내, 비공개방, 비밀번호 일치 시 예외 발생하지 않음")
+    @DisplayName("verifyPassword: 모집기간 내, 비공개방, 비밀번호 일치 시 true 반환")
     void verifyPassword_success() {
         Room room = Room.withoutId(
                 "제목", "설명", false, "1234",
                 START, END, 5, 123L, validCategory
         );
-        assertDoesNotThrow(() -> room.verifyPassword("1234"));
+        assertTrue(room.verifyPassword("1234"));
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #143 

## 📝 작업 내용

- 비공개 방 비밀번호 입력 시에 기존에 비밀번호 불일치시, 발생했던 예외로직을 없애고 matched라는 boolean 값으로 비밀번호 일치여부를 반환하도록 수정하였습니다.
- 또한 누락되었던 roomId도 추가되었습니다

## 📸 스크린샷

## 💬 리뷰 요구사항

브랜치 이름에 깜박하고 이슈번호를 못적었습니닷 ㅜㅜ..


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 비밀번호 검증 결과를 포함하는 응답 객체(RoomVerifyPasswordResponse)를 도입하여, 방 비밀번호 일치 여부와 방 ID를 확인할 수 있습니다.

* **버그 수정**
  * 비밀번호 불일치 시에도 200 OK 응답과 함께 일치 여부를 반환하도록 변경되었습니다.

* **테스트**
  * 비밀번호 검증 관련 테스트가 새로운 응답 구조와 동작 방식에 맞게 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->