### PR TITLE
[feat] 내가 팔로잉하는 유저들 중, 최근 공개 피드 작성한 유저 정보 조회 api 개발

### DIFF
--- a/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/UserQueryController.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import konkuk.thip.common.dto.BaseResponse;
 import konkuk.thip.common.security.annotation.UserId;
+import konkuk.thip.user.application.port.in.*;
 import konkuk.thip.user.application.port.in.dto.UserReactionType;
 import konkuk.thip.user.adapter.in.web.response.*;
 import konkuk.thip.common.swagger.annotation.ExceptionDescription;
@@ -18,13 +19,7 @@ import konkuk.thip.user.adapter.in.web.response.UserFollowingResponse;
 import konkuk.thip.user.adapter.in.web.response.UserVerifyNicknameResponse;
 import konkuk.thip.user.adapter.in.web.response.UserIsFollowingResponse;
 import konkuk.thip.user.adapter.in.web.response.UserViewAliasChoiceResponse;
-import konkuk.thip.user.application.port.in.UserGetFollowUsecase;
-import konkuk.thip.user.application.port.in.UserVerifyNicknameUseCase;
-import konkuk.thip.user.application.port.in.UserIsFollowingUsecase;
-import konkuk.thip.user.application.port.in.UserSearchUsecase;
-import konkuk.thip.user.application.port.in.UserViewAliasChoiceUseCase;
 import konkuk.thip.user.application.port.in.dto.UserSearchQuery;
-import konkuk.thip.user.application.port.in.UserMyPageUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -48,6 +43,7 @@ public class UserQueryController {
     private final UserVerifyNicknameUseCase userVerifyNicknameUseCase;
     private final UserSearchUsecase userSearchUsecase;
     private final UserMyPageUseCase userMyPageUseCase;
+    private final UserShowFollowingRecentWritersUseCase userShowFollowingRecentWritersUseCase;
 
     @Operation(
             summary = "닉네임 중복 확인",
@@ -159,5 +155,16 @@ public class UserQueryController {
     public BaseResponse<Long> showUserMyId(
             @Parameter(hidden = true) @UserId final Long userId) {
         return BaseResponse.ok(userId);
+    }
+
+    @Operation(
+            summary = "최근에 공개 피드를 작성한 내 팔로잉 리스트(= 내 띱 리스트) 조회",
+            description = "내가 팔로잉 하는 사람들 중, 최근에 공개 피드를 작성한 사람들의 정보를 최대 10명 반환합니다."
+    )
+    @GetMapping("/users/my-followings/recent-feeds")
+    public BaseResponse<UserFollowingRecentWritersResponse> showMyFollowingRecentWriters(
+            @Parameter(hidden = true) @UserId Long userId
+    ) {
+        return BaseResponse.ok(userShowFollowingRecentWritersUseCase.showMyFollowingRecentWriters(userId));
     }
 }

--- a/src/main/java/konkuk/thip/user/adapter/in/web/response/UserFollowingRecentWritersResponse.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/response/UserFollowingRecentWritersResponse.java
@@ -1,0 +1,22 @@
+package konkuk.thip.user.adapter.in.web.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "전체 피드 조회 상단에서의 내 띱 목록 응답 DTO")
+public record UserFollowingRecentWritersResponse(
+        @Schema(description = "내가 팔로잉하는 사람들 중, 최근에 공개 피드를 작성한 사람들")
+        List<RecentWriter> recentWriters
+) {
+    public record RecentWriter(
+            @Schema(description = "최근에 피드를 작성한 사람의 userId 값")
+            Long userId,
+
+            @Schema(description = "최근에 피드를 작성한 사람의 nickname 값")
+            String nickname,
+
+            @Schema(description = "최근에 피드를 작성한 사람의 profileImageUrl 값")
+            String profileImageUrl
+    ) {}
+}

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/UserQueryPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/UserQueryPersistenceAdapter.java
@@ -69,6 +69,11 @@ public class UserQueryPersistenceAdapter implements UserQueryPort {
         );
     }
 
+    @Override
+    public List<UserQueryDto> findRecentFeedWritersOfMyFollowings(Long userId, int size) {
+        return userJpaRepository.findFeedWritersOfMyFollowingsOrderByCreatedAtDesc(userId, size);
+    }
+
     private CursorBasedList<ReactionQueryDto> getReactions(Long userId, Cursor cursor, ReactionQueryFunction reactionQueryFunction) {
         LocalDateTime cursorLocalDateTime = cursor.isFirstRequest() ? null : cursor.getLocalDateTime(0);
 

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/UserQueryRepository.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/UserQueryRepository.java
@@ -18,4 +18,5 @@ public interface UserQueryRepository {
 
     List<ReactionQueryDto> findLikeAndCommentByUserId(Long userId, LocalDateTime cursorLocalDateTime, Integer size, String likeLabel, String commentLabel);
 
+    List<UserQueryDto> findFeedWritersOfMyFollowingsOrderByCreatedAtDesc(Long userId, Integer size);
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/UserQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/UserQueryRepositoryImpl.java
@@ -7,11 +7,13 @@ import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import konkuk.thip.comment.adapter.out.jpa.QCommentJpaEntity;
 import konkuk.thip.common.entity.StatusType;
+import konkuk.thip.feed.adapter.out.jpa.QFeedJpaEntity;
 import konkuk.thip.post.adapter.out.jpa.QPostJpaEntity;
 import konkuk.thip.post.adapter.out.jpa.QPostLikeJpaEntity;
 import konkuk.thip.room.adapter.out.jpa.QRoomJpaEntity;
 import konkuk.thip.room.adapter.out.jpa.QRoomParticipantJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.QAliasJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.QFollowingJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.QUserJpaEntity;
 import konkuk.thip.user.application.port.out.dto.QReactionQueryDto;
 import konkuk.thip.user.application.port.out.dto.QUserQueryDto;
@@ -159,5 +161,36 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
                 .toList();
     }
 
+    @Override
+    public List<UserQueryDto> findFeedWritersOfMyFollowingsOrderByCreatedAtDesc(Long userId, Integer size) {
+        QFollowingJpaEntity following = QFollowingJpaEntity.followingJpaEntity;
+        QUserJpaEntity writer = new QUserJpaEntity("writer");
+        QFeedJpaEntity feed = QFeedJpaEntity.feedJpaEntity;
+        QAliasJpaEntity alias = QAliasJpaEntity.aliasJpaEntity;
 
+        return queryFactory
+                .select(new QUserQueryDto(
+                        writer.userId,
+                        writer.nickname,
+                        alias.imageUrl
+                ))
+                .from(following)
+                .join(following.followingUserJpaEntity, writer)     // writer : 나에게 팔로잉 당하는 사람들
+                .join(feed).on(feed.userJpaEntity.eq(writer))
+                .leftJoin(writer.aliasForUserJpaEntity, alias)
+                .where(
+                        following.userJpaEntity.userId.eq(userId)       // 내가 팔로잉 하는 사람
+                                .and(writer.status.eq(StatusType.ACTIVE))       // 그 중 아직 회원인 사람
+                                .and(feed.status.eq(StatusType.ACTIVE))     // 그 중 삭제 X & 공개피드를 작성한 사람
+                                .and(feed.isPublic.isTrue())
+                )
+                .groupBy(       // 그룹핑
+                        writer.userId,
+                        writer.nickname,
+                        alias.imageUrl
+                )
+                .orderBy(feed.createdAt.max().desc())       // 피드 작성 시각 중 최대값 == 가장 최근에 작성한 피드
+                .limit(size)        // 무한 스크롤 X
+                .fetch();
+    }
 }

--- a/src/main/java/konkuk/thip/user/application/mapper/UserQueryMapper.java
+++ b/src/main/java/konkuk/thip/user/application/mapper/UserQueryMapper.java
@@ -1,5 +1,6 @@
 package konkuk.thip.user.application.mapper;
 
+import konkuk.thip.user.adapter.in.web.response.UserFollowingRecentWritersResponse;
 import konkuk.thip.user.adapter.in.web.response.UserSearchResponse;
 import konkuk.thip.user.application.port.out.dto.UserQueryDto;
 import org.mapstruct.Mapper;
@@ -12,6 +13,12 @@ public interface UserQueryMapper {
     // List<QueryDto> -> List<DTO>
     List<UserSearchResponse.UserDto> toUserDtoList(List<UserQueryDto> userQueryDtos);
 
-
-
+    // 단건 매핑: UserQueryDto -> RecentWriter
+    UserFollowingRecentWritersResponse.RecentWriter toRecentWriter(UserQueryDto dto);
+    // 리스트 매핑: List<UserQueryDto> -> List<RecentWriter>
+    List<UserFollowingRecentWritersResponse.RecentWriter> toRecentWriterList(List<UserQueryDto> dtos);
+    // 래핑: List<UserQueryDto> -> UserFollowingRecentWritersResponse
+    default UserFollowingRecentWritersResponse toRecentWriterResponses(List<UserQueryDto> dtos) {
+        return new  UserFollowingRecentWritersResponse(toRecentWriterList(dtos));
+    }
 }

--- a/src/main/java/konkuk/thip/user/application/port/in/UserShowFollowingRecentWritersUseCase.java
+++ b/src/main/java/konkuk/thip/user/application/port/in/UserShowFollowingRecentWritersUseCase.java
@@ -1,0 +1,8 @@
+package konkuk.thip.user.application.port.in;
+
+import konkuk.thip.user.adapter.in.web.response.UserFollowingRecentWritersResponse;
+
+public interface UserShowFollowingRecentWritersUseCase {
+
+    UserFollowingRecentWritersResponse showMyFollowingRecentWriters(Long userId);
+}

--- a/src/main/java/konkuk/thip/user/application/port/out/UserQueryPort.java
+++ b/src/main/java/konkuk/thip/user/application/port/out/UserQueryPort.java
@@ -25,4 +25,6 @@ public interface UserQueryPort {
     CursorBasedList<ReactionQueryDto> findCommentReactionsByUserId(Long userId, Cursor cursor, String label);
 
     CursorBasedList<ReactionQueryDto> findBothReactionsByUserId(Long userId, Cursor cursor, String likeLabel, String commentLabel);
+
+    List<UserQueryDto> findRecentFeedWritersOfMyFollowings(Long userId, int size);
 }

--- a/src/main/java/konkuk/thip/user/application/port/out/dto/UserQueryDto.java
+++ b/src/main/java/konkuk/thip/user/application/port/out/dto/UserQueryDto.java
@@ -18,9 +18,18 @@ public record UserQueryDto(Long userId,
         Assert.notNull(userId, "userId must not be null");
         Assert.notNull(nickname, "nickname must not be null");
         Assert.notNull(profileImageUrl, "profileImageUrl must not be null");
-        Assert.notNull(aliasName, "aliasName must not be null");
-        Assert.notNull(aliasColor, "aliasColor must not be null");
+//        Assert.notNull(aliasName, "aliasName must not be null");
+//        Assert.notNull(aliasColor, "aliasColor must not be null");
 //        Assert.notNull(followerCount, "followerCount must not be null"); // 내 팔로잉 목록 조회에서는 필요 x
-        Assert.notNull(createdAt, "createdAt must not be null");
+//        Assert.notNull(createdAt, "createdAt must not be null");
+    }
+
+    @QueryProjection
+    public UserQueryDto(
+            Long userId,
+            String nickname,
+            String profileImageUrl
+    ) {
+        this(userId, nickname, profileImageUrl, null, null, null, null);
     }
 }

--- a/src/main/java/konkuk/thip/user/application/service/UserShowFollowingRecentWritersService.java
+++ b/src/main/java/konkuk/thip/user/application/service/UserShowFollowingRecentWritersService.java
@@ -1,0 +1,22 @@
+package konkuk.thip.user.application.service;
+
+import konkuk.thip.user.adapter.in.web.response.UserFollowingRecentWritersResponse;
+import konkuk.thip.user.application.mapper.UserQueryMapper;
+import konkuk.thip.user.application.port.in.UserShowFollowingRecentWritersUseCase;
+import konkuk.thip.user.application.port.out.UserQueryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserShowFollowingRecentWritersService implements UserShowFollowingRecentWritersUseCase {
+
+    private static final int SIZE = 10;
+    private final UserQueryPort userQueryPort;
+    private final UserQueryMapper userQueryMapper;
+
+    @Override
+    public UserFollowingRecentWritersResponse showMyFollowingRecentWriters(Long userId) {
+        return userQueryMapper.toRecentWriterResponses(userQueryPort.findRecentFeedWritersOfMyFollowings(userId, SIZE));
+    }
+}

--- a/src/test/java/konkuk/thip/user/adapter/in/web/UserShowFollowingRecentWritersApiTest.java
+++ b/src/test/java/konkuk/thip/user/adapter/in/web/UserShowFollowingRecentWritersApiTest.java
@@ -1,0 +1,229 @@
+package konkuk.thip.user.adapter.in.web;
+
+import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.adapter.out.persistence.repository.BookJpaRepository;
+import konkuk.thip.common.util.TestEntityFactory;
+import konkuk.thip.feed.adapter.out.jpa.FeedJpaEntity;
+import konkuk.thip.feed.adapter.out.persistence.repository.FeedJpaRepository;
+import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.repository.alias.AliasJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.repository.following.FollowingJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("[통합] 내가 팔로잉하는 사람들 중, 최근에 피드 작성한 사람들 조회 api 통합 테스트")
+class UserShowFollowingRecentWritersApiTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private AliasJpaRepository aliasJpaRepository;
+    @Autowired private UserJpaRepository userJpaRepository;
+    @Autowired private FeedJpaRepository feedJpaRepository;
+    @Autowired private FollowingJpaRepository followingJpaRepository;
+    @Autowired private BookJpaRepository bookJpaRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    @AfterEach
+    void tearDown() {
+        feedJpaRepository.deleteAllInBatch();
+        followingJpaRepository.deleteAllInBatch();
+        userJpaRepository.deleteAllInBatch();
+        aliasJpaRepository.deleteAllInBatch();
+        bookJpaRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("내가 팔로잉 하는 사람들 중, 최근에 공개 피드를 작성한 사람들의 [userId, 닉네임, 프로필 이미지] 정보를 반환합니다.")
+    void show_my_following_recent_writers_test() throws Exception {
+        //given
+        AliasJpaEntity a0 = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        UserJpaEntity me = userJpaRepository.save(TestEntityFactory.createUser(a0, "me"));
+        UserJpaEntity user1 = userJpaRepository.save(TestEntityFactory.createUser(a0, "user1"));
+        UserJpaEntity user2 = userJpaRepository.save(TestEntityFactory.createUser(a0, "user2"));
+        UserJpaEntity user3 = userJpaRepository.save(TestEntityFactory.createUser(a0, "user3"));
+
+        // me가 user1, user2를 팔로잉하였음 (user3는 팔로잉하지 X)
+        followingJpaRepository.save(TestEntityFactory.createFollowing(me, user1));
+        followingJpaRepository.save(TestEntityFactory.createFollowing(me, user2));
+
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBook());
+        FeedJpaEntity f1 = feedJpaRepository.save(TestEntityFactory.createFeed(user1, book, true, 50, 10, List.of()));
+        FeedJpaEntity f2 = feedJpaRepository.save(TestEntityFactory.createFeed(user2, book, true, 50, 10, List.of()));
+        FeedJpaEntity f3 = feedJpaRepository.save(TestEntityFactory.createFeed(user3, book, true, 50, 10, List.of()));
+
+        // 피드 작성 순서 : user1이 작성한 f1 -> user2가 작성한 f2 -> user3가 작성한 f3
+        feedJpaRepository.flush();
+        LocalDateTime base = LocalDateTime.now();
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(10)), f1.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(5)), f2.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(1)), f3.getPostId());
+
+        //when //then
+        mockMvc.perform(get("/users/my-followings/recent-feeds")
+                        .requestAttr("userId", me.getUserId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.recentWriters", hasSize(2)))
+                // 정렬 조건 : 내가 팔로잉하는 사람들 중, 최근에 공개 피드를 작성한 사람 순
+                .andExpect(jsonPath("$.data.recentWriters[0].userId", is(user2.getUserId().intValue())))
+                .andExpect(jsonPath("$.data.recentWriters[0].nickname", is(user2.getNickname())))
+                .andExpect(jsonPath("$.data.recentWriters[0].profileImageUrl", is(a0.getImageUrl())))
+                .andExpect(jsonPath("$.data.recentWriters[1].userId", is(user1.getUserId().intValue())))
+                .andExpect(jsonPath("$.data.recentWriters[1].nickname", is(user1.getNickname())))
+                .andExpect(jsonPath("$.data.recentWriters[1].profileImageUrl", is(a0.getImageUrl())));
+    }
+
+    @Test
+    @DisplayName("비공개 피드를 작성한 사람들은 조회되지 않습니다.")
+    void show_my_following_recent_writers_private_feed_writer_test() throws Exception {
+        //given
+        AliasJpaEntity a0 = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        UserJpaEntity me = userJpaRepository.save(TestEntityFactory.createUser(a0, "me"));
+        UserJpaEntity user1 = userJpaRepository.save(TestEntityFactory.createUser(a0, "user1"));
+
+        // me가 user1를 팔로잉하였음
+        followingJpaRepository.save(TestEntityFactory.createFollowing(me, user1));
+
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBook());
+        // user1이 작성한 비공개 피드
+        FeedJpaEntity f1 = feedJpaRepository.save(TestEntityFactory.createFeed(user1, book, false, 50, 10, List.of()));
+
+        //when //then
+        mockMvc.perform(get("/users/my-followings/recent-feeds")
+                        .requestAttr("userId", me.getUserId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.recentWriters", hasSize(0)));       // 아무도 조회되지 않음
+    }
+
+    @Test
+    @DisplayName("내가 팔로잉 하는 사람들 중 최근에 공개 피드를 작성한 사람들이 많을 경우, 최대 10명만 반환됩니다.")
+    void show_my_following_recent_writers_too_many_test() throws Exception {
+        //given
+        AliasJpaEntity a0 = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        UserJpaEntity me = userJpaRepository.save(TestEntityFactory.createUser(a0, "me"));
+        UserJpaEntity user1 = userJpaRepository.save(TestEntityFactory.createUser(a0, "user1"));
+        UserJpaEntity user2 = userJpaRepository.save(TestEntityFactory.createUser(a0, "user2"));
+        UserJpaEntity user3 = userJpaRepository.save(TestEntityFactory.createUser(a0, "user3"));
+        UserJpaEntity user4 = userJpaRepository.save(TestEntityFactory.createUser(a0, "user4"));
+        UserJpaEntity user5 = userJpaRepository.save(TestEntityFactory.createUser(a0, "user5"));
+        UserJpaEntity user6 = userJpaRepository.save(TestEntityFactory.createUser(a0, "user6"));
+        UserJpaEntity user7 = userJpaRepository.save(TestEntityFactory.createUser(a0, "user7"));
+        UserJpaEntity user8 = userJpaRepository.save(TestEntityFactory.createUser(a0, "user8"));
+        UserJpaEntity user9 = userJpaRepository.save(TestEntityFactory.createUser(a0, "user9"));
+        UserJpaEntity user10 = userJpaRepository.save(TestEntityFactory.createUser(a0, "user10"));
+        UserJpaEntity user11 = userJpaRepository.save(TestEntityFactory.createUser(a0, "user11"));
+        UserJpaEntity user12 = userJpaRepository.save(TestEntityFactory.createUser(a0, "user12"));
+
+        // me가 모든 유저 팔로잉 하였음
+        followingJpaRepository.save(TestEntityFactory.createFollowing(me, user1));
+        followingJpaRepository.save(TestEntityFactory.createFollowing(me, user2));
+        followingJpaRepository.save(TestEntityFactory.createFollowing(me, user3));
+        followingJpaRepository.save(TestEntityFactory.createFollowing(me, user4));
+        followingJpaRepository.save(TestEntityFactory.createFollowing(me, user5));
+        followingJpaRepository.save(TestEntityFactory.createFollowing(me, user6));
+        followingJpaRepository.save(TestEntityFactory.createFollowing(me, user7));
+        followingJpaRepository.save(TestEntityFactory.createFollowing(me, user8));
+        followingJpaRepository.save(TestEntityFactory.createFollowing(me, user9));
+        followingJpaRepository.save(TestEntityFactory.createFollowing(me, user10));
+        followingJpaRepository.save(TestEntityFactory.createFollowing(me, user11));
+        followingJpaRepository.save(TestEntityFactory.createFollowing(me, user12));
+
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBook());
+        FeedJpaEntity f1 = feedJpaRepository.save(TestEntityFactory.createFeed(user1, book, true, 50, 10, List.of()));
+        FeedJpaEntity f2 = feedJpaRepository.save(TestEntityFactory.createFeed(user2, book, true, 50, 10, List.of()));
+        FeedJpaEntity f3 = feedJpaRepository.save(TestEntityFactory.createFeed(user3, book, true, 50, 10, List.of()));
+        FeedJpaEntity f4 = feedJpaRepository.save(TestEntityFactory.createFeed(user4, book, true, 50, 10, List.of()));
+        FeedJpaEntity f5 = feedJpaRepository.save(TestEntityFactory.createFeed(user5, book, true, 50, 10, List.of()));
+        FeedJpaEntity f6 = feedJpaRepository.save(TestEntityFactory.createFeed(user6, book, true, 50, 10, List.of()));
+        FeedJpaEntity f7 = feedJpaRepository.save(TestEntityFactory.createFeed(user7, book, true, 50, 10, List.of()));
+        FeedJpaEntity f8 = feedJpaRepository.save(TestEntityFactory.createFeed(user8, book, true, 50, 10, List.of()));
+        FeedJpaEntity f9 = feedJpaRepository.save(TestEntityFactory.createFeed(user9, book, true, 50, 10, List.of()));
+        FeedJpaEntity f10 = feedJpaRepository.save(TestEntityFactory.createFeed(user10, book, true, 50, 10, List.of()));
+        FeedJpaEntity f11 = feedJpaRepository.save(TestEntityFactory.createFeed(user11, book, true, 50, 10, List.of()));
+        FeedJpaEntity f12 = feedJpaRepository.save(TestEntityFactory.createFeed(user12, book, true, 50, 10, List.of()));
+
+        // 피드 작성 순서 : user1이 작성한 f1 -> user2가 작성한 f2 -> ,,, -> f12
+        feedJpaRepository.flush();
+        LocalDateTime base = LocalDateTime.now();
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(60)), f1.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(55)), f2.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(50)), f3.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(45)), f4.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(40)), f5.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(35)), f6.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(30)), f7.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(25)), f8.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(20)), f9.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(15)), f10.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(10)), f11.getPostId());
+        jdbcTemplate.update(
+                "UPDATE posts SET created_at = ? WHERE post_id = ?",
+                Timestamp.valueOf(base.minusMinutes(5)), f12.getPostId());
+
+        //when //then
+        mockMvc.perform(get("/users/my-followings/recent-feeds")
+                        .requestAttr("userId", me.getUserId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.recentWriters", hasSize(10)))
+                // 정렬 조건 : 내가 팔로잉하는 사람들 중, 최근에 공개 피드를 작성한 사람 순
+                .andExpect(jsonPath("$.data.recentWriters[0].userId", is(user12.getUserId().intValue())))
+                .andExpect(jsonPath("$.data.recentWriters[1].userId", is(user11.getUserId().intValue())))
+                .andExpect(jsonPath("$.data.recentWriters[2].userId", is(user10.getUserId().intValue())))
+                .andExpect(jsonPath("$.data.recentWriters[3].userId", is(user9.getUserId().intValue())))
+                .andExpect(jsonPath("$.data.recentWriters[4].userId", is(user8.getUserId().intValue())))
+                .andExpect(jsonPath("$.data.recentWriters[5].userId", is(user7.getUserId().intValue())))
+                .andExpect(jsonPath("$.data.recentWriters[6].userId", is(user6.getUserId().intValue())))
+                .andExpect(jsonPath("$.data.recentWriters[7].userId", is(user5.getUserId().intValue())))
+                .andExpect(jsonPath("$.data.recentWriters[8].userId", is(user4.getUserId().intValue())))
+                .andExpect(jsonPath("$.data.recentWriters[9].userId", is(user3.getUserId().intValue())));
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #196 

## 📝 작업 내용
이슈 참고해주시면 됩니다.

- 요구사항 정리
  - 내가 팔로잉 하는 유저들 중, 최근에 공개 피드를 작성한 유저들이 누구인지를 알기 위한 api 입니다
  - [userId, nickname, profileImageUrl] 의 정보가 필요합니다
  - 내가 팔로잉 하는 유저들이 작성한 여러 공개 피드 중, 가장 최근에 작성한 공개피드의 createdAt 을 기준으로 정렬하여야 합니다
  - 최대 10개를 반환하고, 페이징 처리는 구현하지 않습니다

- 주요 코드 설명
  - service 는 비즈니스 로직을 수행하지 않습니다 (QueryDSL 에서 바로 요구사항에 맞는 데이터를 뽑아서 던지도록 하였습니다)
  - 요구사항에 맞는 데이터를 QueryDSL + Query Projection 을 통해 dto로 조회합니다 (따라서 지연로딩으로 인한 n+1 문제 발생 X)
  - UserQueryMapper 에서 dto -> response 로의 매핑을 수행하도록 하였습니다
  - 관련 api 테스트 코드를 작성하였습니다

## 📸 스크린샷
<img width="790" height="730" alt="image" src="https://github.com/user-attachments/assets/8acc5378-4f00-4ecd-8f2a-16f3d0e8d307" />


## 💬 리뷰 요구사항


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
