### PR TITLE
[hotfix] 기록 작성시 Room과 RoomParticipant 업데이트

### DIFF
--- a/src/main/java/konkuk/thip/room/adapter/out/jpa/RoomParticipantJpaEntity.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/jpa/RoomParticipantJpaEntity.java
@@ -3,6 +3,7 @@ package konkuk.thip.room.adapter.out.jpa;
 import com.google.common.annotations.VisibleForTesting;
 import jakarta.persistence.*;
 import konkuk.thip.common.entity.BaseJpaEntity;
+import konkuk.thip.room.domain.RoomParticipant;
 import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
@@ -49,5 +50,11 @@ public class RoomParticipantJpaEntity extends BaseJpaEntity {
     @VisibleForTesting
     public void updateUserPercentage(double userPercentage) {
         this.userPercentage = userPercentage;
+    }
+
+    public void updateFrom(RoomParticipant roomParticipant) {
+        this.currentPage = roomParticipant.getCurrentPage();
+        this.userPercentage = roomParticipant.getUserPercentage();
+        this.roomParticipantRole = RoomParticipantRole.from(roomParticipant.getRoomParticipantRole());
     }
 }

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomParticipantCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomParticipantCommandPersistenceAdapter.java
@@ -61,6 +61,16 @@ public class RoomParticipantCommandPersistenceAdapter implements RoomParticipant
     }
 
     @Override
+    public void update(RoomParticipant roomParticipant) {
+        RoomParticipantJpaEntity roomParticipantJpaEntity = roomParticipantJpaRepository.findById(roomParticipant.getId()).orElseThrow(
+                () -> new EntityNotFoundException(ErrorCode.ROOM_PARTICIPANT_NOT_FOUND)
+        );
+
+        roomParticipantJpaEntity.updateFrom(roomParticipant);
+        roomParticipantJpaRepository.save(roomParticipantJpaEntity);
+    }
+
+    @Override
     public Optional<RoomParticipant> findByUserIdAndRoomIdOptional(Long userId, Long roomId) {
         return roomParticipantJpaRepository.findByUserIdAndRoomId(userId, roomId)
                 .map(roomParticipantMapper::toDomainEntity);

--- a/src/main/java/konkuk/thip/room/application/port/out/RoomCommandPort.java
+++ b/src/main/java/konkuk/thip/room/application/port/out/RoomCommandPort.java
@@ -1,7 +1,6 @@
 package konkuk.thip.room.application.port.out;
 
 import konkuk.thip.common.exception.EntityNotFoundException;
-import konkuk.thip.room.domain.Category;
 import konkuk.thip.room.domain.Room;
 
 import java.util.Optional;

--- a/src/main/java/konkuk/thip/room/application/port/out/RoomParticipantCommandPort.java
+++ b/src/main/java/konkuk/thip/room/application/port/out/RoomParticipantCommandPort.java
@@ -22,6 +22,5 @@ public interface RoomParticipantCommandPort {
 
     void deleteByUserIdAndRoomId(Long userId, Long roomId);
 
-
-
+    void update(RoomParticipant roomParticipant);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #169 

## 📝 작업 내용

기록 작성시 RoomParticipant와 Room을 도메인 로직에서 업데이트하고 영속화 시키는 로직이 누락되어서 추가했습니다!

## 📸 스크린샷

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
