### PR TITLE
[hotfix] 회원가입 / 닉네임 변경 / 투표하기 api 수정

### DIFF
--- a/src/main/java/konkuk/thip/config/OpenApiConfig.java
+++ b/src/main/java/konkuk/thip/config/OpenApiConfig.java
@@ -46,14 +46,24 @@ public class OpenApiConfig {
 
     @Value("${server.http-url}") private String httpUrl;
 
+    @Value(("${server.profile}")) private String profile;
+
     @Bean
     public OpenAPI openAPI() {
+        List<Server> serverList = switch (profile) {
+            case "prod" -> List.of(new Server().url(httpsUrl).description("HTTPS 배포 서버"));
+            case "dev" -> List.of(
+                    new Server().url(httpUrl).description("HTTP 개발 서버"),
+                    new Server().url(httpsUrl).description("HTTPS 배포 서버"),
+                    new Server().url("http://localhost:8080").description("로컬 개발 서버")
+            );
+            default -> List.of(
+                    new Server().url("http://localhost:8080").description("로컬 개발 서버")
+            );
+        };
+
         return new OpenAPI()
-                .servers(List.of(
-                        new Server().url(httpsUrl).description("HTTPS 배포 서버"),
-                        new Server().url(httpUrl).description("HTTP IP"),
-                        new Server().url("http://localhost:8080").description("로컬 개발 서버")
-                ))
+                .servers(serverList)
                 .components(setComponents())
                 .addSecurityItem(setSecurityItems());
     }

--- a/src/main/java/konkuk/thip/user/adapter/in/web/request/UserSignupRequest.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/request/UserSignupRequest.java
@@ -13,6 +13,7 @@ public record UserSignupRequest(
         String aliasName,
 
         @Schema(description = "사용자 닉네임", example = "홍길동_123")
+        @NotBlank(message = "닉네임은 필수입니다.")
         @Pattern(regexp = "[가-힣a-zA-Z0-9]+", message = "닉네임은 한글, 영어, 숫자로만 구성되어야 합니다.(공백불가)")
         @Size(max = 10, message = "닉네임은 최대 10자 입니다.")
         String nickname

--- a/src/main/java/konkuk/thip/user/adapter/out/jpa/UserJpaEntity.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/jpa/UserJpaEntity.java
@@ -24,7 +24,7 @@ public class UserJpaEntity extends BaseJpaEntity {
     @Column(length = 60, nullable = false)
     private String nickname;
 
-    @Column(name = "nickname_updated_at", nullable = false)
+    @Column(name = "nickname_updated_at", nullable = true) // 회원가입 시에는 null
     private LocalDate nicknameUpdatedAt; // 날짜 형식으로 저장 (예: "2023-10-01")
 
     @Column(name = "oauth2_id", length = 50, nullable = false)

--- a/src/main/java/konkuk/thip/user/application/service/UserSignupService.java
+++ b/src/main/java/konkuk/thip/user/application/service/UserSignupService.java
@@ -11,8 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-
 import static konkuk.thip.user.adapter.out.jpa.UserRole.USER;
 
 
@@ -29,7 +27,7 @@ public class UserSignupService implements UserSignupUseCase {
     public UserSignupResult signup(UserSignupCommand command) {
         Alias alias = Alias.from(command.aliasName());
         User user = User.withoutId(
-                command.nickname(), LocalDate.now(), USER.getType(), command.oauth2Id(), alias
+                command.nickname(), null, USER.getType(), command.oauth2Id(), alias
         );
         Long userId = userCommandPort.save(user);
         String accessToken = jwtUtil.createAccessToken(userId);

--- a/src/main/java/konkuk/thip/vote/adapter/in/web/VoteCommandController.java
+++ b/src/main/java/konkuk/thip/vote/adapter/in/web/VoteCommandController.java
@@ -13,6 +13,7 @@ import konkuk.thip.vote.adapter.in.web.response.VoteCreateResponse;
 import konkuk.thip.vote.adapter.in.web.response.VoteResponse;
 import konkuk.thip.vote.application.port.in.VoteCreateUseCase;
 import konkuk.thip.vote.application.port.in.VoteUseCase;
+import konkuk.thip.vote.application.port.in.dto.VoteResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -55,8 +56,7 @@ public class VoteCommandController {
             @Parameter(description = "투표를 진행할 방 ID", example = "1") @PathVariable Long roomId,
             @Parameter(description = "투표할 투표 ID", example = "1") @PathVariable Long voteId,
             @Valid @RequestBody VoteRequest request) {
-        return BaseResponse.ok(VoteResponse.of(
-                        voteUseCase.vote(request.toCommand(userId, roomId, voteId)))
-        );
+        VoteResult voteResult = voteUseCase.vote(request.toCommand(userId, roomId, voteId));
+        return BaseResponse.ok(VoteResponse.of(voteResult.postId(), voteResult.roomId(), voteResult.voteItems()));
     }
 }

--- a/src/main/java/konkuk/thip/vote/adapter/in/web/response/VoteResponse.java
+++ b/src/main/java/konkuk/thip/vote/adapter/in/web/response/VoteResponse.java
@@ -2,12 +2,15 @@ package konkuk.thip.vote.adapter.in.web.response;
 
 import konkuk.thip.vote.application.port.in.dto.VoteResult;
 
+import java.util.List;
+
 public record VoteResponse(
-        Long voteItemId,
+        Long postId,
         Long roomId,
-        Boolean type
+        List<VoteResult.VoteItemDto> voteItems
 ) {
-    public static VoteResponse of(VoteResult voteResult) {
-        return new VoteResponse(voteResult.voteItemId(), voteResult.roomId(), voteResult.type());
+
+    public static VoteResponse of(Long postId, Long roomId, List<VoteResult.VoteItemDto> voteItems) {
+        return new VoteResponse(postId, roomId, voteItems);
     }
 }

--- a/src/main/java/konkuk/thip/vote/adapter/out/persistence/VoteQueryPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/vote/adapter/out/persistence/VoteQueryPersistenceAdapter.java
@@ -37,4 +37,9 @@ public class VoteQueryPersistenceAdapter implements VoteQueryPort {
                         )
                 );
     }
+
+    @Override
+    public List<VoteItemQueryDto> findVoteItemsByVoteId(Long voteId, Long userId) {
+        return voteJpaRepository.findVoteItemsByVoteId(voteId, userId);
+    }
 }

--- a/src/main/java/konkuk/thip/vote/adapter/out/persistence/repository/VoteQueryRepository.java
+++ b/src/main/java/konkuk/thip/vote/adapter/out/persistence/repository/VoteQueryRepository.java
@@ -14,4 +14,6 @@ public interface VoteQueryRepository {
     List<RoomPlayingDetailViewResponse.CurrentVote> findTopParticipationVotesByRoom(Long roomId, int count);
 
     List<VoteItemQueryDto> mapVoteItemsByVoteIds(Set<Long> voteIds, Long userId);
+
+    List<VoteItemQueryDto> findVoteItemsByVoteId(Long voteId, Long userId);
 }

--- a/src/main/java/konkuk/thip/vote/adapter/out/persistence/repository/VoteQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/vote/adapter/out/persistence/repository/VoteQueryRepositoryImpl.java
@@ -112,4 +112,29 @@ public class VoteQueryRepositoryImpl implements VoteQueryRepository {
                 .where(voteItem.voteJpaEntity.postId.in(voteIds))
                 .fetch();
     }
+
+    @Override
+    public List<VoteItemQueryDto> findVoteItemsByVoteId(Long voteId, Long userId) {
+        QVoteItemJpaEntity voteItem = QVoteItemJpaEntity.voteItemJpaEntity;
+        QVoteParticipantJpaEntity voteParticipant = QVoteParticipantJpaEntity.voteParticipantJpaEntity;
+
+        return jpaQueryFactory
+                .select(new QVoteItemQueryDto(
+                        voteItem.voteJpaEntity.postId,
+                        voteItem.voteItemId,
+                        voteItem.itemName,
+                        voteItem.count,
+                        JPAExpressions
+                                .selectOne()
+                                .from(voteParticipant)
+                                .where(
+                                        voteParticipant.voteItemJpaEntity.eq(voteItem),
+                                        voteParticipant.userJpaEntity.userId.eq(userId)
+                                )
+                                .exists() // isVoted : 로그인한 사용자가 해당 투표 아이템에 투표했는지 여부 서브 쿼리
+                ))
+                .from(voteItem)
+                .where(voteItem.voteJpaEntity.postId.eq(voteId))
+                .fetch();
+    }
 }

--- a/src/main/java/konkuk/thip/vote/application/port/in/dto/VoteResult.java
+++ b/src/main/java/konkuk/thip/vote/application/port/in/dto/VoteResult.java
@@ -1,11 +1,24 @@
 package konkuk.thip.vote.application.port.in.dto;
 
+import java.util.List;
+
 public record VoteResult(
-        Long voteItemId,
+        Long postId,
         Long roomId,
-        Boolean type
+        List<VoteItemDto> voteItems
 ) {
-    public static VoteResult of(Long voteItemId, Long roomId, Boolean type) {
-        return new VoteResult(voteItemId, roomId, type);
+    public record VoteItemDto(
+            Long voteItemId,
+            String itemName,
+            int percentage,
+            Boolean isVoted
+    ) {
+        public static VoteItemDto of(Long voteItemId, String itemName, int percentage, Boolean isVoted) {
+            return new VoteItemDto(voteItemId, itemName, percentage, isVoted);
+        }
+    }
+
+    public static VoteResult of(Long postId, Long roomId, List<VoteItemDto> voteItems) {
+        return new VoteResult(postId, roomId, voteItems);
     }
 }

--- a/src/main/java/konkuk/thip/vote/application/port/out/VoteQueryPort.java
+++ b/src/main/java/konkuk/thip/vote/application/port/out/VoteQueryPort.java
@@ -13,4 +13,6 @@ public interface VoteQueryPort {
     List<RoomPlayingDetailViewResponse.CurrentVote> findTopParticipationVotesByRoom(Room room, int count);
 
     Map<Long, List<VoteItemQueryDto>> findVoteItemsByVoteIds(Set<Long> voteIds, Long userId);
+
+    List<VoteItemQueryDto> findVoteItemsByVoteId(Long voteId, Long userId);
 }

--- a/src/test/java/konkuk/thip/vote/adapter/in/web/VoteApiTest.java
+++ b/src/test/java/konkuk/thip/vote/adapter/in/web/VoteApiTest.java
@@ -91,12 +91,15 @@ class VoteApiTest {
                         .requestAttr("userId", user.getUserId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.postId").value(vote.getPostId()))
+                .andExpect(jsonPath("$.data.roomId").value(room.getRoomId()))
+                .andExpect(jsonPath("$.data.voteItems[0].voteItemId").value(item.getVoteItemId()))
+                .andExpect(jsonPath("$.data.voteItems[0].isVoted").value(true));
 
         assertThat(voteParticipantJpaRepository.findAll())
                 .hasSize(1)
                 .allMatch(vp -> vp.getVoteItemJpaEntity().getVoteItemId().equals(item.getVoteItemId()));
-
         voteItemJpaRepository.findById(item.getVoteItemId())
                 .ifPresent(voteItem -> assertThat(voteItem.getCount()).isEqualTo(1));
     }
@@ -121,12 +124,13 @@ class VoteApiTest {
                         .requestAttr("userId", user.getUserId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.voteItems[?(@.voteItemId == %s)].isVoted", item2.getVoteItemId()).value(true))
+                .andExpect(jsonPath("$.data.voteItems[?(@.voteItemId == %s)].isVoted", item1.getVoteItemId()).value(false));
 
         assertThat(voteParticipantJpaRepository.findAll())
                 .hasSize(1)
                 .allMatch(vp -> vp.getVoteItemJpaEntity().getVoteItemId().equals(item2.getVoteItemId()));
-
         voteItemJpaRepository.findById(item1.getVoteItemId())
                 .ifPresent(voteItem -> assertThat(voteItem.getCount()).isEqualTo(0));
         voteItemJpaRepository.findById(item2.getVoteItemId())
@@ -167,7 +171,8 @@ class VoteApiTest {
                         .requestAttr("userId", user.getUserId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.voteItems[?(@.voteItemId == %s)].isVoted", item.getVoteItemId()).value(false));
 
         assertThat(voteParticipantJpaRepository.findAll()).isEmpty();
         voteItemJpaRepository.findById(item.getVoteItemId())
@@ -208,4 +213,5 @@ class VoteApiTest {
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.code").value(ROOM_ACCESS_FORBIDDEN.getCode()));
     }
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closes #205 
closes #222 
closes #219 

## 📝 작업 내용

다음의 api를 수정했습니다.
- 회원가입 api : 닉네임 null 또는 blank 못받도록 수정
- 닉네임 변경 시점 수정 : 회원가입 이후에는 언제든지 변경 가능하도록 회원가입시에 nicknameUpdatedAt을 null로 주입해주도록 했습니다.
- 투표하기 api : 투표하기 이후 반환시에 모든 투표항목들을 반환하도록 수정하였습니다.

## 📸 스크린샷

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
