### PR TITLE
[hotfix] 내 방 목록 조회, 모집중인 모임방 상세조회 api response 추가 수정

### DIFF
--- a/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomRecruitingDetailViewResponse.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomRecruitingDetailViewResponse.java
@@ -28,6 +28,7 @@ public record RoomRecruitingDetailViewResponse(
 ) {
     @Builder
     public record RecommendRoom(
+            Long roomId,
             String roomImageUrl,
             String roomName,
             int memberCount,

--- a/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomShowMineResponse.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomShowMineResponse.java
@@ -14,6 +14,11 @@ public record RoomShowMineResponse(
             Long roomId,
             String bookImageUrl,
             String roomName,
+
+            @Schema(description = "방의 최대 모집인원 수")
+            int recruitCount,
+
+            @Schema(description = "방의 멤버 수")
             int memberCount,
 
             @Schema(description = "방 진행 마감일 or 방 모집 마감일까지 남은 시간 (ex. \"3일 뒤\"), 완료된 방은 쓰레기값이 넘어갑니다. 무시해주세요.")

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomQueryRepositoryImpl.java
@@ -169,6 +169,7 @@ public class RoomQueryRepositoryImpl implements RoomQueryRepository {
 
         return tuples.stream()
                 .map(t -> RoomRecruitingDetailViewResponse.RecommendRoom.builder()
+                        .roomId(t.get(room.roomId))
                         .roomImageUrl(null)     // roomImageUrl은 추후 구현
                         .roomName(t.get(room.title))
                         .memberCount(t.get(memberCountExpr).intValue())


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #157 

## 📝 작업 내용
157 번 이슈 참고하시면 됩니다

## 📸 스크린샷
<img width="627" height="835" alt="image" src="https://github.com/user-attachments/assets/9435dbb0-141c-49bb-85bd-90f6adfc6937" />

response에 recruitingCount 추가하였습니다

<img width="569" height="834" alt="image" src="https://github.com/user-attachments/assets/be7d81d2-b4b5-4d15-855e-f8d5df85f22b" />

resposne에 추천방의 roomId 값 추가하였습니다

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 추천 방 정보에 방 식별자(roomId)가 추가되어 더 많은 정보를 확인할 수 있습니다.
  * 내 방 목록에서 최대 모집 인원(recruitCount)과 현재 멤버 수(memberCount)가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->