### PR TITLE
[hotfix] 내 모임방 리스트 조회 api 수정

### DIFF
--- a/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomShowMineResponse.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomShowMineResponse.java
@@ -1,7 +1,10 @@
 package konkuk.thip.room.adapter.in.web.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(description = "내가 참여 중인 방 목록 조회 응답")
 public record RoomShowMineResponse(
         List<MyRoom> roomList,
         String nextCursor,
@@ -12,6 +15,11 @@ public record RoomShowMineResponse(
             String bookImageUrl,
             String roomName,
             int memberCount,
-            String endDate      // 방 진행 마감일 or 방 모집 마감일 (~ 뒤 형식)
+
+            @Schema(description = "방 진행 마감일 or 방 모집 마감일까지 남은 시간 (ex. \"3일 뒤\"), 완료된 방은 쓰레기값이 넘어갑니다. 무시해주세요.")
+            String endDate,     // 방 진행 마감일 or 방 모집 마감일 (~ 뒤 형식)
+
+            @Schema(description = "방 상태 : [모집중(=recruiting), 진행중(=playing), 완료된(=expired)] 중 하나")
+            String type
     ) {}
 }

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomQueryRepositoryImpl.java
@@ -429,6 +429,7 @@ public class RoomQueryRepositoryImpl implements RoomQueryRepository {
                         room.title,
                         room.recruitCount,
                         room.memberCount,
+                        room.startDate,     // 방의 진행 시작일 정보 채우기
                         cursorExpr
                 ))
                 .from(participant)

--- a/src/main/java/konkuk/thip/room/application/mapper/RoomQueryMapper.java
+++ b/src/main/java/konkuk/thip/room/application/mapper/RoomQueryMapper.java
@@ -4,6 +4,8 @@ import konkuk.thip.common.util.DateUtil;
 import konkuk.thip.room.adapter.in.web.response.RoomGetDeadlinePopularResponse;
 import konkuk.thip.room.adapter.in.web.response.RoomShowMineResponse;
 import konkuk.thip.room.application.port.out.dto.RoomQueryDto;
+import konkuk.thip.room.application.port.in.dto.MyRoomType;
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -17,11 +19,9 @@ import java.util.List;
 )
 public interface RoomQueryMapper {
 
-    @Mapping(
-            target = "endDate",
-            expression = "java(DateUtil.formatAfterTime(dto.endDate()))"
-    )
-    RoomShowMineResponse.MyRoom toShowMyRoomResponse(RoomQueryDto dto);
+    @Mapping(target = "endDate", expression = "java(DateUtil.formatAfterTime(dto.endDate()))")
+    @Mapping(target = "type", expression = "java(myRoomType.getType())")
+    RoomShowMineResponse.MyRoom toShowMyRoomResponse(RoomQueryDto dto, @Context MyRoomType myRoomType);
 
     @Mapping(
             target = "deadlineDate",

--- a/src/main/java/konkuk/thip/room/application/port/in/dto/MyRoomType.java
+++ b/src/main/java/konkuk/thip/room/application/port/in/dto/MyRoomType.java
@@ -1,4 +1,4 @@
-package konkuk.thip.room.domain;
+package konkuk.thip.room.application.port.in.dto;
 
 import konkuk.thip.common.exception.InvalidStateException;
 import konkuk.thip.common.exception.code.ErrorCode;

--- a/src/main/java/konkuk/thip/room/application/port/out/dto/RoomQueryDto.java
+++ b/src/main/java/konkuk/thip/room/application/port/out/dto/RoomQueryDto.java
@@ -1,6 +1,7 @@
 package konkuk.thip.room.application.port.out.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
+import jakarta.annotation.Nullable;
 import lombok.Builder;
 import org.springframework.util.Assert;
 
@@ -13,6 +14,7 @@ public record RoomQueryDto(
         String roomName,
         int recruitCount, // 방 최대 인원 수
         int memberCount,
+        @Nullable LocalDate startDate,    // 방 진행 시작일
         LocalDate endDate       // 방 진행 마감일 or 방 모집 마감일
 ) {
     @QueryProjection
@@ -23,5 +25,17 @@ public record RoomQueryDto(
         Assert.notNull(endDate, "endDate must not be null");
         Assert.isTrue(recruitCount > 0, "recruitCount must be greater than 0");
         Assert.isTrue(memberCount >= 0, "memberCount must be greater than or equal to 0");
+    }
+
+    @QueryProjection
+    public RoomQueryDto(
+            Long roomId,
+            String bookImageUrl,
+            String roomName,
+            int recruitCount,
+            int memberCount,
+            LocalDate endDate
+    ) {
+        this(roomId, bookImageUrl, roomName, recruitCount, memberCount, null, endDate);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #151 

## 📝 작업 내용
@rbqks529 님의 요청으로 조회한 방이 [모집중, 진행중, 완료된] 상태 중 어떤 상태인지를 알 수 있도록 response dto 를 수정하였습니다

현재 api는 request param의 값에 의해 내가 참여한 모임방 중 [모집중, 진행중, 모집+진행중, 완료된] 방을 조회할 수 있는데,
- 모집중, 진행중, 완료된 모임방 조회일 경우 : request param 의 값에 해당하는 방들을 조회 + 이 값을 그대로 응답
- 모집+진행중 일 경우 : 모집+진행중인 방 조회 + 조회한 방이 어떤 방인지를 분기처리하여 응답

하도록 api 를 수정하였습니다

## 📸 스크린샷
<img width="681" height="799" alt="image" src="https://github.com/user-attachments/assets/0f0047a4-ba10-433e-8db6-7197841501b4" />
-> 모집+진행 중인 방으로 조회해도 recruiting 으로 응답이 오는것을 확인할 수 있습니다

## 💬 리뷰 요구사항
RoomQueryDto 를 수정한 부분 확인해 주시면 감사하겠습니다! @buzz0331 @hd0rable 


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
