### PR TITLE
[hotfix] alias color 빠진 api 1개 수정 + category color 값을 반환해야하는 요구사항에 따라 코드 수정

### DIFF
--- a/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomGetMemberListResponse.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomGetMemberListResponse.java
@@ -15,6 +15,7 @@ public record RoomGetMemberListResponse(
                 String nickname,
                 String imageUrl,
                 String aliasName,
+                String aliasColor,
                 int followerCount
         ) {}
 }

--- a/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomPlayingDetailViewResponse.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomPlayingDetailViewResponse.java
@@ -14,6 +14,7 @@ public record RoomPlayingDetailViewResponse(
         String progressStartDate,
         String progressEndDate,
         String category,
+        String categoryColor,
         String roomDescription,
         int memberCount,
         int recruitCount,

--- a/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomRecruitingDetailViewResponse.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomRecruitingDetailViewResponse.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 import java.util.List;
 
+@Builder
 public record RoomRecruitingDetailViewResponse(
         boolean isHost,
         boolean isJoining,
@@ -15,6 +16,7 @@ public record RoomRecruitingDetailViewResponse(
         String progressEndDate,
         String recruitEndDate,
         String category,
+        String categoryColor,
         String roomDescription,
         int memberCount,
         int recruitCount,

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomQueryPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomQueryPersistenceAdapter.java
@@ -1,5 +1,7 @@
 package konkuk.thip.room.adapter.out.persistence;
 
+import konkuk.thip.common.exception.EntityNotFoundException;
+import konkuk.thip.common.exception.code.ErrorCode;
 import konkuk.thip.common.util.Cursor;
 import konkuk.thip.common.util.CursorBasedList;
 import konkuk.thip.room.adapter.in.web.response.RoomGetHomeJoinedListResponse;
@@ -7,6 +9,7 @@ import konkuk.thip.room.adapter.in.web.response.RoomRecruitingDetailViewResponse
 import konkuk.thip.room.adapter.in.web.response.RoomSearchResponse;
 import konkuk.thip.room.adapter.out.persistence.function.RoomQueryFunction;
 import konkuk.thip.room.adapter.out.persistence.repository.RoomJpaRepository;
+import konkuk.thip.room.adapter.out.persistence.repository.category.CategoryJpaRepository;
 import konkuk.thip.room.application.port.out.RoomQueryPort;
 import konkuk.thip.room.application.port.out.dto.RoomQueryDto;
 import konkuk.thip.room.domain.Category;
@@ -24,6 +27,7 @@ import java.util.List;
 public class RoomQueryPersistenceAdapter implements RoomQueryPort {
 
     private final RoomJpaRepository roomJpaRepository;
+    private final CategoryJpaRepository categoryJpaRepository;
 
     @Override
     public int countRecruitingRoomsByBookAndStartDateAfter(String isbn, LocalDate currentDate) {
@@ -100,5 +104,13 @@ public class RoomQueryPersistenceAdapter implements RoomQueryPort {
     @Override
     public List<RoomQueryDto> findRoomsByCategoryOrderByPopular(Category category, int limit, Long userId) {
         return roomJpaRepository.findRoomsByCategoryOrderByMemberCount(category.getValue(), limit, userId);
+    }
+
+    // TODO : 리펙토링 대상
+    @Override
+    public String findAliasColorOfCategory(Category category) {
+        return categoryJpaRepository.findAliasColorByValue(category.getValue()).orElseThrow(
+                () -> new EntityNotFoundException(ErrorCode.CATEGORY_NOT_FOUND)
+        );
     }
 }

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/category/CategoryJpaRepository.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/category/CategoryJpaRepository.java
@@ -2,10 +2,18 @@ package konkuk.thip.room.adapter.out.persistence.repository.category;
 
 import konkuk.thip.room.adapter.out.jpa.CategoryJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface CategoryJpaRepository extends JpaRepository<CategoryJpaEntity, Long> {
 
     Optional<CategoryJpaEntity> findByValue(String value);
+
+    // TODO : 리펙토링 대상
+    @Query("select a.color " +
+            "from CategoryJpaEntity c join c.aliasForCategoryJpaEntity a " +
+            "where c.value = :categoryValue")
+    Optional<String> findAliasColorByValue(@Param("categoryValue") String categoryValue);
 }

--- a/src/main/java/konkuk/thip/room/application/port/out/RoomQueryPort.java
+++ b/src/main/java/konkuk/thip/room/application/port/out/RoomQueryPort.java
@@ -38,5 +38,9 @@ public interface RoomQueryPort {
 
     List<RoomQueryDto> findRoomsByCategoryOrderByPopular(Category category, int limit, Long userId);
 
-
+    /**
+     * 임시 메서드
+     * TODO 리펙토링 대상
+     */
+    String findAliasColorOfCategory(Category category);
 }

--- a/src/main/java/konkuk/thip/room/application/service/RoomGetMemberListService.java
+++ b/src/main/java/konkuk/thip/room/application/service/RoomGetMemberListService.java
@@ -52,6 +52,7 @@ public class RoomGetMemberListService implements RoomGetMemberListUseCase {
                             .nickname(user.getNickname())
                             .imageUrl(user.getAlias().getImageUrl())
                             .aliasName(user.getAlias().getValue())
+                            .aliasColor(user.getAlias().getColor())
                             .followerCount(user.getFollowerCount())
                             .build();
                 })

--- a/src/main/java/konkuk/thip/room/application/service/RoomShowPlayingDetailViewService.java
+++ b/src/main/java/konkuk/thip/room/application/service/RoomShowPlayingDetailViewService.java
@@ -6,6 +6,7 @@ import konkuk.thip.common.util.DateUtil;
 import konkuk.thip.room.adapter.in.web.response.RoomPlayingDetailViewResponse;
 import konkuk.thip.room.application.port.in.RoomShowPlayingDetailViewUseCase;
 import konkuk.thip.room.application.port.out.RoomCommandPort;
+import konkuk.thip.room.application.port.out.RoomQueryPort;
 import konkuk.thip.room.domain.Room;
 import konkuk.thip.room.application.port.out.RoomParticipantCommandPort;
 import konkuk.thip.room.domain.RoomParticipants;
@@ -24,6 +25,7 @@ public class RoomShowPlayingDetailViewService implements RoomShowPlayingDetailVi
     private static final int TOP_PARTICIPATION_VOTES_COUNT = 3;
 
     private final RoomCommandPort roomCommandPort;
+    private final RoomQueryPort roomQueryPort;
     private final BookCommandPort bookCommandPort;
     private final RoomParticipantCommandPort roomParticipantCommandPort;
     private final VoteQueryPort voteQueryPort;
@@ -31,7 +33,7 @@ public class RoomShowPlayingDetailViewService implements RoomShowPlayingDetailVi
     @Override
     @Transactional(readOnly = true)
     public RoomPlayingDetailViewResponse getPlayingRoomDetailView(Long userId, Long roomId) {
-        // 1. Room 조회, Book 조회
+        // 1. Room 조회, Book 조회, Category와 연관된 Alias 조회
         Room room = roomCommandPort.getByIdOrThrow(roomId);
         Book book = bookCommandPort.findById(room.getBookId());
 
@@ -66,6 +68,7 @@ public class RoomShowPlayingDetailViewService implements RoomShowPlayingDetailVi
                 .currentPage(roomParticipants.getCurrentPageOfUser(userId))
                 .userPercentage(roomParticipants.getUserPercentageOfUser(userId))
                 .currentVotes(topParticipationVotes)
+                .categoryColor(roomQueryPort.findAliasColorOfCategory(room.getCategory()))      // TODO : 리펙토링 대상
                 .build();
     }
 }

--- a/src/main/java/konkuk/thip/room/application/service/RoomShowRecruitingDetailViewService.java
+++ b/src/main/java/konkuk/thip/room/application/service/RoomShowRecruitingDetailViewService.java
@@ -53,27 +53,28 @@ public class RoomShowRecruitingDetailViewService implements RoomShowRecruitingDe
             RoomParticipants participants,
             List<RoomRecruitingDetailViewResponse.RecommendRoom> recommendRooms
     ) {
-        return new RoomRecruitingDetailViewResponse(
-                participants.isHostOfRoom(userId),
-                participants.isJoiningToRoom(userId),
-                room.getId(),
-                room.getTitle(),
-                room.getCategory().getImageUrl(),
-                room.isPublic(),
-                DateUtil.formatDate(room.getStartDate()),
-                DateUtil.formatDate(room.getEndDate()),
-                DateUtil.formatAfterTime(room.getStartDate()),
-                room.getCategory().getValue(),
-                room.getDescription(),
-                participants.calculateMemberCount(),
-                room.getRecruitCount(),
-                book.getIsbn(),
-                book.getImageUrl(),
-                book.getTitle(),
-                book.getAuthorName(),
-                book.getDescription(),
-                book.getPublisher(),
-                recommendRooms
-        );
+        return RoomRecruitingDetailViewResponse.builder()
+                .isHost(participants.isHostOfRoom(userId))
+                .isJoining(participants.isJoiningToRoom(userId))
+                .roomId(room.getId())
+                .roomName(room.getTitle())
+                .roomImageUrl(room.getCategory().getImageUrl())
+                .isPublic(room.isPublic())
+                .progressStartDate(DateUtil.formatDate(room.getStartDate()))
+                .progressEndDate(DateUtil.formatDate(room.getEndDate()))
+                .recruitEndDate(DateUtil.formatAfterTime(room.getStartDate()))
+                .category(room.getCategory().getValue())
+                .categoryColor(roomQueryPort.findAliasColorOfCategory(room.getCategory()))      // TODO : 리펙토링 대상
+                .roomDescription(room.getDescription())
+                .memberCount(participants.calculateMemberCount())
+                .recruitCount(room.getRecruitCount())
+                .isbn(book.getIsbn())
+                .bookImageUrl(book.getImageUrl())
+                .bookTitle(book.getTitle())
+                .authorName(book.getAuthorName())
+                .bookDescription(book.getDescription())
+                .publisher(book.getPublisher())
+                .recommendRooms(recommendRooms)
+                .build();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #210 

## 📝 작업 내용

- response 에 alias color 를 빼먹은 api 1개에 alias color 값 추가
- 모집중/진행중인 방 상세보기 api의 response 에 category의 color 값을 추가해야하는 요구사항이 발견되어, response 수정

@hd0rable @buzz0331 현재 Alias, Category 는 도메인이 아니라, 각각 User, Room에 속하는 Value 로 분류된 상황인데, 모집중/진행중인 방 상세보기 api의 response 에 category에 해당하는 color 값을 반환해야하는 요구사항이 생김으로써
1. Room 도메인 내부의 Category를 영속성 adapter 로 던지기
2. CategoryJpaRepository 내부에서 Category.value 로 이와 매핑되는 CategoryJpaEntity 를 찾아서
3. 이와 연관되는 AliasJpaEntity 의 color 값을 반환

하도록 구현하였습니다.

현재 도메인 레벨에서는 [Alias, Category 의 연관관계를 고려 X, 그리고 각각을 엔티티가 아니라 Value로 분류] 하지만,
JPA 레벨에서는 [Alias, Category를 각각 엔티티로 분류, 서로 연관관계 존재] 하는 상황이라서 일단 임시 방편으로 요구사항을 만족하기 위해 위 방식으로 수정하였습니다

추후에 JPA 엔티티 및 DB 테이블 구조를 수정하여 Alias, Category를 DB 테이블에서 탈락시킨다고 해도, category의 color 값을 반환해야하는 요구사항으로 인해 
- Category enum의 내부에 color 값 추가 or
- Alias 와 Category의 연관관계에 대한 enum 클래스를 정의 or
- 또다른???

위와 같은 방법을 고려해야 할 것 같습니다!! 일단 hotfix이니 바로 머지하고 노션에 위 내용 추가해놓겠습니다!

## 📸 스크린샷

## 💬 리뷰 요구사항


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
