### PR TITLE
[hotfix] 기록장 조회 api에서 총평 가능 여부 플래그 반환

### DIFF
--- a/src/main/java/konkuk/thip/record/adapter/in/web/response/RecordSearchResponse.java
+++ b/src/main/java/konkuk/thip/record/adapter/in/web/response/RecordSearchResponse.java
@@ -9,6 +9,7 @@ public record RecordSearchResponse(
     List<PostDto> postList,
     Long roomId,
     String isbn,
+    boolean isOverviewEnabled,
     String nextCursor,
     Boolean isLast
 ){

--- a/src/main/java/konkuk/thip/record/application/service/RecordSearchService.java
+++ b/src/main/java/konkuk/thip/record/application/service/RecordSearchService.java
@@ -106,6 +106,7 @@ public class RecordSearchService implements RecordSearchUseCase {
         return RecordSearchResponse.builder()
                 .roomId(roomId)
                 .isbn(book.getIsbn())
+                .isOverviewEnabled(roomParticipant.getUserPercentage() >= 80)
                 .postList(postDtos)
                 .nextCursor(cursorBasedList.nextCursor())
                 .isLast(!cursorBasedList.hasNext())


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #189 

## 📝 작업 내용

@Nico1eKim 님의 요청에 따라서 기록장 조회 api에서 해당 사용자가 총평 필터칩을 활성화 가능한지 여부를 판단하는 플래그를 반환합니다.

사용자 진행도 >= 80 : isOverviewEnabled = true
사용자 진행도 < 80 : isOverviewEnabled = false

## 📸 스크린샷

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 검색 결과에 ‘개요 보기’ 사용 가능 여부가 함께 표시됩니다. 사용자 참여율이 80% 이상일 때 자동으로 활성화되어, 조건을 충족하면 개요 보기 진입이 가능해집니다.
  - 화면에서 개요 보기 관련 버튼/배지가 상황에 맞게 활성화 또는 비활성화되어, 현재 사용 가능 상태를 직관적으로 확인할 수 있습니다.
  - 조건 미충족 시 불필요한 접근 시도가 줄어들고, 기능 접근성에 대한 피드백이 명확해집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->