### PR TITLE
[hotfix] 모임홈 진행중인 내모임방 조회 시 책 제목이 아닌 방제목 반환 하도록 수정 

### DIFF
--- a/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomGetHomeJoinedListResponse.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomGetHomeJoinedListResponse.java
@@ -19,7 +19,7 @@ public record RoomGetHomeJoinedListResponse(
     public record RoomSearchResult(
             Long roomId,
             String bookImageUrl,
-            String bookTitle,
+            String roomTitle,
             int memberCount,
             int userPercentage
     ) {}

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomQueryRepositoryImpl.java
@@ -9,7 +9,6 @@ import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.DateExpression;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
-import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import konkuk.thip.book.adapter.out.jpa.QBookJpaEntity;
 import konkuk.thip.common.entity.StatusType;
@@ -192,20 +191,13 @@ public class RoomQueryRepositoryImpl implements RoomQueryRepository {
         where.and(room.startDate.loe(date));
         where.and(room.endDate.goe(date));
 
-        // TODO : Room 에 멤버 수 추가되면 로직 수정
-        // 멤버 수 서브쿼리
-        JPQLQuery<Long> memberCountSubQuery = JPAExpressions
-                .select(userRoomSub.count())
-                .from(userRoomSub)
-                .where(userRoomSub.roomJpaEntity.roomId.eq(room.roomId));
-
         // 2. 페이징된 목록 조회
         List<Tuple> tuples = queryFactory
                 .select(
                         room.roomId,
                         book.imageUrl,
                         room.title,
-                        memberCountSubQuery,
+                        room.memberCount,
                         room.recruitCount,
                         room.startDate,
                         book.title,
@@ -229,8 +221,8 @@ public class RoomQueryRepositoryImpl implements RoomQueryRepository {
                 .map(t -> RoomGetHomeJoinedListResponse.RoomSearchResult.builder()
                         .roomId(t.get(room.roomId))
                         .bookImageUrl(t.get(book.imageUrl))
-                        .bookTitle(t.get(book.title))
-                        .memberCount(Optional.ofNullable(t.get(memberCountSubQuery)).map(Number::intValue).orElse(1))
+                        .roomTitle(t.get(room.title))
+                        .memberCount(t.get(room.memberCount))
                         .userPercentage(Optional.ofNullable(t.get(participant.userPercentage))
                                         .map(val -> ((Number) val).doubleValue())
                                                 .map(Math::round)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #186 

## 📝 작업 내용

- 모임홈 진행중인 내모임방 조회 시 책 제목이 아닌 방제목을 반환 하도록 수정했습니다

## 📸 스크린샷
<img width="517" height="432" alt="image" src="https://github.com/user-attachments/assets/32c417f7-c72a-4489-b2a2-1e7b6527ab0a" />

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
