### PR TITLE
[hotfix] 총평 여부 api에서 최근 읽은 책 페이지 반환

### DIFF
--- a/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomGetBookPageResponse.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomGetBookPageResponse.java
@@ -2,10 +2,11 @@ package konkuk.thip.room.adapter.in.web.response;
 
 public record RoomGetBookPageResponse(
         int totalBookPage,
+        int recentBookPage,
         boolean isOverviewPossible,
         Long roomId
 ) {
-    public static RoomGetBookPageResponse of(int totalBookPage, boolean isOverviewPossible, Long roomId) {
-        return new RoomGetBookPageResponse(totalBookPage, isOverviewPossible, roomId);
+    public static RoomGetBookPageResponse of(int totalBookPage, int recentBookPage, boolean isOverviewPossible, Long roomId) {
+        return new RoomGetBookPageResponse(totalBookPage, recentBookPage, isOverviewPossible, roomId);
     }
 }

--- a/src/main/java/konkuk/thip/room/application/service/RoomGetBookPageService.java
+++ b/src/main/java/konkuk/thip/room/application/service/RoomGetBookPageService.java
@@ -28,6 +28,6 @@ public class RoomGetBookPageService implements RoomGetBookPageUseCase {
         Book book = bookCommandPort.findBookByRoomId(roomId);
         RoomParticipant roomParticipant = roomParticipantCommandPort.getByUserIdAndRoomIdOrThrow(userId, roomId);
 
-        return RoomGetBookPageResponse.of(book.getPageCount(), roomParticipant.canWriteOverview(), roomId);
+        return RoomGetBookPageResponse.of(book.getPageCount(), roomParticipant.getCurrentPage(), roomParticipant.canWriteOverview(), roomId);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #184 

## 📝 작업 내용

@Nico1eKim 님의 요청에 따라 총평 여부 api에서 최근 읽은 책 페이지를 반환합니다. (처음 읽는 경우 0)

## 📸 스크린샷

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 방의 책 페이지 정보를 조회할 때 최근 읽은 페이지 정보가 추가로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->