### PR TITLE
[feat] 특정 책으로 작성된 피드 목록 조회 api 개발

### DIFF
--- a/src/main/java/konkuk/thip/book/adapter/out/persistence/BookQueryPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/persistence/BookQueryPersistenceAdapter.java
@@ -31,6 +31,11 @@ public class BookQueryPersistenceAdapter implements BookQueryPort {
     }
 
     @Override
+    public boolean existsBookByIsbn(String isbn) {
+        return bookJpaRepository.existsByIsbn(isbn);
+    }
+
+    @Override
     public List<Book> findSavedBooksByUserId(Long userId) {
         UserJpaEntity user = userJpaRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));

--- a/src/main/java/konkuk/thip/book/adapter/out/persistence/repository/BookJpaRepository.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/persistence/repository/BookJpaRepository.java
@@ -24,4 +24,6 @@ public interface BookJpaRepository extends JpaRepository<BookJpaEntity, Long> {
             "AND r.startDate <= CURRENT_TIMESTAMP " + // 진행 중인 방만 조회 (모집 중 / 만료된 방 x)
             "ORDER BY r.roomPercentage DESC")  // 방의 진행률이 높은 순서로 정렬
     List<BookJpaEntity> findJoiningRoomsBooksByUserId(Long userId);
+
+    boolean existsByIsbn(String isbn);
 }

--- a/src/main/java/konkuk/thip/book/application/port/out/BookQueryPort.java
+++ b/src/main/java/konkuk/thip/book/application/port/out/BookQueryPort.java
@@ -8,6 +8,8 @@ public interface BookQueryPort {
 
     boolean existsSavedBookByUserIdAndBookId(Long userId, Long bookId);
 
+    boolean existsBookByIsbn(String isbn);
+
     List<Book> findSavedBooksByUserId(Long userId);
 
     List<Book> findJoiningRoomsBooksByUserId(Long userId);

--- a/src/main/java/konkuk/thip/feed/adapter/in/web/response/FeedRelatedWithBookResponse.java
+++ b/src/main/java/konkuk/thip/feed/adapter/in/web/response/FeedRelatedWithBookResponse.java
@@ -1,0 +1,36 @@
+package konkuk.thip.feed.adapter.in.web.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record FeedRelatedWithBookResponse(
+       List<FeedRelatedWithBookDto> feeds,
+       String nextCursor,
+       boolean isLast
+) {
+    public record FeedRelatedWithBookDto(
+            Long feedId,
+            Long creatorId,
+            boolean isWriter,
+            String creatorNickname,
+            String creatorProfileImageUrl,
+            String aliasName,
+            String aliasColor,
+            String postDate,
+            String isbn,
+            String bookTitle,
+            String bookAuthor,
+            String contentBody,
+            String[] contentUrls,
+            int likeCount,
+            int commentCount,
+            boolean isSaved,
+            boolean isLiked
+    ) {}
+
+    public static FeedRelatedWithBookResponse of(List<FeedRelatedWithBookDto> feeds, String nextCursor, boolean isLast) {
+        return new FeedRelatedWithBookResponse(feeds, nextCursor, isLast);
+    }
+}

--- a/src/main/java/konkuk/thip/feed/adapter/out/persistence/FeedQueryPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/persistence/FeedQueryPersistenceAdapter.java
@@ -162,7 +162,8 @@ public class FeedQueryPersistenceAdapter implements FeedQueryPort {
         List<FeedQueryDto> feedQueryDtos = feedJpaRepository.findFeedsByBookIsbnOrderByLikeCount(isbn, userId, lastCreatedAt, lastLikeCount, size);
 
         return CursorBasedList.of(feedQueryDtos, size, feedQueryDto -> {
-            Cursor nextCursor = new Cursor(List.of(feedQueryDto.createdAt().toString()));
+            Cursor nextCursor = new Cursor(List.of(feedQueryDto.createdAt().toString(),
+                    feedQueryDto.likeCount().toString()));
             return nextCursor.toEncodedString();
         });
     }

--- a/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/FeedQueryRepository.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/FeedQueryRepository.java
@@ -19,4 +19,8 @@ public interface FeedQueryRepository {
     List<FeedQueryDto> findSpecificUserFeedsByCreatedAt(Long feedOwnerId, LocalDateTime lastCreatedAt, int size);
 
     List<TagCategoryQueryDto> findAllTags();
+
+    List<FeedQueryDto> findFeedsByBookIsbnOrderByLikeCount(String isbn, Long userId, LocalDateTime lastCreatedAt, Integer lastLikeCount, int size);
+
+    List<FeedQueryDto> findFeedsByBookIsbnOrderByCreatedAt(String isbn, Long userId, LocalDateTime lastCreatedAt, int size);
 }

--- a/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/FeedQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/FeedQueryRepositoryImpl.java
@@ -301,8 +301,6 @@ public class FeedQueryRepositoryImpl implements FeedQueryRepository {
                     feed.likeCount.lt(lastLikeCount)
                             .or(feed.likeCount.eq(lastLikeCount)
                                     .and(feed.createdAt.lt(lastCreatedAt)))
-                            .or(feed.likeCount.eq(lastLikeCount)
-                                    .and(feed.createdAt.eq(lastCreatedAt)))
             );
         }
 
@@ -332,7 +330,6 @@ public class FeedQueryRepositoryImpl implements FeedQueryRepository {
             // createdAt DESC
             where = where.and(
                     feed.createdAt.lt(lastCreatedAt)
-                            .or(feed.createdAt.eq(lastCreatedAt))
             );
         }
 

--- a/src/main/java/konkuk/thip/feed/application/mapper/FeedQueryMapper.java
+++ b/src/main/java/konkuk/thip/feed/application/mapper/FeedQueryMapper.java
@@ -23,6 +23,9 @@ import java.util.stream.Collectors;
 )
 public interface FeedQueryMapper {
 
+    /**
+     * 피드 전체 조회 응답 DTO 변환
+     */
     @Mapping(target = "aliasName", source = "dto.alias")
     @Mapping(target = "aliasColor", expression = "java(Alias.from(dto.alias()).getColor())")
     @Mapping(target = "isSaved", expression = "java(savedFeedIds.contains(dto.feedId()))")
@@ -39,6 +42,9 @@ public interface FeedQueryMapper {
             @Context Long userId
     );
 
+    /**
+     * 내 피드 조회 응답 DTO 변환
+     */
     @Mapping(target = "postDate", expression = "java(DateUtil.formatBeforeTime(dto.createdAt()))")
     @Mapping(target = "isWriter", source = "dto.creatorId", qualifiedByName = "isWriter")
     FeedShowMineResponse.FeedDto toFeedShowMineDto(FeedQueryDto dto, @Context Long userId);
@@ -59,6 +65,9 @@ public interface FeedQueryMapper {
             @Context Long userId
     );
 
+    /**
+     * 특정 유저의 피드 조회 응답 DTO 변환
+     */
     @Mapping(target = "creatorId", source = "feedOwner.id")
     @Mapping(target = "profileImageUrl", source = "feedOwner.alias.imageUrl")
     @Mapping(target = "nickname", source = "feedOwner.nickname")
@@ -70,6 +79,9 @@ public interface FeedQueryMapper {
     @Mapping(target = "latestFollowerProfileImageUrls", source = "latestFollowerProfileImageUrls")
     FeedShowUserInfoResponse toFeedShowUserInfoResponse(User feedOwner, int totalFeedCount, boolean isFollowing, List<String> latestFollowerProfileImageUrls);
 
+    /**
+     * 피드 상세 조회 응답 DTO 변환
+     */
     @Mapping(target = "feedId", source = "feed.id")
     @Mapping(target = "creatorId", source = "feedCreator.id")
     @Mapping(target = "creatorNickname", source = "feedCreator.nickname")
@@ -121,4 +133,43 @@ public interface FeedQueryMapper {
     default boolean isWriter(Long creatorId, @Context Long userId) {
         return creatorId != null && creatorId.equals(userId);
     }
+
+    /**
+     * 특정 책 관련 피드 조회 응답 DTO 변환
+     */
+    @Mapping(target = "feedId", source = "dto.feedId")
+    @Mapping(target = "creatorId", source = "dto.creatorId")
+    @Mapping(target = "isWriter", source = "dto.creatorId", qualifiedByName = "isWriter")
+    @Mapping(target = "creatorNickname", source = "dto.creatorNickname")
+    @Mapping(target = "creatorProfileImageUrl", source = "dto.creatorProfileImageUrl")
+    @Mapping(target = "aliasName", expression = "java(Alias.from(dto.alias()).getValue())")
+    @Mapping(target = "aliasColor", expression = "java(Alias.from(dto.alias()).getColor())")
+    @Mapping(target = "postDate", expression = "java(DateUtil.formatBeforeTime(dto.createdAt()))")
+    @Mapping(target = "isbn", source = "dto.isbn")
+    @Mapping(target = "bookTitle", source = "dto.bookTitle")
+    @Mapping(target = "bookAuthor", source = "dto.bookAuthor")
+    @Mapping(target = "contentBody", source = "dto.contentBody")
+    @Mapping(target = "contentUrls", source = "dto.contentUrls")
+    @Mapping(target = "likeCount", source = "dto.likeCount")
+    @Mapping(target = "commentCount", source = "dto.commentCount")
+    @Mapping(target = "isSaved", source = "isSaved")
+    @Mapping(target = "isLiked", source = "isLiked")
+    FeedRelatedWithBookResponse.FeedRelatedWithBookDto toFeedRelatedWithBookDto(
+            FeedQueryDto dto,
+            boolean isSaved,
+            boolean isLiked,
+            @Context Long userId
+    );
+
+    default List<FeedRelatedWithBookResponse.FeedRelatedWithBookDto> toFeedRelatedWithBookDtos(
+            List<FeedQueryDto> dtos,
+            Set<Long> savedFeedIds,
+            Set<Long> likedFeedIds,
+            @Context Long userId
+    ) {
+        return dtos.stream()
+                .map(dto -> toFeedRelatedWithBookDto(dto, savedFeedIds.contains(dto.feedId()), likedFeedIds.contains(dto.feedId()), userId))
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/konkuk/thip/feed/application/port/in/FeedRelatedWithBookUseCase.java
+++ b/src/main/java/konkuk/thip/feed/application/port/in/FeedRelatedWithBookUseCase.java
@@ -1,0 +1,9 @@
+package konkuk.thip.feed.application.port.in;
+
+import konkuk.thip.feed.adapter.in.web.response.FeedRelatedWithBookResponse;
+import konkuk.thip.feed.application.port.in.dto.FeedRelatedWithBookQuery;
+
+public interface FeedRelatedWithBookUseCase {
+
+    FeedRelatedWithBookResponse getFeedsByBook(FeedRelatedWithBookQuery query);
+}

--- a/src/main/java/konkuk/thip/feed/application/port/in/dto/FeedRelatedWithBookQuery.java
+++ b/src/main/java/konkuk/thip/feed/application/port/in/dto/FeedRelatedWithBookQuery.java
@@ -1,0 +1,12 @@
+package konkuk.thip.feed.application.port.in.dto;
+
+import lombok.Builder;
+
+@Builder
+public record FeedRelatedWithBookQuery(
+        String isbn,
+        FeedRelatedWithBookSortType sortType,
+        String cursor,
+        Long userId
+) {
+}

--- a/src/main/java/konkuk/thip/feed/application/port/in/dto/FeedRelatedWithBookSortType.java
+++ b/src/main/java/konkuk/thip/feed/application/port/in/dto/FeedRelatedWithBookSortType.java
@@ -1,0 +1,26 @@
+package konkuk.thip.feed.application.port.in.dto;
+
+import konkuk.thip.common.exception.InvalidStateException;
+import konkuk.thip.common.exception.code.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FeedRelatedWithBookSortType {
+    LIKE("like"),
+    LATEST("latest")
+    ;
+
+    private final String type;
+
+    public static FeedRelatedWithBookSortType from(String type) {
+        for (FeedRelatedWithBookSortType sortType : values()) {
+            if (sortType.getType().equals(type)) {
+                return sortType;
+            }
+        }
+        throw new InvalidStateException(ErrorCode.API_INVALID_PARAM,
+                new IllegalArgumentException("정렬 타입은 like 또는 latest 중 하나여야 합니다. 현재 타입: " + type));
+    }
+}

--- a/src/main/java/konkuk/thip/feed/application/port/out/FeedQueryPort.java
+++ b/src/main/java/konkuk/thip/feed/application/port/out/FeedQueryPort.java
@@ -41,4 +41,11 @@ public interface FeedQueryPort {
     Set<Long> findSavedFeedIdsByUserIdAndFeedIds(Set<Long> feedIds, Long userId);
 
     List<TagCategoryQueryDto> findAllTags();
+
+    /**
+     * 특정 책으로 작성된 피드 조회
+     */
+    CursorBasedList<FeedQueryDto> findFeedsByBookIsbnOrderByLike(String isbn, Long userId, Cursor cursor);
+
+    CursorBasedList<FeedQueryDto> findFeedsByBookIsbnOrderByLatest(String isbn, Long userId, Cursor cursor);
 }

--- a/src/main/java/konkuk/thip/feed/application/port/out/dto/FeedQueryDto.java
+++ b/src/main/java/konkuk/thip/feed/application/port/out/dto/FeedQueryDto.java
@@ -1,5 +1,6 @@
 package konkuk.thip.feed.application.port.out.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import jakarta.annotation.Nullable;
 import lombok.Builder;
 
@@ -22,4 +23,50 @@ public record FeedQueryDto(
         int commentCount,
         boolean isPublic,
         @Nullable Boolean isPriorityFeed
-) { }
+) {
+    @QueryProjection
+    public FeedQueryDto(
+            Long feedId,
+            Long creatorId,
+            String creatorNickname,
+            String creatorProfileImageUrl,
+            String alias,
+            LocalDateTime createdAt,
+            String isbn,
+            String bookTitle,
+            String bookAuthor,
+            String contentBody,
+            String concatenatedContentUrls, // GROUP_CONCAT 결과
+            Integer likeCount,
+            Integer commentCount,
+            Boolean isPublic,
+            @Nullable Boolean isPriorityFeed
+    ) {
+        this(
+                feedId,
+                creatorId,
+                creatorNickname,
+                creatorProfileImageUrl,
+                alias,
+                createdAt,
+                isbn,
+                bookTitle,
+                bookAuthor,
+                contentBody,
+                splitToArray(concatenatedContentUrls),
+                likeCount == null ? 0 : likeCount,
+                commentCount == null ? 0 : commentCount,
+                isPublic,
+                isPriorityFeed
+        );
+    }
+
+    // Attribute convertor로 바꾸기 전에 임시 메서드
+    private static String[] splitToArray(String concatenated) {
+        if (concatenated == null || concatenated.isEmpty()) return new String[0];
+        String[] parts = concatenated.split(",");
+        for (int i = 0; i < parts.length; i++) parts[i] = parts[i].trim();
+        return parts;
+    }
+
+}

--- a/src/main/java/konkuk/thip/feed/application/port/out/dto/FeedQueryDto.java
+++ b/src/main/java/konkuk/thip/feed/application/port/out/dto/FeedQueryDto.java
@@ -19,8 +19,8 @@ public record FeedQueryDto(
         String bookAuthor,
         String contentBody,
         String[] contentUrls,
-        int likeCount,
-        int commentCount,
+        Integer likeCount,
+        Integer commentCount,
         boolean isPublic,
         @Nullable Boolean isPriorityFeed
 ) {

--- a/src/main/java/konkuk/thip/feed/application/service/FeedRelatedWithBookService.java
+++ b/src/main/java/konkuk/thip/feed/application/service/FeedRelatedWithBookService.java
@@ -1,0 +1,78 @@
+package konkuk.thip.feed.application.service;
+
+import konkuk.thip.book.application.port.out.BookQueryPort;
+import konkuk.thip.common.util.Cursor;
+import konkuk.thip.common.util.CursorBasedList;
+import konkuk.thip.feed.adapter.in.web.response.FeedRelatedWithBookResponse;
+import konkuk.thip.feed.application.mapper.FeedQueryMapper;
+import konkuk.thip.feed.application.port.in.FeedRelatedWithBookUseCase;
+import konkuk.thip.feed.application.port.in.dto.FeedRelatedWithBookQuery;
+import konkuk.thip.feed.application.port.out.FeedQueryPort;
+import konkuk.thip.feed.application.port.out.dto.FeedQueryDto;
+import konkuk.thip.post.application.port.out.PostLikeQueryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FeedRelatedWithBookService implements FeedRelatedWithBookUseCase {
+
+    private final FeedQueryPort feedQueryPort;
+    private final BookQueryPort bookQueryPort;
+    private final PostLikeQueryPort postLikeQueryPort;
+
+    private final FeedQueryMapper feedQueryMapper;
+
+    private static final int DEFAULT_PAGE_SIZE = 10;
+
+    @Override
+    public FeedRelatedWithBookResponse getFeedsByBook(FeedRelatedWithBookQuery query) {
+
+        // 책이 DB에 존재하는지 확인
+        boolean isBookExist = bookQueryPort.existsBookByIsbn(query.isbn());
+
+        // 책이 존재하지 않는 경우 빈 리스트로 응답
+        if(!isBookExist) {
+            return FeedRelatedWithBookResponse.of(List.of(), null, true);
+        }
+
+        Cursor cursor = Cursor.from(query.cursor(), DEFAULT_PAGE_SIZE);
+
+        // 정렬 조건에 따른 피드 조회
+        CursorBasedList<FeedQueryDto> feedQueryDtoCursorBasedList = switch(query.sortType()) {
+            case LIKE -> feedQueryPort.findFeedsByBookIsbnOrderByLike(query.isbn(), query.userId(), cursor);
+            case LATEST -> feedQueryPort.findFeedsByBookIsbnOrderByLatest(query.isbn(), query.userId(), cursor);
+        };
+
+        // 사용자가 저장한 피드 ID를 조회
+        Set<Long> savedFeedIds = feedQueryPort.findSavedFeedIdsByUserIdAndFeedIds(
+                feedQueryDtoCursorBasedList.contents().stream()
+                        .map(FeedQueryDto::feedId)
+                        .collect(Collectors.toSet()),
+                query.userId()
+        );
+
+        // 사용자가 좋아요한 피드 ID를 조회
+        Set<Long> likedFeedIds = postLikeQueryPort.findPostIdsLikedByUser(
+                feedQueryDtoCursorBasedList.contents().stream()
+                        .map(FeedQueryDto::feedId)
+                        .collect(Collectors.toSet()),
+                query.userId()
+        );
+
+        return FeedRelatedWithBookResponse.of(
+                feedQueryMapper.toFeedRelatedWithBookDtos(
+                        feedQueryDtoCursorBasedList.contents(),
+                        savedFeedIds,
+                        likedFeedIds,
+                        query.userId()
+                ),
+                feedQueryDtoCursorBasedList.nextCursor(),
+                feedQueryDtoCursorBasedList.isLast()
+        );
+    }
+}

--- a/src/test/java/konkuk/thip/feed/adapter/in/web/FeedRelatedWithBookApiTest.java
+++ b/src/test/java/konkuk/thip/feed/adapter/in/web/FeedRelatedWithBookApiTest.java
@@ -1,0 +1,389 @@
+package konkuk.thip.feed.adapter.in.web;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.adapter.out.persistence.repository.BookJpaRepository;
+import konkuk.thip.common.util.TestEntityFactory;
+import konkuk.thip.feed.adapter.out.jpa.FeedJpaEntity;
+import konkuk.thip.feed.adapter.out.persistence.repository.FeedJpaRepository;
+import konkuk.thip.feed.adapter.out.persistence.repository.SavedFeedJpaRepository;
+import konkuk.thip.post.adapter.out.jpa.PostLikeJpaEntity;
+import konkuk.thip.post.adapter.out.persistence.PostLikeJpaRepository;
+import konkuk.thip.room.adapter.out.jpa.CategoryJpaEntity;
+import konkuk.thip.room.adapter.out.persistence.repository.category.CategoryJpaRepository;
+import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserRole;
+import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.repository.alias.AliasJpaRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("[통합] 특정 책으로 작성된 피드 조회 api 통합 테스트")
+@AutoConfigureMockMvc(addFilters = false)
+@Transactional
+class FeedRelatedWithBookApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private AliasJpaRepository aliasJpaRepository;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private CategoryJpaRepository categoryJpaRepository;
+
+    @Autowired
+    private BookJpaRepository bookJpaRepository;
+
+    @Autowired
+    private FeedJpaRepository feedJpaRepository;
+
+    @Autowired
+    private SavedFeedJpaRepository savedFeedJpaRepository;
+
+    @Autowired
+    private PostLikeJpaRepository postLikeJpaRepository;
+
+    private static final String VALID_ISBN = "9781234567890";
+
+    @Test
+    @DisplayName("책 존재하지 않으면 빈 리스트 isLast true nextCursor null 반환")
+    void getFeedsByBook_book_not_exist_returns_empty() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(get("/feeds/related-books/" + VALID_ISBN)
+                .requestAttr("userId", 1L) // 임의 사용자
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.data.feeds").isArray())
+                .andExpect(jsonPath("$.data.feeds").isEmpty())
+                .andExpect(jsonPath("$.data.isLast").value(true))
+                .andExpect(jsonPath("$.data.nextCursor").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("기본 정렬 like 좋아요순 응답 성공")
+    void getFeedsByBook_like_default_success() throws Exception {
+        // given
+        TestData td = prepareDataForFeeds(); // 사용자 피드 생성
+
+        // requester가 저장한 피드 지정
+        savedFeedJpaRepository.save(TestEntityFactory.createSavedFeed(td.requester, td.publicFeed2));
+
+        // requester가 좋아요한 피드 지정
+        postLikeJpaRepository.save(PostLikeJpaEntity.builder()
+                .userJpaEntity(td.requester)
+                .postJpaEntity(td.publicFeed1)
+                .build());
+
+        // when
+        ResultActions result = mockMvc.perform(get("/feeds/related-books/" + td.book.getIsbn())
+                .requestAttr("userId", td.requester.getUserId())
+                .param("sort", "like")
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.data.feeds").isArray())
+                .andExpect(jsonPath("$.data.isLast").isBoolean());
+
+        String json = result.andReturn().getResponse().getContentAsString();
+        JsonNode root = objectMapper.readTree(json);
+        JsonNode feeds = root.path("data").path("feeds");
+
+        assertThat(feeds.size()).isGreaterThan(0);
+
+        // 좋아요 내림차순 검증
+        int prevLike = Integer.MAX_VALUE;
+        for (JsonNode f : feeds) {
+            int like = f.path("likeCount").asInt();
+            assertThat(like).isLessThanOrEqualTo(prevLike);
+            prevLike = like;
+        }
+
+        // isWriter false 검증 requester가 아닌 다른 사용자의 피드만 조회
+        for (JsonNode f : feeds) {
+            assertThat(f.path("isWriter").asBoolean()).isFalse();
+        }
+
+        // isSaved isLiked 매핑 검증
+        // publicFeed2 저장됨 → isSaved true
+        // publicFeed1 좋아요됨 → isLiked true
+        boolean hasSavedTrue = false;
+        boolean hasLikedTrue = false;
+        boolean hasContentUrls = false;
+        for (JsonNode f : feeds) {
+            if (f.path("feedId").asLong() == td.publicFeed2.getPostId()) {
+                assertThat(f.path("isSaved").asBoolean()).isTrue();
+                hasSavedTrue = true;
+            }
+            if (f.path("feedId").asLong() == td.publicFeed1.getPostId()) {
+                assertThat(f.path("isLiked").asBoolean()).isTrue();
+                hasLikedTrue = true;
+            }
+            // contentUrls 배열 확인
+            if (f.has("contentUrls") && f.path("contentUrls").isArray()) {
+                hasContentUrls = true;
+            }
+        }
+        assertThat(hasSavedTrue).isTrue();
+        assertThat(hasLikedTrue).isTrue();
+        assertThat(hasContentUrls).isTrue();
+    }
+
+    @Test
+    @DisplayName("정렬 latest 최신순 응답 성공 createdAt 내림차순 검증")
+    void getFeedsByBook_latest_success() throws Exception {
+        // given
+        TestData td = prepareDataForFeeds();
+
+        // when
+        ResultActions result = mockMvc.perform(get("/feeds/related-books/" + td.book.getIsbn())
+                .requestAttr("userId", td.requester.getUserId())
+                .param("sort", "latest")
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(status().isOk());
+
+        String json = result.andReturn().getResponse().getContentAsString();
+        JsonNode root = objectMapper.readTree(json);
+        JsonNode feeds = root.path("data").path("feeds");
+
+        assertThat(feeds.size()).isGreaterThan(0);
+
+        // createdAt 정렬은 응답 필드에 노출되지 않지만 서버 정렬 결과의 안정성은 likeCount 동일 시 createdAt 보조키로 검증하기 어려우므로
+        // 최신 정렬 케이스는 최소 결과 유효성 중심으로 점검
+        // 추가 보조 검증 isWriter false 유지
+        for (JsonNode f : feeds) {
+            assertThat(f.path("isWriter").asBoolean()).isFalse();
+        }
+    }
+
+    @Test
+    @DisplayName("커서 기반 페이징 동작 검증")
+    void getFeedsByBook_cursor_paging_success() throws Exception {
+        // given
+        int totalFeeds = 25; // 총 25개의 피드를 생성
+        int pageSize = 10; // 페이지당 10개씩
+        int sum = 0; // 피드 개수 합산 검증용
+        TestData td = prepareDataManyFeeds(totalFeeds);
+
+        // first page
+        ResultActions first = mockMvc.perform(get("/feeds/related-books/" + td.book.getIsbn())
+                .requestAttr("userId", td.requester.getUserId())
+                .param("sort", "like")
+                .contentType(MediaType.APPLICATION_JSON));
+
+        first.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.feeds").isArray());
+
+        String firstJson = first.andReturn().getResponse().getContentAsString();
+        JsonNode firstRoot = objectMapper.readTree(firstJson);
+        JsonNode feeds = firstRoot.path("data").path("feeds");
+        assertThat(feeds.size()).isEqualTo(pageSize);
+        sum += feeds.size();
+        String nextCursor = firstRoot.path("data").path("nextCursor").asText(null);
+        boolean isLast = firstRoot.path("data").path("isLast").asBoolean();
+
+        if (!isLast && nextCursor != null && !nextCursor.isEmpty()) {
+            // second page
+            ResultActions second = mockMvc.perform(get("/feeds/related-books/" + td.book.getIsbn())
+                    .requestAttr("userId", td.requester.getUserId())
+                    .param("sort", "like")
+                    .param("cursor", nextCursor)
+                    .contentType(MediaType.APPLICATION_JSON));
+
+            second.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.feeds").isArray());
+
+            String secondJson = second.andReturn().getResponse().getContentAsString();
+            JsonNode secondRoot = objectMapper.readTree(secondJson);
+            JsonNode secondFeeds = secondRoot.path("data").path("feeds");
+            assertThat(secondFeeds.size()).isEqualTo(pageSize);
+            sum += secondFeeds.size();
+            nextCursor = secondRoot.path("data").path("nextCursor").asText(null);
+            isLast = secondRoot.path("data").path("isLast").asBoolean();
+            assertThat(isLast).isFalse(); // 아직 마지막 페이지가 아니어야 함
+        }
+
+        if (!isLast && nextCursor != null && !nextCursor.isEmpty()) {
+            // third page
+            ResultActions third = mockMvc.perform(get("/feeds/related-books/" + td.book.getIsbn())
+                    .requestAttr("userId", td.requester.getUserId())
+                    .param("sort", "like")
+                    .param("cursor", nextCursor)
+                    .contentType(MediaType.APPLICATION_JSON));
+
+            third.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.feeds").isArray());
+
+            String thirdJson = third.andReturn().getResponse().getContentAsString();
+            JsonNode thirdRoot = objectMapper.readTree(thirdJson);
+            JsonNode thirdFeeds = thirdRoot.path("data").path("feeds");
+            assertThat(thirdFeeds.size()).isLessThanOrEqualTo(pageSize);
+            sum += thirdFeeds.size();
+            boolean isLastThird = thirdRoot.path("data").path("isLast").asBoolean();
+            assertThat(isLastThird).isTrue(); // 마지막 페이지여야 함
+            String thirdCursor = thirdRoot.path("data").path("nextCursor").asText();
+            assertThat(thirdCursor).isEqualTo("null"); // 다음 커서가 없어야 함
+        }
+
+        // 전체 피드 개수 검증
+        assertThat(sum).isEqualTo(totalFeeds);
+    }
+
+    @Test
+    @DisplayName("비공개 피드 제외 및 자기 자신 피드 제외 검증")
+    void getFeedsByBook_visibility_and_self_filter() throws Exception {
+        // given
+        AliasJpaEntity alias = aliasJpaRepository.save(TestEntityFactory.createLiteratureAlias());
+
+        UserJpaEntity requester = userJpaRepository.save(UserJpaEntity.builder()
+                .oauth2Id("kakao_req")
+                .nickname("요청자")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
+                .role(UserRole.USER)
+                .aliasForUserJpaEntity(alias)
+                .build());
+
+        CategoryJpaEntity category = categoryJpaRepository.save(TestEntityFactory.createLiteratureCategory(alias));
+
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBookWithISBN(VALID_ISBN));
+
+        // 자기 자신 글 두 개 생성
+        FeedJpaEntity myPublic = TestEntityFactory.createFeed(requester, book, true);
+        FeedJpaEntity myPrivate = TestEntityFactory.createFeed(requester, book, false);
+        feedJpaRepository.saveAll(List.of(myPublic, myPrivate));
+
+        // 다른 사람 공개 글 하나 생성
+        UserJpaEntity other = userJpaRepository.save(TestEntityFactory.createUser(alias, "다른사용자"));
+        FeedJpaEntity othersPublic = TestEntityFactory.createFeed(other, book, true);
+        feedJpaRepository.save(othersPublic);
+
+        // when
+        ResultActions result = mockMvc.perform(get("/feeds/related-books/" + book.getIsbn())
+                .requestAttr("userId", requester.getUserId())
+                .param("sort", "like")
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(status().isOk());
+
+        String json = result.andReturn().getResponse().getContentAsString();
+        JsonNode root = objectMapper.readTree(json);
+        JsonNode feeds = root.path("data").path("feeds");
+
+        // 자기 자신 글 제외 비공개 제외로 인해 only othersPublic 만 남아야 함
+        assertThat(feeds.size()).isEqualTo(1);
+        assertThat(feeds.get(0).path("creatorId").asLong()).isEqualTo(other.getUserId());
+        assertThat(feeds.get(0).path("isWriter").asBoolean()).isFalse();
+    }
+
+    private TestData prepareDataForFeeds() {
+        AliasJpaEntity alias = aliasJpaRepository.save(TestEntityFactory.createLiteratureAlias());
+        CategoryJpaEntity category = categoryJpaRepository.save(TestEntityFactory.createLiteratureCategory(alias));
+
+        UserJpaEntity requester = userJpaRepository.save(UserJpaEntity.builder()
+                .oauth2Id("kakao_req")
+                .nickname("요청자")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
+                .role(UserRole.USER)
+                .aliasForUserJpaEntity(alias)
+                .build());
+
+        UserJpaEntity author = userJpaRepository.save(TestEntityFactory.createUser(alias, "작성자"));
+
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBookWithISBN(VALID_ISBN));
+
+        // 공개 피드 두 개 비공개 하나 생성
+        FeedJpaEntity publicFeed1 = TestEntityFactory.createFeedWithContents(
+                author,
+                book,
+                List.of("http://img/1.jpg", "http://img/2.jpg"),
+                true
+        );
+        publicFeed1.updateLikeCount(7); // 좋아요 정렬을 위해 수치 조정
+
+        FeedJpaEntity publicFeed2 = TestEntityFactory.createFeedWithContents(
+                author,
+                book,
+                List.of("http://img/3.jpg"),
+                true
+        );
+        publicFeed2.updateLikeCount(3);
+
+        FeedJpaEntity privateFeed = TestEntityFactory.createFeed(author, book, false);
+
+        feedJpaRepository.saveAll(List.of(publicFeed1, publicFeed2, privateFeed));
+
+        return new TestData(requester, author, book, publicFeed1, publicFeed2);
+    }
+
+    private TestData prepareDataManyFeeds(int count) {
+        AliasJpaEntity alias = aliasJpaRepository.save(TestEntityFactory.createScienceAlias());
+        categoryJpaRepository.save(TestEntityFactory.createScienceCategory(alias));
+
+        UserJpaEntity requester = userJpaRepository.save(UserJpaEntity.builder()
+                .oauth2Id("kakao_req_many")
+                .nickname("요청자")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
+                .role(UserRole.USER)
+                .aliasForUserJpaEntity(alias)
+                .build());
+
+        UserJpaEntity author = userJpaRepository.save(TestEntityFactory.createUser(alias, "작성자"));
+
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBookWithISBN(VALID_ISBN));
+
+        for (int i = 0; i < count; i++) {
+            FeedJpaEntity f = TestEntityFactory.createFeedWithContents(
+                    author,
+                    book,
+                    List.of("http://img/" + i + ".jpg"),
+                    true
+            );
+            f.updateLikeCount(count - i); // 다양한 likeCount 부여
+            feedJpaRepository.save(f);
+        }
+
+        return new TestData(requester, author, book, null, null);
+    }
+
+    private record TestData(
+            UserJpaEntity requester,
+            UserJpaEntity author,
+            BookJpaEntity book,
+            FeedJpaEntity publicFeed1,
+            FeedJpaEntity publicFeed2
+    ) {}
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #139 

## 📝 작업 내용

api 흐름은 다음과 같습니다.
1. 파라미터로 넘어온 isbn으로 된 책이 DB에 존재하는지 확인 (존재하지 않으면 바로 빈 리스트 반환)
2. DB에 존재한다면 정렬 조건에 따라 쿼리 분기 처리
3. 인기순의 경우 likeCount와 createdAt을 복합 커서로 정렬 / 최신순의 경우 createdAt 단일 커서로 정렬
4. 조회한 피드 중 사용자가 좋아요 / 저장한 피드의 id를 배치 쿼리로 조회
5. FeedQueryMapper를 통해 dto 매핑

## 📸 스크린샷
<img width="4064" height="2334" alt="스크린샷 2025-08-16 오전 2 27 00" src="https://github.com/user-attachments/assets/bd53b908-0371-406e-a11f-5e2e33739c89" />

## 💬 리뷰 요구사항

기존에 FeedQueryDto에서 QueryProjection을 사용하지 못한 이유가 Content와의 1 : N 관계 때문이였는데 이를 group_concat이라는 MySQL 내부 함수를 사용하여 풀어냈습니다! (함수 내부적으로 `,` 를 통해 그룹을 만들어주기 때문에 FeedQueryDto 내부적으로 `,` 를 파싱해서 배열로 변환하도록 하였습니다.)

**페이징 처리 + 정렬 + Content 그룹핑**
```sql
Hibernate: 
    select
        fje1_0.post_id,
        uje1_0.user_id,
        uje1_0.nickname,
        afuje1_0.image_url,
        afuje1_0.alias_value,
        fje1_1.created_at,
        bje1_0.isbn,
        bje1_0.title,
        bje1_0.author_name,
        fje1_1.content,
        (select
            group_concat(cje1_0.content_url) 
        from
            contents cje1_0 
        where
            cje1_0.post_id=fje1_0.post_id),
        fje1_1.like_count,
        fje1_1.comment_count,
        fje1_0.is_public,
        null 
    from
        feeds fje1_0 
    join
        posts fje1_1 
            on fje1_0.post_id=fje1_1.post_id 
    join
        users uje1_0 
            on uje1_0.user_id=fje1_1.user_id 
    join
        aliases afuje1_0 
            on afuje1_0.alias_id=uje1_0.user_alias_id 
    join
        books bje1_0 
            on bje1_0.book_id=fje1_0.book_id 
    where
        fje1_1.status=? 
        and bje1_0.isbn=? 
        and uje1_0.user_id<>? 
        and fje1_0.is_public=? 
        and (
            fje1_1.like_count<? 
            or fje1_1.like_count=? 
            and fje1_1.created_at<?
        ) 
    order by
        fje1_1.like_count desc,
        fje1_1.created_at desc 
    fetch
        first ? rows only
```

**FeedQueryDto 내부 Content 파싱 메서드**
```java
private static String[] splitToArray(String concatenated) {
        if (concatenated == null || concatenated.isEmpty()) return new String[0];
        String[] parts = concatenated.split(",");
        for (int i = 0; i < parts.length; i++) parts[i] = parts[i].trim();
        return parts;
    }
```


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
