### PR TITLE
[hotfix] 전체 팔로잉/팔로워 count 반환 및 isFollowing = true 반환

### DIFF
--- a/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
@@ -99,6 +99,7 @@ public class UserQueryController {
         return BaseResponse.ok(userGetFollowUsecase.getMyFollowing(userId, cursor, size));
     }
 
+    @Deprecated
     @Operation(
             summary = "팔로잉 여부 조회",
             description = "특정 사용자가 다른 사용자를 팔로우하고 있는지 확인합니다."

--- a/src/main/java/konkuk/thip/user/adapter/in/web/response/UserFollowersResponse.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/response/UserFollowersResponse.java
@@ -7,6 +7,7 @@ import java.util.List;
 @Builder
 public record UserFollowersResponse(
         List<FollowerDto> followers,
+        Integer totalFollowerCount,
         String nextCursor,
         boolean isLast
 ) {

--- a/src/main/java/konkuk/thip/user/adapter/in/web/response/UserFollowingResponse.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/response/UserFollowingResponse.java
@@ -7,6 +7,7 @@ import java.util.List;
 @Builder
 public record UserFollowingResponse(
         List<FollowingDto> followings,
+        Integer totalFollowingCount,
         String nextCursor,
         boolean isLast
 ) {
@@ -16,7 +17,8 @@ public record UserFollowingResponse(
             String nickname,
             String profileImageUrl,
             String aliasName,
-            String aliasColor
+            String aliasColor,
+            boolean isFollowing
     ){
     }
 

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/FollowingQueryPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/FollowingQueryPersistenceAdapter.java
@@ -48,6 +48,11 @@ public class FollowingQueryPersistenceAdapter implements FollowingQueryPort {
 
     @Override
     public boolean isFollowingUser(Long userId, Long targetUserId) {
-        return followingJpaRepository.existsByUserJpaEntity_UserIdAndFollowingUserJpaEntity_UserId(userId, targetUserId);
+        return followingJpaRepository.existsByUserIdAndFollowingUserId(userId, targetUserId);
+    }
+
+    @Override
+    public int getFollowingCountByUser(Long userId) {
+        return followingJpaRepository.countFollowingByUserId(userId);
     }
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingJpaRepository.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingJpaRepository.java
@@ -2,10 +2,15 @@ package konkuk.thip.user.adapter.out.persistence.repository.following;
 
 import konkuk.thip.user.adapter.out.jpa.FollowingJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FollowingJpaRepository extends JpaRepository<FollowingJpaEntity, Long>, FollowingQueryRepository {
 
-    boolean existsByUserJpaEntity_UserIdAndFollowingUserJpaEntity_UserId(Long userId, Long followingUserId);
+    @Query("SELECT COUNT(f) > 0 FROM FollowingJpaEntity f WHERE f.userJpaEntity.userId = :userId AND f.followingUserJpaEntity.userId = :followingUserId")
+    boolean existsByUserIdAndFollowingUserId(Long userId, Long followingUserId);
+
+    @Query("SELECT COUNT(f) FROM FollowingJpaEntity f WHERE f.userJpaEntity.userId = :userId")
+    int countFollowingByUserId(Long userId);
 }

--- a/src/main/java/konkuk/thip/user/application/mapper/FollowQueryMapper.java
+++ b/src/main/java/konkuk/thip/user/application/mapper/FollowQueryMapper.java
@@ -4,11 +4,13 @@ import konkuk.thip.user.adapter.in.web.response.UserFollowersResponse;
 import konkuk.thip.user.adapter.in.web.response.UserFollowingResponse;
 import konkuk.thip.user.application.port.out.dto.UserQueryDto;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface FollowQueryMapper {
 
     UserFollowersResponse.FollowerDto toFollowerDto(UserQueryDto dto);
 
+    @Mapping(target = "isFollowing", constant = "true")
     UserFollowingResponse.FollowingDto toFollowingDto(UserQueryDto dto);
 }

--- a/src/main/java/konkuk/thip/user/application/port/out/FollowingQueryPort.java
+++ b/src/main/java/konkuk/thip/user/application/port/out/FollowingQueryPort.java
@@ -12,5 +12,7 @@ public interface FollowingQueryPort {
     List<String> getLatestFollowerImageUrls(Long userId, int size);
 
     boolean isFollowingUser(Long userId, Long targetUserId);
+
+    int getFollowingCountByUser(Long userId);
 }
 

--- a/src/main/java/konkuk/thip/user/application/service/following/UserGetFollowService.java
+++ b/src/main/java/konkuk/thip/user/application/service/following/UserGetFollowService.java
@@ -39,6 +39,7 @@ public class UserGetFollowService implements UserGetFollowUsecase {
 
         return UserFollowersResponse.builder()
                 .followers(followers)
+                .totalFollowerCount(user.getFollowerCount())
                 .nextCursor(result.nextCursor())
                 .isLast(!result.hasNext())
                 .build();
@@ -48,6 +49,7 @@ public class UserGetFollowService implements UserGetFollowUsecase {
     @Transactional(readOnly = true)
     public UserFollowingResponse getMyFollowing(Long userId, String cursor, int size) {
         User user = userCommandPort.findById(userId);
+        int totalFollowingCount = followingQueryPort.getFollowingCountByUser(user.getId());
 
         CursorBasedList<UserQueryDto> result = followingQueryPort.getFollowingByUserId(
                 user.getId(), cursor, Math.min(size, MAX_PAGE_SIZE)
@@ -59,6 +61,7 @@ public class UserGetFollowService implements UserGetFollowUsecase {
 
         return UserFollowingResponse.builder()
                 .followings(following)
+                .totalFollowingCount(totalFollowingCount)
                 .nextCursor(result.nextCursor())
                 .isLast(!result.hasNext())
                 .build();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #148 

## 📝 작업 내용

@heeeeyong 님의 요청에 따라 특정 사용자의 팔로워 조회, 내 팔로잉 조회 api 시에 전체 팔로잉/팔로워 count를 반환하고 내 팔로잉 조회시에는 isFollowing을 true로 반환합니다.

## 📸 스크린샷

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
