### PR TITLE
[feat] 소셜 로그인 사용자 정보 조회 api 개발 및 소셜 로그인 리다이렉트 분기 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ dependencies {
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 
+	// Spring Boot Actuator
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 

--- a/src/main/java/konkuk/thip/common/security/constant/AuthParameters.java
+++ b/src/main/java/konkuk/thip/common/security/constant/AuthParameters.java
@@ -12,6 +12,8 @@ public enum AuthParameters {
     GOOGLE_PROVIDER_ID_KEY("sub"),
     JWT_ACCESS_TOKEN_KEY("userId"),
     JWT_SIGNUP_TOKEN_KEY("oauth2Id"),
+    REDIRECT_SIGNUP_URL("/signup/genre"),
+    REDIRECT_HOME_URL("/feed"),
     ;
 
     private final String value;

--- a/src/main/java/konkuk/thip/common/security/oauth2/CustomOAuth2UserController.java
+++ b/src/main/java/konkuk/thip/common/security/oauth2/CustomOAuth2UserController.java
@@ -1,0 +1,47 @@
+package konkuk.thip.common.security.oauth2;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.servlet.http.HttpServletResponse;
+import konkuk.thip.common.dto.BaseResponse;
+import konkuk.thip.common.security.util.JwtUtil;
+import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+import static konkuk.thip.common.security.constant.AuthParameters.*;
+
+@RestController
+@RequiredArgsConstructor
+public class CustomOAuth2UserController {
+
+    private final UserJpaRepository userJpaRepository;
+    private final JwtUtil jwtUtil;
+
+    @Operation(
+            summary = "소셜 로그인 유저 확인",
+            description = "소셜 로그인 시 기존 유저인지 신규 유저인지 확인하고, AccessToken 또는 SignupToken을 발급합니다." +
+            "isNewUser가 true인 경우 신규 유저로 간주하며(임시 토큰 발급), false인 경우 기존 유저로 간주합니다.(액세스 토큰 발급)"
+    )
+    @GetMapping("/oauth2/users")
+    public BaseResponse<OAuth2TokenResponse> checkUserExists(
+            @Parameter(description = "소셜 로그인 ID (형식: {provider}_{식별자 ID})", example = "kakao_1234567890")
+            @RequestParam("oauth2Id") String oauth2Id,
+            HttpServletResponse response) throws IOException {
+        return userJpaRepository.findByOauth2Id(oauth2Id)
+                .map(user -> {
+                    // 기존 유저: AccessToken 발급
+                    String accessToken = jwtUtil.createAccessToken(user.getUserId());
+                    return BaseResponse.ok(OAuth2TokenResponse.of(JWT_PREFIX.getValue() + accessToken,false));
+                })
+                .orElseGet(() -> {
+                    // 신규 유저: SignupToken 발급
+                    String tempToken = jwtUtil.createSignupToken(oauth2Id);
+                    return BaseResponse.ok(OAuth2TokenResponse.of(JWT_PREFIX.getValue() + tempToken, true));
+                });
+    }
+}

--- a/src/main/java/konkuk/thip/common/security/oauth2/CustomOAuth2UserController.java
+++ b/src/main/java/konkuk/thip/common/security/oauth2/CustomOAuth2UserController.java
@@ -13,8 +13,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
 
-import static konkuk.thip.common.security.constant.AuthParameters.*;
-
 @RestController
 @RequiredArgsConstructor
 public class CustomOAuth2UserController {
@@ -36,12 +34,12 @@ public class CustomOAuth2UserController {
                 .map(user -> {
                     // 기존 유저: AccessToken 발급
                     String accessToken = jwtUtil.createAccessToken(user.getUserId());
-                    return BaseResponse.ok(OAuth2TokenResponse.of(JWT_PREFIX.getValue() + accessToken,false));
+                    return BaseResponse.ok(OAuth2TokenResponse.of(accessToken,false));
                 })
                 .orElseGet(() -> {
                     // 신규 유저: SignupToken 발급
                     String tempToken = jwtUtil.createSignupToken(oauth2Id);
-                    return BaseResponse.ok(OAuth2TokenResponse.of(JWT_PREFIX.getValue() + tempToken, true));
+                    return BaseResponse.ok(OAuth2TokenResponse.of(tempToken, true));
                 });
     }
 }

--- a/src/main/java/konkuk/thip/common/security/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/konkuk/thip/common/security/oauth2/CustomSuccessHandler.java
@@ -1,12 +1,12 @@
 package konkuk.thip.common.security.oauth2;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import konkuk.thip.common.dto.BaseResponse;
 import konkuk.thip.common.security.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -16,38 +16,59 @@ import java.io.IOException;
 import static konkuk.thip.common.security.constant.AuthParameters.JWT_HEADER_KEY;
 import static konkuk.thip.common.security.constant.AuthParameters.JWT_PREFIX;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
-    private static final String CONTENT_TYPE = "application/json";
-    private static final String ENCODING = "UTF-8";
+
+    private static final int COOKIE_MAX_AGE = 60 * 60 * 24; // 1일
+
     private final JwtUtil jwtUtil;
 
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) throws IOException, ServletException {
+
         CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
         LoginUser loginUser = oAuth2User.getLoginUser();
 
-        if(oAuth2User.isNewUser()) {
-            // 최초 로그인 : 회원가입을 위한 임시 토큰 발급
-            String tempToken = jwtUtil.createSignupToken(loginUser.oauth2Id());
-            response.setHeader(JWT_HEADER_KEY.getValue(), JWT_PREFIX.getValue() + tempToken);
-            writeResponse(response, BaseResponse.ok(oAuth2User.getLoginUser()));
+        // 요청 파라미터에서 리디렉션 URL 추출
+        String signupUrl = request.getParameter("signupUrl");
+        String homeUrl = request.getParameter("homeUrl");
+
+        if (signupUrl == null) {
+            log.error("signupUrl 파라미터가 누락되었습니다.");
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "signupUrl 파라미터가 누락되었습니다.");
+            return;
+        }
+        if (homeUrl == null) {
+            log.error("homeUrl 파라미터가 누락되었습니다.");
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "homeUrl 파라미터가 누락되었습니다.");
             return;
         }
 
-        // 기존 회원 : Access Token 발급
-        String accessToken = jwtUtil.createAccessToken(loginUser.userId());
-        response.setHeader(JWT_HEADER_KEY.getValue(), JWT_PREFIX.getValue() + accessToken);
-        writeResponse(response, BaseResponse.ok(oAuth2User.getLoginUser()));
+        if (oAuth2User.isNewUser()) {
+            // 신규 유저 - 회원가입용 임시 토큰
+            String tempToken = jwtUtil.createSignupToken(loginUser.oauth2Id());
+            addTokenCookie(response, tempToken);
+            getRedirectStrategy().sendRedirect(request, response, signupUrl);
+        } else {
+            // 기존 유저 - 로그인용 액세스 토큰
+            String accessToken = jwtUtil.createAccessToken(loginUser.userId());
+            addTokenCookie(response, accessToken);
+            getRedirectStrategy().sendRedirect(request, response, homeUrl);
+        }
     }
 
-    private void writeResponse(HttpServletResponse response, Object value) throws IOException {
-        response.setStatus(HttpServletResponse.SC_OK);
-        response.setContentType(CONTENT_TYPE);
-        response.setCharacterEncoding(ENCODING);
-        ObjectMapper objectMapper = new ObjectMapper();
-        String body = objectMapper.writeValueAsString(value);
-        response.getWriter().write(body);
+    private void addTokenCookie(HttpServletResponse response, String token) {
+        Cookie cookie = new Cookie(JWT_HEADER_KEY.getValue(), JWT_PREFIX.getValue() + token);
+//        cookie.setHttpOnly(true);
+//        cookie.setSecure(true); // HTTPS에서만 전송
+        cookie.setPath("/");
+        cookie.setMaxAge(COOKIE_MAX_AGE);
+        response.addCookie(cookie);
     }
 }

--- a/src/main/java/konkuk/thip/common/security/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/konkuk/thip/common/security/oauth2/CustomSuccessHandler.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
-import static konkuk.thip.common.security.constant.AuthParameters.JWT_HEADER_KEY;
+import static konkuk.thip.common.security.constant.AuthParameters.*;
 
 @Slf4j
 @Component
@@ -23,12 +23,10 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     private static final int COOKIE_MAX_AGE = 60 * 60 * 24; // 1일
 
-    @Value("${server.web-domain-url}")
+    @Value("${server.web-redirect-url}")
     private String webRedirectUrl;
 
     private final JwtUtil jwtUtil;
-    private final String signupEndPoint = "/signup/genre";
-    private final String homeEndPoint = "/feed";
 
     @Override
     public void onAuthenticationSuccess(
@@ -44,12 +42,12 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             // 신규 유저 - 회원가입용 임시 토큰
             String tempToken = jwtUtil.createSignupToken(loginUser.oauth2Id());
             addTokenCookie(response, tempToken);
-            getRedirectStrategy().sendRedirect(request, response, webRedirectUrl + signupEndPoint);
+            getRedirectStrategy().sendRedirect(request, response, webRedirectUrl + REDIRECT_SIGNUP_URL);
         } else {
             // 기존 유저 - 로그인용 액세스 토큰
             String accessToken = jwtUtil.createAccessToken(loginUser.userId());
             addTokenCookie(response, accessToken);
-            getRedirectStrategy().sendRedirect(request, response, webRedirectUrl + homeEndPoint);
+            getRedirectStrategy().sendRedirect(request, response, webRedirectUrl + REDIRECT_HOME_URL);
         }
     }
 

--- a/src/main/java/konkuk/thip/common/security/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/konkuk/thip/common/security/oauth2/CustomSuccessHandler.java
@@ -53,6 +53,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     private void addTokenCookie(HttpServletResponse response, String token) {
         Cookie cookie = new Cookie(JWT_HEADER_KEY.getValue(), token);
+        cookie.setSecure(true);
         cookie.setPath("/");
         cookie.setMaxAge(COOKIE_MAX_AGE);
         response.addCookie(cookie);

--- a/src/main/java/konkuk/thip/common/security/oauth2/OAuth2TokenResponse.java
+++ b/src/main/java/konkuk/thip/common/security/oauth2/OAuth2TokenResponse.java
@@ -1,0 +1,10 @@
+package konkuk.thip.common.security.oauth2;
+
+public record OAuth2TokenResponse(
+        String token,
+        boolean isNewUser
+) {
+    public static OAuth2TokenResponse of(String token, boolean isNewUser) {
+        return new OAuth2TokenResponse(token, isNewUser);
+    }
+}

--- a/src/main/java/konkuk/thip/config/SecurityConfig.java
+++ b/src/main/java/konkuk/thip/config/SecurityConfig.java
@@ -24,6 +24,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import java.util.Collections;
 import java.util.List;
 
+import static konkuk.thip.common.security.constant.AuthParameters.JWT_HEADER_KEY;
+
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -103,7 +105,7 @@ public class SecurityConfig {
         config.setAllowCredentials(true);
         config.setMaxAge(3600L);
 
-        config.setExposedHeaders(Collections.singletonList("Authorization"));
+        config.setExposedHeaders(Collections.singletonList(JWT_HEADER_KEY.getValue()));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);

--- a/src/main/java/konkuk/thip/config/SecurityConfig.java
+++ b/src/main/java/konkuk/thip/config/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
             "/swagger-ui/**", "/api-docs/**", "/swagger-ui.html",
             "/v3/api-docs/**","/oauth2/authorization/**",
             "/login/oauth2/code/**", "/actuator/health",
+            "/oauth2/users",
 
     };
 

--- a/src/main/java/konkuk/thip/user/adapter/in/web/UserCommandController.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/UserCommandController.java
@@ -3,12 +3,10 @@ package konkuk.thip.user.adapter.in.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import konkuk.thip.common.dto.BaseResponse;
 import konkuk.thip.common.security.annotation.Oauth2Id;
 import konkuk.thip.common.security.annotation.UserId;
-import konkuk.thip.common.security.util.JwtUtil;
 import konkuk.thip.common.swagger.annotation.ExceptionDescription;
 import konkuk.thip.user.adapter.in.web.request.UserFollowRequest;
 import konkuk.thip.user.adapter.in.web.request.UserSignupRequest;
@@ -21,8 +19,6 @@ import konkuk.thip.user.application.port.in.UserUpdateUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import static konkuk.thip.common.security.constant.AuthParameters.JWT_HEADER_KEY;
-import static konkuk.thip.common.security.constant.AuthParameters.JWT_PREFIX;
 import static konkuk.thip.common.swagger.SwaggerResponseDescription.*;
 
 @Tag(name = "User Command API", description = "사용자가 주체가 되는 정보 수정")
@@ -34,8 +30,6 @@ public class UserCommandController {
     private final UserFollowUsecase userFollowUsecase;
     private final UserUpdateUseCase userUpdateUseCase;
 
-    private final JwtUtil jwtUtil;
-
     @Operation(
             summary = "사용자 회원가입",
             description = "사용자가 회원가입을 합니다. OAuth2 ID를 통해 사용자를 식별합니다."
@@ -43,12 +37,10 @@ public class UserCommandController {
     @ExceptionDescription(USER_SIGNUP)
     @PostMapping("/users/signup")
     public BaseResponse<UserSignupResponse> signup(@Valid @RequestBody final UserSignupRequest request,
-                                                   @Parameter(hidden = true) @Oauth2Id final String oauth2Id,
-                                                   HttpServletResponse response) {
-        Long userId = userSignupUseCase.signup(request.toCommand(oauth2Id));
-        String accessToken = jwtUtil.createAccessToken(userId);
-        response.setHeader(JWT_HEADER_KEY.getValue(), JWT_PREFIX.getValue() + accessToken);
-        return BaseResponse.ok(UserSignupResponse.of(userId));
+                                                   @Parameter(hidden = true) @Oauth2Id final String oauth2Id) {
+        return BaseResponse.ok(
+                UserSignupResponse.of(userSignupUseCase.signup(request.toCommand(oauth2Id)))
+        );
     }
 
     @Operation(

--- a/src/main/java/konkuk/thip/user/adapter/in/web/response/UserSignupResponse.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/response/UserSignupResponse.java
@@ -1,7 +1,12 @@
 package konkuk.thip.user.adapter.in.web.response;
 
-public record UserSignupResponse(Long userId) {
-    public static UserSignupResponse of(Long userId) {
-        return new UserSignupResponse(userId);
+import konkuk.thip.user.application.port.in.dto.UserSignupResult;
+
+public record UserSignupResponse(
+        Long userId,
+        String accessToken
+        ) {
+    public static UserSignupResponse of(UserSignupResult userSignupResult) {
+        return new UserSignupResponse(userSignupResult.userId(), userSignupResult.accessToken());
     }
 }

--- a/src/main/java/konkuk/thip/user/application/port/in/UserSignupUseCase.java
+++ b/src/main/java/konkuk/thip/user/application/port/in/UserSignupUseCase.java
@@ -1,8 +1,9 @@
 package konkuk.thip.user.application.port.in;
 
 import konkuk.thip.user.application.port.in.dto.UserSignupCommand;
+import konkuk.thip.user.application.port.in.dto.UserSignupResult;
 
 public interface UserSignupUseCase {
 
-    Long signup(UserSignupCommand command);
+    UserSignupResult signup(UserSignupCommand command);
 }

--- a/src/main/java/konkuk/thip/user/application/port/in/dto/UserSignupResult.java
+++ b/src/main/java/konkuk/thip/user/application/port/in/dto/UserSignupResult.java
@@ -1,0 +1,10 @@
+package konkuk.thip.user.application.port.in.dto;
+
+public record UserSignupResult(
+        Long userId,
+        String accessToken
+) {
+    public static UserSignupResult of(Long userId, String accessToken) {
+        return new UserSignupResult(userId, accessToken);
+    }
+}

--- a/src/main/java/konkuk/thip/user/application/service/UserSignupService.java
+++ b/src/main/java/konkuk/thip/user/application/service/UserSignupService.java
@@ -1,7 +1,9 @@
 package konkuk.thip.user.application.service;
 
+import konkuk.thip.common.security.util.JwtUtil;
 import konkuk.thip.user.application.port.in.UserSignupUseCase;
 import konkuk.thip.user.application.port.in.dto.UserSignupCommand;
+import konkuk.thip.user.application.port.in.dto.UserSignupResult;
 import konkuk.thip.user.application.port.out.UserCommandPort;
 import konkuk.thip.user.domain.Alias;
 import konkuk.thip.user.domain.User;
@@ -20,14 +22,18 @@ public class UserSignupService implements UserSignupUseCase {
 
     private final UserCommandPort userCommandPort;
 
+    private final JwtUtil jwtUtil;
+
     @Override
     @Transactional
-    public Long signup(UserSignupCommand command) {
+    public UserSignupResult signup(UserSignupCommand command) {
         Alias alias = Alias.from(command.aliasName());
         User user = User.withoutId(
                 command.nickname(), LocalDate.now(), USER.getType(), command.oauth2Id(), alias
         );
+        Long userId = userCommandPort.save(user);
+        String accessToken = jwtUtil.createAccessToken(userId);
 
-        return userCommandPort.save(user);
+        return UserSignupResult.of(userId, accessToken);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #174 

## 📝 작업 내용

**안드로이드**
소셜 로그인 provider로부터 받은 식별자를 쿼리 파라미터로 받아 서버 DB에 존재하는지 여부를 판단하여 액세스 토큰 또는 임시 토큰을 전달하는 api를 구현했습니다.

**웹**
기존 소셜 로그인 api를 유지하고 정적 redirect url을 통해 신규 유저 여부에 따라 홈화면 또는 회원가입 화면으로 redirect 시키도록 했습니다. 이때, 쿠키를 통해 토큰을 전달합니다.

## 📸 스크린샷

## 💬 리뷰 요구사항

토큰을 바디로 넘겨주는 것이 더 안전하다는 피드백을 받아 회원가입 api, 사용자 정보 조회 api에서 반환하는 토큰은 모두 바디로 넘겨주는 것으로 수정하였습니다.

하나의 간단한 api이기 때문에 따로 패키지를 만드는 것보다는 기존 security.oauth2Id 패키지 하위에 컨트롤러 하나만 선언하는 것이 낫다고 판단했습니다~

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
