### PR TITLE
[refactor] 기록장 조회 api 리팩토링

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM openjdk:17
 
 ARG PORT=8000
+ENV JAVA_TOOL_OPTIONS="-Xms512m -Xmx2g -XX:+ExitOnOutOfMemoryError"
 
 EXPOSE ${PORT}
 

--- a/src/main/java/konkuk/thip/record/adapter/in/web/response/RecordSearchResponse.java
+++ b/src/main/java/konkuk/thip/record/adapter/in/web/response/RecordSearchResponse.java
@@ -25,6 +25,7 @@ public record RecordSearchResponse(
             String content,
             int likeCount,
             int commentCount,
+            boolean isOverview,
             boolean isLiked,
             boolean isWriter,
             boolean isLocked,

--- a/src/main/java/konkuk/thip/record/application/mapper/RecordQueryMapper.java
+++ b/src/main/java/konkuk/thip/record/application/mapper/RecordQueryMapper.java
@@ -1,5 +1,6 @@
 package konkuk.thip.record.application.mapper;
 
+import konkuk.thip.common.util.DateUtil;
 import konkuk.thip.record.adapter.in.web.response.RecordSearchResponse;
 import konkuk.thip.record.application.port.out.dto.PostQueryDto;
 import org.mapstruct.Mapper;
@@ -8,7 +9,7 @@ import org.mapstruct.ReportingPolicy;
 
 import java.util.List;
 
-@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.ERROR)
+@Mapper(componentModel = "spring", imports = DateUtil.class, unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface RecordQueryMapper {
 
     @Mapping(target = "postId",         source = "dto.postId")

--- a/src/main/java/konkuk/thip/record/application/mapper/RecordQueryMapper.java
+++ b/src/main/java/konkuk/thip/record/application/mapper/RecordQueryMapper.java
@@ -1,0 +1,37 @@
+package konkuk.thip.record.application.mapper;
+
+import konkuk.thip.record.adapter.in.web.response.RecordSearchResponse;
+import konkuk.thip.record.application.port.out.dto.PostQueryDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.ERROR)
+public interface RecordQueryMapper {
+
+    @Mapping(target = "postId",         source = "dto.postId")
+    @Mapping(target = "postDate",       expression = "java(DateUtil.formatBeforeTime(dto.postDate()))")
+    @Mapping(target = "postType",       source = "dto.postType")
+    @Mapping(target = "page",           source = "dto.page")
+    @Mapping(target = "userId",         source = "dto.userId")
+    @Mapping(target = "nickName",       source = "dto.nickName")
+    @Mapping(target = "profileImageUrl",source = "dto.profileImageUrl")
+    @Mapping(target = "content",        source = "content")
+    @Mapping(target = "likeCount",      source = "dto.likeCount")
+    @Mapping(target = "commentCount",   source = "dto.commentCount")
+    @Mapping(target = "isOverview",     source = "dto.isOverview")
+    @Mapping(target = "isLiked",        source = "isLiked")
+    @Mapping(target = "isWriter",       source = "isWriter")
+    @Mapping(target = "isLocked",       source = "isLocked")
+    @Mapping(target = "voteItems",      source = "voteItems")
+    RecordSearchResponse.PostDto toPostDto(
+            PostQueryDto dto,
+            String content,
+            boolean isLiked,
+            boolean isWriter,
+            boolean isLocked,
+            List<RecordSearchResponse.PostDto.VoteItemDto> voteItems
+    );
+}

--- a/src/main/java/konkuk/thip/record/application/service/RecordSearchService.java
+++ b/src/main/java/konkuk/thip/record/application/service/RecordSearchService.java
@@ -6,15 +6,16 @@ import konkuk.thip.common.exception.BusinessException;
 import konkuk.thip.common.exception.code.ErrorCode;
 import konkuk.thip.common.util.Cursor;
 import konkuk.thip.common.util.CursorBasedList;
-import konkuk.thip.common.util.DateUtil;
 import konkuk.thip.post.application.port.out.PostLikeQueryPort;
 import konkuk.thip.record.adapter.in.web.response.RecordSearchResponse;
 import konkuk.thip.record.adapter.out.persistence.RecordSearchSortParams;
 import konkuk.thip.record.adapter.out.persistence.RecordSearchTypeParams;
+import konkuk.thip.record.application.mapper.RecordQueryMapper;
 import konkuk.thip.record.application.port.in.dto.RecordSearchQuery;
 import konkuk.thip.record.application.port.in.dto.RecordSearchUseCase;
 import konkuk.thip.record.application.port.out.RecordQueryPort;
 import konkuk.thip.record.application.port.out.dto.PostQueryDto;
+import konkuk.thip.record.application.service.validator.RecordAccessValidator;
 import konkuk.thip.room.application.port.out.RoomParticipantCommandPort;
 import konkuk.thip.room.domain.RoomParticipant;
 import konkuk.thip.vote.application.port.out.VoteQueryPort;
@@ -32,6 +33,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static konkuk.thip.common.post.PostType.RECORD;
+import static konkuk.thip.common.post.PostType.VOTE;
 
 @Slf4j
 @Service
@@ -44,8 +46,10 @@ public class RecordSearchService implements RecordSearchUseCase {
     private final PostLikeQueryPort postLikeQueryPort;
     private final RoomParticipantCommandPort roomParticipantCommandPort;
 
+    private final RecordAccessValidator recordAccessValidator;
+    private final RecordQueryMapper recordQueryMapper;
+
     private static final int DEFAULT_PAGE_SIZE = 10;
-    private static final String BLURRED_STRING = "여긴 못 지나가지롱~~";
 
     @Override
     @Transactional(readOnly = true)
@@ -68,27 +72,23 @@ public class RecordSearchService implements RecordSearchUseCase {
         // Type에 따라 그룹기록, 내 기록 조회 분기처리
         CursorBasedList<PostQueryDto> cursorBasedList = switch(RecordSearchTypeParams.from(recordSearchQuery.type())) {
             case GROUP -> {
-                validateGroupRecordFilters(pageStart, pageEnd, isPageFilter, isOverview, book.getPageCount(), roomParticipant.getUserPercentage());
+                recordAccessValidator.validateGroupRecordFilters(pageStart, pageEnd, isPageFilter, isOverview, book.getPageCount(), roomParticipant.getUserPercentage());
                 // 총평 보기가 아닌 경우, pageStart와 pageEnd를 default 값 주입
                 if(!isOverview) {
-                    if(pageStart == null) {
-                        pageStart = 0;
-                    }
-                    if(pageEnd == null) {
-                        pageEnd = book.getPageCount();
-                    }
+                    if(pageStart == null) pageStart = 0;
+                    if(pageEnd == null) pageEnd = book.getPageCount();
                 }
                 yield getGroupRecordBySortParams(recordSearchQuery.sort(), roomId, userId, cursor, pageStart, pageEnd, isOverview);
             }
             case MINE -> {
-                validateMyRecordFilters(pageStart, pageEnd, isPageFilter, isOverview, recordSearchQuery.sort());
+                recordAccessValidator.validateMyRecordFilters(pageStart, pageEnd, isPageFilter, isOverview, recordSearchQuery.sort());
                 yield recordQueryPort.searchMyRecords(roomId, userId, cursor);
             }
         };
 
         // VoteItem 한번에 조회 (투표 게시물에 대한 투표 항목 조회)
         Map<Long, List<VoteItemQueryDto>> voteItemQueryMap = voteQueryPort.findVoteItemsByVoteIds(cursorBasedList.contents().stream()
-                .filter(postQueryDto -> postQueryDto.postType().equals("VOTE"))
+                .filter(postQueryDto -> postQueryDto.postType().equals(VOTE.getType()))
                 .map(PostQueryDto::postId)
                 .collect(Collectors.toSet()), userId);
 
@@ -99,7 +99,17 @@ public class RecordSearchService implements RecordSearchUseCase {
 
         // 게시물 DTO 변환
         var postDtos = cursorBasedList.contents().stream()
-                .map(postQueryDto -> toPostDto(postQueryDto, roomParticipant, userId, voteItemQueryMap, likedPostIds))
+                .map(dto -> {
+                    boolean isLocked = recordAccessValidator.isLocked(roomParticipant.getCurrentPage(), dto.page());
+                    boolean isWriter = dto.userId().equals(userId);
+                    boolean isLiked  = likedPostIds.contains(dto.postId());
+                    String content   = isLocked ? recordAccessValidator.createBlurredString(dto.content()) : dto.content();
+
+                    List<RecordSearchResponse.PostDto.VoteItemDto> voteItems =
+                            getVoteItemDtosIfApplicable(dto, voteItemQueryMap, isLocked);
+
+                    return recordQueryMapper.toPostDto(dto, content, isLiked, isWriter, isLocked, voteItems);
+                })
                 .toList();
 
         // RecordSearchResponse 생성
@@ -113,6 +123,7 @@ public class RecordSearchService implements RecordSearchUseCase {
                 .build();
     }
 
+    // 그룹 기록을 정렬 파라미터에 따라 조회하는 메서드
     private CursorBasedList<PostQueryDto> getGroupRecordBySortParams(String sort, Long roomId, Long userId, Cursor cursor, Integer pageStart, Integer pageEnd, Boolean isOverview) {
         return switch(RecordSearchSortParams.from(sort)) {
             case LATEST -> recordQueryPort.searchGroupRecordsByLatest(roomId, userId, cursor, pageStart, pageEnd, isOverview);
@@ -121,29 +132,7 @@ public class RecordSearchService implements RecordSearchUseCase {
         };
     }
 
-    private RecordSearchResponse.PostDto toPostDto(PostQueryDto dto, RoomParticipant participant, Long userId, Map<Long, List<VoteItemQueryDto>> voteItemMap, Set<Long> likedPostIds) {
-        boolean isLocked = participant.getCurrentPage() < dto.page();
-        boolean isWriter = dto.userId().equals(userId);
-        String content = isLocked ? createBlurredString(dto.content()) : dto.content();
-
-        return RecordSearchResponse.PostDto.builder()
-                .postId(dto.postId())
-                .postDate(DateUtil.formatBeforeTime(dto.postDate()))
-                .postType(dto.postType())
-                .page(dto.page())
-                .userId(dto.userId())
-                .nickName(dto.nickName())
-                .profileImageUrl(dto.profileImageUrl())
-                .content(content)
-                .likeCount(dto.likeCount())
-                .commentCount(dto.commentCount())
-                .isLiked(likedPostIds.contains(dto.postId()))
-                .isWriter(isWriter)
-                .isLocked(isLocked)
-                .voteItems(getVoteItemDtosIfApplicable(dto, voteItemMap, isLocked))
-                .build();
-    }
-
+    // 투표 게시물인 경우 VoteItem DTO 목록을 생성하는 메서드
     private List<RecordSearchResponse.PostDto.VoteItemDto> getVoteItemDtosIfApplicable(PostQueryDto dto, Map<Long, List<VoteItemQueryDto>> voteItemMap, boolean isLocked) {
         if (RECORD.getType().equals(dto.postType())) {
             return List.of();
@@ -153,6 +142,7 @@ public class RecordSearchService implements RecordSearchUseCase {
         return mapToVoteItemDtos(items, isLocked);
     }
 
+    // VoteItemQueryDto 목록을 RecordSearchResponse.PostDto.VoteItemDto 목록으로 변환하는 메서드
     private List<RecordSearchResponse.PostDto.VoteItemDto> mapToVoteItemDtos(List<VoteItemQueryDto> items, boolean isLocked) {
         // voteCount를 모아 리스트로 변환
         List<Integer> counts = items.stream()
@@ -166,70 +156,11 @@ public class RecordSearchService implements RecordSearchUseCase {
         return IntStream.range(0, items.size())
                 .mapToObj(i -> RecordSearchResponse.PostDto.VoteItemDto.of(
                         items.get(i).voteItemId(),
-                        isLocked ? createBlurredString(items.get(i).itemName()) : items.get(i).itemName(),
+                        isLocked ? recordAccessValidator.createBlurredString(items.get(i).itemName()) : items.get(i).itemName(),
                         percentages.get(i),
                         items.get(i).isVoted()
                 ))
                 .toList();
-    }
-
-    private String createBlurredString(String contents) {
-        if (contents == null || contents.isEmpty()) {
-            return contents;
-        }
-
-        int originalLength = contents.length();
-        int blurLen = BLURRED_STRING.length();
-
-        // 필요한 전체 반복 횟수 계산
-        int repeat = originalLength / blurLen;
-
-        StringBuilder sb = new StringBuilder(originalLength);
-
-        // 몫 만큼 반복
-        for (int i = 0; i < repeat + 1; i++) {
-            sb.append(BLURRED_STRING);
-        }
-
-        return sb.toString();
-    }
-
-    private void validateGroupRecordFilters(Integer pageStart, Integer pageEnd, Boolean isPageFilter, Boolean isOverview, int bookPageSize, double currentPercentage) {
-        if(!isPageFilter && !isOverview) { // 어떤 필터도 적용되지 않는 경우
-            if (pageStart != null || pageEnd != null) {
-                throw new BusinessException(ErrorCode.API_INVALID_PARAM, new IllegalArgumentException("어떤 필터도 적용되지 않는 경우 pageStart와 pageEnd는 null이어야 합니다."));
-            }
-        }
-        if(!isPageFilter && isOverview) { // 총평보기 필터만 적용된 경우
-            if (pageStart != null || pageEnd != null) {
-                throw new BusinessException(ErrorCode.API_INVALID_PARAM, new IllegalArgumentException("총평보기 필터만 적용된 경우 pageStart와 pageEnd는 null이어야 합니다."));
-            }
-            if (currentPercentage < 80) {
-                throw new BusinessException(ErrorCode.API_INVALID_PARAM, new IllegalArgumentException("총평보기 필터가 적용된 경우 현재 독서 진행률은 80% 이상이어야 합니다."));
-            }
-        }
-        if(isPageFilter && !isOverview) { // 페이지 필터만 적용된 경우는 pageStart와 pageEnd가 null이여도 됨
-            if(pageStart != null && (pageStart < 0 || pageStart > bookPageSize)) {
-                throw new BusinessException(ErrorCode.API_INVALID_PARAM, new IllegalArgumentException("pageStart는 책의 페이지 범위 내에 있어야 합니다."));
-            }
-            if(pageEnd != null && (pageEnd < 0 || pageEnd > bookPageSize)) {
-                throw new BusinessException(ErrorCode.API_INVALID_PARAM, new IllegalArgumentException("pageEnd는 책의 페이지 범위 내에 있어야 합니다."));
-            }
-            if(pageStart != null && pageEnd != null && pageStart > pageEnd) {
-                throw new BusinessException(ErrorCode.API_INVALID_PARAM, new IllegalArgumentException("pageStart는 pageEnd보다 작아야 합니다."));
-            }
-        }
-        if(isPageFilter && isOverview) { // 페이지 필터와 총평보기 필터가 동시에 적용된 경우
-            throw new BusinessException(ErrorCode.API_INVALID_PARAM, new IllegalArgumentException("페이지 필터와 총평보기 필터는 동시에 적용될 수 없습니다."));
-        }
-    }
-
-    private void validateMyRecordFilters(Integer pageStart, Integer pageEnd, Boolean isPageFilter, Boolean isOverview, String sort) {
-        // 모든 파라미터중 하나라도 null이 아닌 경우 예외 발생
-        if (pageStart != null || pageEnd != null || isPageFilter || isOverview || sort != null) {
-            throw new BusinessException(ErrorCode.API_INVALID_PARAM, new IllegalArgumentException("내 기록 조회에서는 roomId, type, cursor를 제외한 모든 파라미터는 null이어야 합니다."));
-        }
-
     }
 }
 

--- a/src/main/java/konkuk/thip/record/application/service/validator/RecordAccessValidator.java
+++ b/src/main/java/konkuk/thip/record/application/service/validator/RecordAccessValidator.java
@@ -1,0 +1,74 @@
+package konkuk.thip.record.application.service.validator;
+
+import konkuk.thip.common.annotation.HelperService;
+import konkuk.thip.common.exception.BusinessException;
+import konkuk.thip.common.exception.code.ErrorCode;
+
+@HelperService
+public class RecordAccessValidator {
+
+    private static final String BLURRED_STRING = "여긴 못 지나가지롱~~";
+
+    public void validateGroupRecordFilters(Integer pageStart, Integer pageEnd, Boolean isPageFilter, Boolean isOverview, int bookPageSize, double currentPercentage) {
+        if(!isPageFilter && !isOverview) { // 어떤 필터도 적용되지 않는 경우
+            if (pageStart != null || pageEnd != null) {
+                throw new BusinessException(ErrorCode.API_INVALID_PARAM, new IllegalArgumentException("어떤 필터도 적용되지 않는 경우 pageStart와 pageEnd는 null이어야 합니다."));
+            }
+        }
+        if(!isPageFilter && isOverview) { // 총평보기 필터만 적용된 경우
+            if (pageStart != null || pageEnd != null) {
+                throw new BusinessException(ErrorCode.API_INVALID_PARAM, new IllegalArgumentException("총평보기 필터만 적용된 경우 pageStart와 pageEnd는 null이어야 합니다."));
+            }
+            if (currentPercentage < 80) {
+                throw new BusinessException(ErrorCode.API_INVALID_PARAM, new IllegalArgumentException("총평보기 필터가 적용된 경우 현재 독서 진행률은 80% 이상이어야 합니다."));
+            }
+        }
+        if(isPageFilter && !isOverview) { // 페이지 필터만 적용된 경우는 pageStart와 pageEnd가 null이여도 됨
+            if(pageStart != null && (pageStart < 0 || pageStart > bookPageSize)) {
+                throw new BusinessException(ErrorCode.API_INVALID_PARAM, new IllegalArgumentException("pageStart는 책의 페이지 범위 내에 있어야 합니다."));
+            }
+            if(pageEnd != null && (pageEnd < 0 || pageEnd > bookPageSize)) {
+                throw new BusinessException(ErrorCode.API_INVALID_PARAM, new IllegalArgumentException("pageEnd는 책의 페이지 범위 내에 있어야 합니다."));
+            }
+            if(pageStart != null && pageEnd != null && pageStart > pageEnd) {
+                throw new BusinessException(ErrorCode.API_INVALID_PARAM, new IllegalArgumentException("pageStart는 pageEnd보다 작아야 합니다."));
+            }
+        }
+        if(isPageFilter && isOverview) { // 페이지 필터와 총평보기 필터가 동시에 적용된 경우
+            throw new BusinessException(ErrorCode.API_INVALID_PARAM, new IllegalArgumentException("페이지 필터와 총평보기 필터는 동시에 적용될 수 없습니다."));
+        }
+    }
+
+    public void validateMyRecordFilters(Integer pageStart, Integer pageEnd, Boolean isPageFilter, Boolean isOverview, String sort) {
+        // 모든 파라미터중 하나라도 null이 아닌 경우 예외 발생
+        if (pageStart != null || pageEnd != null || isPageFilter || isOverview || sort != null) {
+            throw new BusinessException(ErrorCode.API_INVALID_PARAM, new IllegalArgumentException("내 기록 조회에서는 roomId, type, cursor를 제외한 모든 파라미터는 null이어야 합니다."));
+        }
+
+    }
+
+    public String createBlurredString(String contents) {
+        if (contents == null || contents.isEmpty()) {
+            return contents;
+        }
+
+        int originalLength = contents.length();
+        int blurLen = BLURRED_STRING.length();
+
+        // 필요한 전체 반복 횟수 계산
+        int repeat = originalLength / blurLen;
+
+        StringBuilder sb = new StringBuilder(originalLength);
+
+        // 몫 만큼 반복
+        for (int i = 0; i < repeat + 1; i++) {
+            sb.append(BLURRED_STRING);
+        }
+
+        return sb.toString();
+    }
+
+    public boolean isLocked(int currentPage, int bookPageSize) {
+        return currentPage < bookPageSize;
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #225 

## 📝 작업 내용

기록장 조회 api를 다음과 같이 수정하였습니다.
1. dtype 도입에 따른 instance of 구문 모두 제거
2. isOverview 반환
3. 헬퍼 서비스 도입 (RecordAccessValidator)
4. RecordQueryMapper 도입

전체적으로 서비스 로직을 조금 분리하고자 했습니다! 아직 쿼리 성능이 최적화되지 않은 상태여서 이는 저희가 수정하기로 했던 상속 전략을 도입해보고 한번 다시 테스트 해봐야 할 것 같습니다!

추가적으로 EC2에서 OOME 에러로 인해 서버가 다운되는 경우가 발생해서 Dockerfile을 통해 이미지 빌드시에 JAVA OPTION을 달도록 추가했습니다. (로컬에서는 빌드가 되긴했는데 cd에서 어떻게 될지는 모르겠네여 하핳)

## 📸 스크린샷
<img width="4064" height="2334" alt="스크린샷 2025-08-15 오전 1 46 50" src="https://github.com/user-attachments/assets/c208b05b-8166-45c5-a545-59c70cd2b522" />

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 검색 결과에 게시글의 개요 노출 여부(isOverview) 필드가 추가되어 클라이언트 표시가 정교해졌습니다.
- Refactor
  - 필터 검증과 데이터 매핑이 개선되어 정렬·필터 결과가 더 일관되며, 잠금/블러 처리로 비공개 콘텐츠 표시가 예측 가능해졌습니다.
- Chores
  - 컨테이너 JVM 메모리 기본값을 설정하고 메모리 부족 시 즉시 종료하도록 구성해 서비스 안정성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->