### PR TITLE
[hotfix] 방 검색 api 수정

### DIFF
--- a/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
@@ -75,7 +75,8 @@ public enum SwaggerResponseDescription {
     ))),
 
     ROOM_SEARCH(new LinkedHashSet<>(Set.of(
-                INVALID_ROOM_SEARCH_SORT
+            INVALID_ROOM_SEARCH_SORT,
+            CATEGORY_NOT_MATCH
     ))),
     ROOM_PASSWORD_CHECK(new LinkedHashSet<>(Set.of(
             ROOM_NOT_FOUND,

--- a/src/main/java/konkuk/thip/room/adapter/in/web/RoomQueryController.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/RoomQueryController.java
@@ -11,6 +11,7 @@ import konkuk.thip.room.adapter.in.web.request.RoomVerifyPasswordRequest;
 import konkuk.thip.room.adapter.in.web.response.*;
 import konkuk.thip.room.application.port.in.*;
 import konkuk.thip.room.application.port.in.dto.RoomGetHomeJoinedListQuery;
+import konkuk.thip.room.application.port.in.dto.RoomSearchQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,20 +33,23 @@ public class RoomQueryController {
     private final RoomGetDeadlinePopularUseCase roomGetDeadlinePopularUsecase;
 
     @Operation(
-            summary = "방 검색",
-            description = "키워드, 카테고리, 정렬 방식, 페이지 번호를 기준으로 방을 검색합니다. 아직 수정중입니다. 일단 request param 만 수정한 상태입니다."
+            summary = "모집중인 방 검색",
+            description = "검색어(= 방이름 or 첵제목), 카테고리 와 매핑되는 모집중인 방을 검색합니다. 공개/비공개 방 모두 검색 가능합니다."
     )
     @ExceptionDescription(ROOM_SEARCH)
     @GetMapping("/rooms/search")
-    public BaseResponse<RoomSearchResponse> searchRooms(
-            @Parameter(description = "검색 키워드 (책 이름 or 방 이름", example = "해리") @RequestParam(value = "keyword", required = false, defaultValue = "") final String keyword,
+    public BaseResponse<RoomSearchResponse> searchRecruitingRooms(
+            @Parameter(description = "검색 키워드 (책 이름 or 방 이름)", example = "해리") @RequestParam(value = "keyword", required = false, defaultValue = "") final String keyword,
             @Parameter(description = "모임방 카테고리", example = "문학") @RequestParam(value = "category", required = false, defaultValue = "") final String category,
             @Parameter(description = "정렬 방식 (마감 임박 : deadline, 신청 인원 : memberCount)", example = "deadline") @RequestParam("sort") final String sort,
             @Parameter(description = "사용자가 검색어 입력을 '확정'했는지 여부 (입력 중: false, 입력 확정: true)", example = "false") @RequestParam(name = "isFinalized") final boolean isFinalized,
-            @Parameter(description = "페이지 번호", example = "1") @RequestParam("page") final int page,
+            @Parameter(description = "커서 (첫번째 요청시 : null, 다음 요청시 : 이전 요청에서 반환받은 nextCursor 값)")
+            @RequestParam(value = "cursor", required = false) final String cursor,
             @Parameter(hidden = true) @UserId final Long userId
     ) {
-        return BaseResponse.ok(roomSearchUseCase.searchRoom(keyword, category, sort, page, isFinalized, userId));
+        return BaseResponse.ok(roomSearchUseCase.searchRecruitingRooms(
+                RoomSearchQuery.of(keyword, category, sort, isFinalized, cursor, userId)
+        ));
     }
 
     @Operation(

--- a/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomGetHomeJoinedListResponse.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomGetHomeJoinedListResponse.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 @Builder
 public record RoomGetHomeJoinedListResponse(
-        List<RoomSearchResult> roomList,
+        List<JoinedRoomInfo> roomList,
         String nickname,
         int page,       // 현재 페이지
         int size,       // 현재 페이지에 포함된 데이터 수
@@ -16,7 +16,7 @@ public record RoomGetHomeJoinedListResponse(
 
 
     @Builder
-    public record RoomSearchResult(
+    public record JoinedRoomInfo(
             Long roomId,
             String bookImageUrl,
             String roomTitle,

--- a/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomSearchResponse.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomSearchResponse.java
@@ -3,20 +3,18 @@ package konkuk.thip.room.adapter.in.web.response;
 import java.util.List;
 
 public record RoomSearchResponse(
-        List<RoomSearchResult> roomList,
-        int page,       // 현재 페이지
-        int size,       // 현재 페이지에 포함된 데이터 수
-        boolean last,
-        boolean first
+        List<RoomSearchDto> roomList,
+        String nextCursor,
+        boolean isLast
 ) {
 
-    public record RoomSearchResult(
+    public record RoomSearchDto(
             Long roomId,
             String bookImageUrl,
             String roomName,
             int memberCount,
             int recruitCount,
             String deadlineDate,
-            String category
+            boolean isPublic
     ) {}
 }

--- a/src/main/java/konkuk/thip/room/adapter/out/jpa/RoomJpaEntity.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/jpa/RoomJpaEntity.java
@@ -50,7 +50,7 @@ public class RoomJpaEntity extends BaseJpaEntity {
     private int memberCount = 1;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "book_id")
+    @JoinColumn(name = "book_id", nullable = false)
     private BookJpaEntity bookJpaEntity;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/function/IntegerCursorRoomQueryFunction.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/function/IntegerCursorRoomQueryFunction.java
@@ -1,0 +1,10 @@
+package konkuk.thip.room.adapter.out.persistence.function;
+
+import konkuk.thip.room.application.port.out.dto.RoomQueryDto;
+
+import java.util.List;
+
+@FunctionalInterface
+public interface IntegerCursorRoomQueryFunction {
+    List<RoomQueryDto> apply(Integer lastInteger, Long lastId, int pageSize);
+}

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/function/LocalDateCursorRoomQueryFunction.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/function/LocalDateCursorRoomQueryFunction.java
@@ -6,6 +6,6 @@ import java.time.LocalDate;
 import java.util.List;
 
 @FunctionalInterface
-public interface RoomQueryFunction {
+public interface LocalDateCursorRoomQueryFunction {
     List<RoomQueryDto> apply(LocalDate lastLocalDate, Long lastId, int pageSize);
 }

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomQueryRepository.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomQueryRepository.java
@@ -2,7 +2,6 @@ package konkuk.thip.room.adapter.out.persistence.repository;
 
 import konkuk.thip.room.adapter.in.web.response.RoomRecruitingDetailViewResponse;
 import konkuk.thip.room.adapter.in.web.response.RoomGetHomeJoinedListResponse;
-import konkuk.thip.room.adapter.in.web.response.RoomSearchResponse;
 import konkuk.thip.room.application.port.out.dto.RoomQueryDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,11 +12,17 @@ import java.time.LocalDate;
 
 public interface RoomQueryRepository {
 
-    Page<RoomSearchResponse.RoomSearchResult> searchRoom(String keyword, String category, Pageable pageable);
+    /**
+     * 방 검색
+     */
+    List<RoomQueryDto> findRecruitingRoomsOrderByStartDateAsc(String keyword, LocalDate lastStartDate, Long roomId, int pageSize);
+    List<RoomQueryDto> findRecruitingRoomsWithCategoryOrderByStartDateAsc(String keyword, String categoryVal, LocalDate lastStartDate, Long roomId, int pageSize);
+    List<RoomQueryDto> findRecruitingRoomsOrderByMemberCountDesc(String keyword, Integer lastMemberCount, Long roomId, int pageSize);
+    List<RoomQueryDto> findRecruitingRoomsWithCategoryOrderByMemberCountDesc(String keyword, String categoryVal, Integer lastMemberCount, Long roomId, int pageSize);
 
     List<RoomRecruitingDetailViewResponse.RecommendRoom> findOtherRecruitingRoomsByCategoryOrderByStartDateAsc(Long roomId, String category, int count);
 
-    Page<RoomGetHomeJoinedListResponse.RoomSearchResult> searchHomeJoinedRooms(Long userId, LocalDate today, Pageable pageable);
+    Page<RoomGetHomeJoinedListResponse.JoinedRoomInfo> searchHomeJoinedRooms(Long userId, LocalDate today, Pageable pageable);
 
     List<RoomQueryDto> findRecruitingRoomsUserParticipated(Long userId, LocalDate dateCursor, Long roomIdCursor, int pageSize);
 

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomQueryRepositoryImpl.java
@@ -2,7 +2,6 @@ package konkuk.thip.room.adapter.out.persistence.repository;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
-import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
@@ -15,7 +14,6 @@ import konkuk.thip.common.entity.StatusType;
 import konkuk.thip.common.util.DateUtil;
 import konkuk.thip.room.adapter.in.web.response.RoomGetHomeJoinedListResponse;
 import konkuk.thip.room.adapter.in.web.response.RoomRecruitingDetailViewResponse;
-import konkuk.thip.room.adapter.in.web.response.RoomSearchResponse;
 import konkuk.thip.room.adapter.out.jpa.QCategoryJpaEntity;
 import konkuk.thip.room.adapter.out.jpa.QRoomJpaEntity;
 import konkuk.thip.room.adapter.out.jpa.QRoomParticipantJpaEntity;
@@ -25,7 +23,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -42,112 +39,139 @@ public class RoomQueryRepositoryImpl implements RoomQueryRepository {
     private final QRoomParticipantJpaEntity participant = QRoomParticipantJpaEntity.roomParticipantJpaEntity;
     private final QCategoryJpaEntity category = QCategoryJpaEntity.categoryJpaEntity;
 
-    @Override
-    public Page<RoomSearchResponse.RoomSearchResult> searchRoom(String keyword, String category, Pageable pageable) {
-        // 1. 검색 조건(where) 조립 : 방이름 or 첵제목에 keyword 포함, category 필터 적용, 멤버 모집중인(= 활동 시작전인) 방만 검색
+    /** 모집중 + ACTIVE 공통 where */
+    private BooleanBuilder recruitingActiveWhere(LocalDate today) {
         BooleanBuilder where = new BooleanBuilder();
-        // keyword 필터 (빈 문자열이면 생략)
+        where.and(room.startDate.after(today))
+                .and(room.status.eq(StatusType.ACTIVE));
+        return where;
+    }
+
+    /** 카테고리 조건 추가 */
+    private void applyCategory(BooleanBuilder where, String categoryVal) {
+        if (categoryVal != null && !categoryVal.isBlank()) {
+            where.and(room.categoryJpaEntity.value.eq(categoryVal));
+        }
+    }
+
+    /** 키워드(방 이름 OR 책 제목) 조건 추가 */
+    private void applyKeyword(BooleanBuilder where, String keyword) {
         if (keyword != null && !keyword.isBlank()) {
-            where.and(room.title.containsIgnoreCase(keyword).or(book.title.containsIgnoreCase(keyword)));
+            where.and(room.title.containsIgnoreCase(keyword)
+                    .or(book.title.containsIgnoreCase(keyword)));
         }
-        // category 필터 (빈 문자열이면 생략)
-        if (category != null && !category.isBlank()) {
-            where.and(room.categoryJpaEntity.value.eq(category));
+    }
+
+    /** 커서 조건: startDate ASC */
+    private void applyCursorStartDateAsc(BooleanBuilder where, DateExpression<LocalDate> cursorExpr, LocalDate lastStartDate, Long roomId) {
+        if (lastStartDate != null && roomId != null) {
+            where.and(cursorExpr.gt(lastStartDate)
+                    .or(cursorExpr.eq(lastStartDate).and(room.roomId.gt(roomId))));
         }
-        // 모집중인 방만
-        where.and(room.startDate.after(LocalDate.now()));
+    }
 
-        // 2. 페이징된 content 조회
-        // 우선순위 표현식 : keyword가 방 제목에 매칭되면 1, 아니면 0
-        NumberExpression<Integer> priorityExpr = new CaseBuilder()
-                .when(room.title.containsIgnoreCase(keyword)).then(1)
-                .otherwise(0);
+    /** 커서 조건: memberCount DESC */
+    private void applyCursorMemberCountDesc(BooleanBuilder where, Integer lastMemberCount, Long roomId) {
+        if (lastMemberCount != null && roomId != null) {
+            where.and(room.memberCount.lt(lastMemberCount)
+                    .or(room.memberCount.eq(lastMemberCount).and(room.roomId.gt(roomId))));
+        }
+    }
 
-        NumberExpression<Long> memberCountExpr = participant.roomParticipantId.count();       // 방 별 멤버수 표현식
-
-        List<Tuple> tuples = queryFactory
-                .select(
-                        room.roomId,
-                        book.imageUrl,
-                        room.title,
-                        memberCountExpr,
-                        room.recruitCount,
-                        room.startDate,
-                        room.categoryJpaEntity.value
-                )
-                .from(room)
-                .join(room.bookJpaEntity, book)
-                .leftJoin(participant).on(participant.roomJpaEntity.eq(room))
-                .where(where)
-                .groupBy(
-                        room.roomId,
-                        book.imageUrl,
-                        room.title,
-                        room.recruitCount,
-                        room.startDate,
-                        room.categoryJpaEntity.value
-                )
-                .orderBy(
-                        // 1차 정렬 : 설정된 정렬 조건, 2차 정렬 : 방이름으로 방 검색 > 책제목으로 방 검색
-                        toOrderSpecifier(pageable.getSort(), room, memberCountExpr),
-                        priorityExpr.desc()
-                )
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
-        // TODO : 추후에 오프셋 페이징이 아니라, 키셋 페이징 기법 도입 검토
-
-        // 3. Tuple → DTO 매핑
-        List<RoomSearchResponse.RoomSearchResult> content = tuples.stream()
-                .map(t -> new RoomSearchResponse.RoomSearchResult(
-                        t.get(room.roomId),
-                        t.get(book.imageUrl),
-                        t.get(room.title),
-                        // 참여자 수를 int로 캐스팅
-                        t.get(memberCountExpr).intValue(),
-                        t.get(room.recruitCount),
-                        // 모집마감일 까지 남은 시간 포맷
-                        DateUtil.formatAfterTime(t.get(room.startDate)),
-                        t.get(room.categoryJpaEntity.value)
-                ))
-                .toList();
-
-        // 4. 전체 개수 조회 (페이징 정보 계산용)
-        Long totalCount = queryFactory
-                .select(room.count())
-                .from(room)
-                .join(room.bookJpaEntity, book)
-                .where(where)
-                .fetchOne();
-        long total = (totalCount != null) ? totalCount : 0L;
-
-        // 5. PageImpl 생성하여 반환
-        return new PageImpl<>(content, pageable, total);
+    /** 공통 SELECT 프로젝션 */
+    private QRoomQueryDto projectionForRecruitingRoomSearch() {
+        return new QRoomQueryDto(
+                room.roomId,
+                book.imageUrl,
+                room.title,
+                room.recruitCount,
+                room.memberCount,
+                room.startDate,
+                room.isPublic
+        );
     }
 
     /**
-     * 지원하는 정렬 키에 대해, 미리 정의된 Q 필드를 반환합니다.
-     * sort가 없으면 '마감 임박순' 으로 기본 처리합니다.
+     * 모집중인 방 검색 관련 메서드
      */
-    private OrderSpecifier<?> toOrderSpecifier(Sort sort, QRoomJpaEntity room, NumberExpression<Long> memberCountExpr) {
-        // sort 파라미터가 없으면 기본 마감 임박순
-        if (sort.isUnsorted()) {
-            return room.startDate.asc();
-        }
+    @Override
+    public List<RoomQueryDto> findRecruitingRoomsOrderByStartDateAsc(String keyword, LocalDate lastStartDate, Long roomId, int pageSize) {
+        final LocalDate today = LocalDate.now();
+        DateExpression<LocalDate> cursorExpr = room.startDate; // 커서 비교는 startDate
 
-        // 클라이언트가 보낸 첫 번째 sort 키를 꺼냅니다.
-        String key = sort.stream().findFirst().get().getProperty();
-
-        switch (key) {
-            case "memberCount":
-                // user_rooms 테이블에서 현재 참여자 수 집계 → 내림차순
-                return new OrderSpecifier<>(Order.DESC, memberCountExpr);
-            case "deadLine":
-            default:
-                // deadLine: 마감 임박순 = startDate 빠른 순서대로(오름차순)
-                return room.startDate.asc();
-        }
+        BooleanBuilder where = recruitingActiveWhere(today);
+        applyKeyword(where, keyword);
+        applyCursorStartDateAsc(where, cursorExpr, lastStartDate, roomId);
+        
+        return queryFactory
+                .select(projectionForRecruitingRoomSearch())
+                .from(room)
+                .join(room.bookJpaEntity, book)
+                .where(where)
+                .orderBy(cursorExpr.asc(), room.roomId.asc())
+                .limit(pageSize + 1)
+                .fetch();
     }
+
+    @Override
+    public List<RoomQueryDto> findRecruitingRoomsWithCategoryOrderByStartDateAsc(String keyword, String categoryVal, LocalDate lastStartDate, Long roomId, int pageSize) {
+        final LocalDate today = LocalDate.now();
+        DateExpression<LocalDate> cursorExpr = room.startDate;
+
+        BooleanBuilder where = recruitingActiveWhere(today);
+        applyCategory(where, categoryVal);
+        applyKeyword(where, keyword);
+        applyCursorStartDateAsc(where, cursorExpr, lastStartDate, roomId);
+
+        return queryFactory
+                .select(projectionForRecruitingRoomSearch())
+                .from(room)
+                .join(room.bookJpaEntity, book)
+                .join(room.categoryJpaEntity, category)
+                .where(where)
+                .orderBy(cursorExpr.asc(), room.roomId.asc())
+                .limit(pageSize + 1)
+                .fetch();
+    }
+
+    @Override
+    public List<RoomQueryDto> findRecruitingRoomsOrderByMemberCountDesc(String keyword, Integer lastMemberCount, Long roomId, int pageSize) {
+        final LocalDate today = LocalDate.now();
+
+        BooleanBuilder where = recruitingActiveWhere(today);
+        applyKeyword(where, keyword);
+        applyCursorMemberCountDesc(where, lastMemberCount, roomId);
+
+        return queryFactory
+                .select(projectionForRecruitingRoomSearch())
+                .from(room)
+                .join(room.bookJpaEntity, book)
+                .where(where)
+                .orderBy(room.memberCount.desc(), room.roomId.asc())
+                .limit(pageSize + 1)
+                .fetch();
+    }
+
+    @Override
+    public List<RoomQueryDto> findRecruitingRoomsWithCategoryOrderByMemberCountDesc(String keyword, String categoryVal, Integer lastMemberCount, Long roomId, int pageSize) {
+        final LocalDate today = LocalDate.now();
+
+        BooleanBuilder where = recruitingActiveWhere(today);
+        applyCategory(where, categoryVal);
+        applyKeyword(where, keyword);
+        applyCursorMemberCountDesc(where, lastMemberCount, roomId);
+
+        return queryFactory
+                .select(projectionForRecruitingRoomSearch())
+                .from(room)
+                .join(room.bookJpaEntity, book)
+                .join(room.categoryJpaEntity, category)
+                .where(where)
+                .orderBy(room.memberCount.desc(), room.roomId.asc())
+                .limit(pageSize + 1)
+                .fetch();
+    }
+//  -----------------------------------------------------------------------------------------------------------------------
 
     @Override
     public List<RoomRecruitingDetailViewResponse.RecommendRoom> findOtherRecruitingRoomsByCategoryOrderByStartDateAsc(Long roomId, String category, int count) {
@@ -179,7 +203,7 @@ public class RoomQueryRepositoryImpl implements RoomQueryRepository {
     }
 
     @Override
-    public Page<RoomGetHomeJoinedListResponse.RoomSearchResult> searchHomeJoinedRooms(Long userId, LocalDate date, Pageable pageable) {
+    public Page<RoomGetHomeJoinedListResponse.JoinedRoomInfo> searchHomeJoinedRooms(Long userId, LocalDate date, Pageable pageable) {
 
         QRoomParticipantJpaEntity userRoomSub = new QRoomParticipantJpaEntity("userRoomSub");
 
@@ -217,8 +241,8 @@ public class RoomQueryRepositoryImpl implements RoomQueryRepository {
         // TODO : 추후에 오프셋 페이징이 아니라, 키셋 페이징 기법 도입 검토
 
         // 3. Tuple → DTO 매핑
-        List<RoomGetHomeJoinedListResponse.RoomSearchResult> content = tuples.stream()
-                .map(t -> RoomGetHomeJoinedListResponse.RoomSearchResult.builder()
+        List<RoomGetHomeJoinedListResponse.JoinedRoomInfo> content = tuples.stream()
+                .map(t -> RoomGetHomeJoinedListResponse.JoinedRoomInfo.builder()
                         .roomId(t.get(room.roomId))
                         .bookImageUrl(t.get(book.imageUrl))
                         .roomTitle(t.get(room.title))
@@ -341,8 +365,8 @@ public class RoomQueryRepositoryImpl implements RoomQueryRepository {
                         room.startDate
                 ))
                 .from(room)
-                .leftJoin(room.bookJpaEntity, book)
-                .leftJoin(room.categoryJpaEntity, category)
+                .join(room.bookJpaEntity, book)
+                .join(room.categoryJpaEntity, category)
                 .where(findDeadlinePopularRoomCondition(categoryVal, userId))
                 .orderBy(room.startDate.asc(), room.memberCount.desc(), room.roomId.asc())
                 .limit(limit)
@@ -361,8 +385,8 @@ public class RoomQueryRepositoryImpl implements RoomQueryRepository {
                         room.startDate
                 ))
                 .from(room)
-                .leftJoin(room.bookJpaEntity, book)
-                .leftJoin(room.categoryJpaEntity, category)
+                .join(room.bookJpaEntity, book)
+                .join(room.categoryJpaEntity, category)
                 .where(findDeadlinePopularRoomCondition(categoryVal, userId))
                 .orderBy(room.memberCount.desc(), room.startDate.asc(), room.roomId.asc())
                 .limit(limit)
@@ -391,7 +415,7 @@ public class RoomQueryRepositoryImpl implements RoomQueryRepository {
                         cursorExpr
                 ))
                 .from(room)
-                .leftJoin(room.bookJpaEntity, book)
+                .join(room.bookJpaEntity, book)
                 .where(baseCondition)
                 .orderBy(cursorExpr.asc(), room.roomId.asc())
                 .limit(pageSize + 1)
@@ -451,12 +475,11 @@ public class RoomQueryRepositoryImpl implements RoomQueryRepository {
                         room.title,
                         room.recruitCount,
                         room.memberCount,
-                        room.startDate,     // 방의 진행 시작일 정보 채우기
                         cursorExpr
                 ))
                 .from(participant)
                 .join(participant.roomJpaEntity, room)
-                .leftJoin(room.bookJpaEntity, book)
+                .join(room.bookJpaEntity, book)
                 .where(where)
                 .orderBy(orders)
                 .limit(pageSize + 1)

--- a/src/main/java/konkuk/thip/room/application/mapper/RoomQueryMapper.java
+++ b/src/main/java/konkuk/thip/room/application/mapper/RoomQueryMapper.java
@@ -2,6 +2,7 @@ package konkuk.thip.room.application.mapper;
 
 import konkuk.thip.common.util.DateUtil;
 import konkuk.thip.room.adapter.in.web.response.RoomGetDeadlinePopularResponse;
+import konkuk.thip.room.adapter.in.web.response.RoomSearchResponse;
 import konkuk.thip.room.adapter.in.web.response.RoomShowMineResponse;
 import konkuk.thip.room.application.port.out.dto.RoomQueryDto;
 import konkuk.thip.room.application.port.in.dto.MyRoomType;
@@ -30,4 +31,12 @@ public interface RoomQueryMapper {
     RoomGetDeadlinePopularResponse.RoomDto toDeadlinePopularRoomDto(RoomQueryDto dto);
 
     List<RoomGetDeadlinePopularResponse.RoomDto> toDeadlinePopularRoomDtoList(List<RoomQueryDto> roomQueryDtos);
+
+
+
+    @Mapping(target = "deadlineDate", expression = "java(DateUtil.formatAfterTime(dto.endDate()))")
+    @Mapping(target = "isPublic", expression = "java(Boolean.TRUE.equals(dto.isPublic()))")
+    RoomSearchResponse.RoomSearchDto toRoomSearchDto(RoomQueryDto dto);
+
+    List<RoomSearchResponse.RoomSearchDto> toRoomSearchResponse(List<RoomQueryDto> dtos);
 }

--- a/src/main/java/konkuk/thip/room/application/port/in/RoomSearchUseCase.java
+++ b/src/main/java/konkuk/thip/room/application/port/in/RoomSearchUseCase.java
@@ -1,8 +1,9 @@
 package konkuk.thip.room.application.port.in;
 
 import konkuk.thip.room.adapter.in.web.response.RoomSearchResponse;
+import konkuk.thip.room.application.port.in.dto.RoomSearchQuery;
 
 public interface RoomSearchUseCase {
 
-    RoomSearchResponse searchRoom(String keyword, String category, String sort, int page, boolean isFinalized, Long userId);
+    RoomSearchResponse searchRecruitingRooms(RoomSearchQuery query);
 }

--- a/src/main/java/konkuk/thip/room/application/port/in/dto/RoomSearchQuery.java
+++ b/src/main/java/konkuk/thip/room/application/port/in/dto/RoomSearchQuery.java
@@ -1,0 +1,15 @@
+package konkuk.thip.room.application.port.in.dto;
+
+public record RoomSearchQuery(
+        String keyword,
+        String categoryStr,
+        String sortStr,
+        boolean isFinalized,
+        String cursorStr,
+        Long userId
+) {
+    public static RoomSearchQuery of (String keyword, String categoryStr, String sortStr,
+                                      boolean isFinalized, String cursorStr, Long userId) {
+        return new RoomSearchQuery(keyword, categoryStr, sortStr, isFinalized, cursorStr, userId);
+    }
+}

--- a/src/main/java/konkuk/thip/room/application/port/in/dto/RoomSearchSortParam.java
+++ b/src/main/java/konkuk/thip/room/application/port/in/dto/RoomSearchSortParam.java
@@ -1,9 +1,12 @@
-package konkuk.thip.room.adapter.out.persistence;
+package konkuk.thip.room.application.port.in.dto;
 
+import konkuk.thip.common.exception.InvalidStateException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
+
+import static konkuk.thip.common.exception.code.ErrorCode.INVALID_ROOM_SEARCH_SORT;
 
 @Getter
 @RequiredArgsConstructor
@@ -20,7 +23,7 @@ public enum RoomSearchSortParam {
                 .filter(param -> param.getValue().equals(value))
                 .findFirst()
                 .orElseThrow(
-                        () -> new IllegalArgumentException("현재 정렬 조건 param : " + value)
+                        () -> new InvalidStateException(INVALID_ROOM_SEARCH_SORT)
                 );
     }
 }

--- a/src/main/java/konkuk/thip/room/application/port/out/RoomQueryPort.java
+++ b/src/main/java/konkuk/thip/room/application/port/out/RoomQueryPort.java
@@ -4,7 +4,6 @@ import konkuk.thip.common.util.Cursor;
 import konkuk.thip.common.util.CursorBasedList;
 import konkuk.thip.room.adapter.in.web.response.RoomGetHomeJoinedListResponse;
 import konkuk.thip.room.adapter.in.web.response.RoomRecruitingDetailViewResponse;
-import konkuk.thip.room.adapter.in.web.response.RoomSearchResponse;
 import konkuk.thip.room.application.port.out.dto.RoomQueryDto;
 import konkuk.thip.room.domain.Category;
 import konkuk.thip.room.domain.Room;
@@ -18,11 +17,17 @@ public interface RoomQueryPort {
 
     int countRecruitingRoomsByBookAndStartDateAfter(String isbn, LocalDate currentDate);
 
-    Page<RoomSearchResponse.RoomSearchResult> searchRoom(String keyword, String category, Pageable pageable);
+    /**
+     * 방 검색
+     */
+    CursorBasedList<RoomQueryDto> searchRecruitingRoomsByDeadline(String keyword, Cursor cursor);
+    CursorBasedList<RoomQueryDto> searchRecruitingRoomsWithCategoryByDeadline(String keyword, Category category, Cursor cursor);
+    CursorBasedList<RoomQueryDto> searchRecruitingRoomsByMemberCount(String keyword, Cursor cursor);
+    CursorBasedList<RoomQueryDto> searchRecruitingRoomsWithCategoryByMemberCount(String keyword, Category category, Cursor cursor);
 
     List<RoomRecruitingDetailViewResponse.RecommendRoom> findOtherRecruitingRoomsByCategoryOrderByStartDateAsc(Room currentRoom, int count);
 
-    Page<RoomGetHomeJoinedListResponse.RoomSearchResult> searchHomeJoinedRooms(Long userId, LocalDate today, Pageable pageable);
+    Page<RoomGetHomeJoinedListResponse.JoinedRoomInfo> searchHomeJoinedRooms(Long userId, LocalDate today, Pageable pageable);
 
     CursorBasedList<RoomQueryDto> findRecruitingRoomsUserParticipated(Long userId, Cursor cursor);
 

--- a/src/main/java/konkuk/thip/room/application/port/out/dto/RoomQueryDto.java
+++ b/src/main/java/konkuk/thip/room/application/port/out/dto/RoomQueryDto.java
@@ -12,10 +12,11 @@ public record RoomQueryDto(
         Long roomId,
         String bookImageUrl,
         String roomName,
-        int recruitCount, // 방 최대 인원 수
-        int memberCount,
+        Integer recruitCount, // 방 최대 인원 수
+        Integer memberCount,
         @Nullable LocalDate startDate,    // 방 진행 시작일
-        LocalDate endDate       // 방 진행 마감일 or 방 모집 마감일
+        LocalDate endDate,       // 방 진행 마감일 or 방 모집 마감일
+        Boolean isPublic        // 공개방 여부
 ) {
     @QueryProjection
     public RoomQueryDto {
@@ -23,19 +24,34 @@ public record RoomQueryDto(
         Assert.notNull(bookImageUrl, "bookImageUrl must not be null");
         Assert.notNull(roomName, "roomName must not be null");
         Assert.notNull(endDate, "endDate must not be null");
-        Assert.isTrue(recruitCount > 0, "recruitCount must be greater than 0");
-        Assert.isTrue(memberCount >= 0, "memberCount must be greater than or equal to 0");
+        Assert.notNull(recruitCount, "recruitCount must not be null");
+        Assert.notNull(memberCount, "memberCount must not be null");
     }
 
+    // 내가 참여한 모임방(모집중, 진행중, 모집+진행중, 완료된) 조회 시 활용
     @QueryProjection
     public RoomQueryDto(
             Long roomId,
             String bookImageUrl,
             String roomName,
-            int recruitCount,
-            int memberCount,
+            Integer recruitCount,
+            Integer memberCount,
             LocalDate endDate
     ) {
-        this(roomId, bookImageUrl, roomName, recruitCount, memberCount, null, endDate);
+        this(roomId, bookImageUrl, roomName, recruitCount, memberCount, null, endDate, null);
+    }
+
+    // 방 검색 시 활용
+    @QueryProjection
+    public RoomQueryDto(
+            Long roomId,
+            String bookImageUrl,
+            String roomName,
+            Integer recruitCount,
+            Integer memberCount,
+            LocalDate endDate,
+            Boolean isPublic
+    ) {
+        this(roomId, bookImageUrl, roomName, recruitCount, memberCount, null, endDate, isPublic);
     }
 }

--- a/src/main/java/konkuk/thip/room/application/service/RoomGetHomeJoinedListService.java
+++ b/src/main/java/konkuk/thip/room/application/service/RoomGetHomeJoinedListService.java
@@ -40,7 +40,7 @@ public class RoomGetHomeJoinedListService implements RoomGetHomeJoinedListUseCas
         Pageable pageable = PageRequest.of(pageIndex, DEFAULT_PAGE_SIZE);
 
         // 4. 모임 홈에서 참여중인 모임 방 검색
-        Page<RoomGetHomeJoinedListResponse.RoomSearchResult> result = roomQueryPort.searchHomeJoinedRooms(query.userId(), LocalDate.now(), pageable);
+        Page<RoomGetHomeJoinedListResponse.JoinedRoomInfo> result = roomQueryPort.searchHomeJoinedRooms(query.userId(), LocalDate.now(), pageable);
 
         // 5. response 구성
         return RoomGetHomeJoinedListResponse.builder()

--- a/src/test/java/konkuk/thip/common/util/TestEntityFactory.java
+++ b/src/test/java/konkuk/thip/common/util/TestEntityFactory.java
@@ -102,7 +102,7 @@ public class TestEntityFactory {
     }
 
     /**
-     * page 값을 지정할 수 있는 custom 생성자
+     * Book custom 생성자
      */
     public static BookJpaEntity createBook(int page) {
         return BookJpaEntity.builder()
@@ -113,6 +113,19 @@ public class TestEntityFactory {
                 .publisher("출판사")
                 .imageUrl("img")
                 .pageCount(page)
+                .description("설명")
+                .build();
+    }
+
+    public static BookJpaEntity createBookWithBookTitle(String bookTitle) {
+        return BookJpaEntity.builder()
+                .title(bookTitle)
+                .authorName("저자")
+                .isbn(UUID.randomUUID().toString().replace("-", "").substring(0, 13))
+                .bestSeller(false)
+                .publisher("출판사")
+                .imageUrl("img")
+                .pageCount(300)
                 .description("설명")
                 .build();
     }
@@ -143,7 +156,7 @@ public class TestEntityFactory {
                 .build();
     }
 
-    public static RoomJpaEntity createCustomRoom(BookJpaEntity book, CategoryJpaEntity category,LocalDate startDate,LocalDate endDate) {
+    public static RoomJpaEntity createCustomRoom(BookJpaEntity book, CategoryJpaEntity category, LocalDate startDate, LocalDate endDate) {
         return RoomJpaEntity.builder()
                 .title("방이름")
                 .description("설명")
@@ -151,6 +164,19 @@ public class TestEntityFactory {
                 .startDate(startDate)
                 .endDate(endDate)
                 .recruitCount(3)
+                .bookJpaEntity(book)
+                .categoryJpaEntity(category)
+                .build();
+    }
+
+    public static RoomJpaEntity createCustomRoom(BookJpaEntity book, CategoryJpaEntity category, String roomName, LocalDate startDate, LocalDate endDate) {
+        return RoomJpaEntity.builder()
+                .title(roomName)
+                .description("설명")
+                .isPublic(true)
+                .startDate(startDate)
+                .endDate(endDate)
+                .recruitCount(20)
                 .bookJpaEntity(book)
                 .categoryJpaEntity(category)
                 .build();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #65 

## 📝 작업 내용

- 방 검색 api를 수정하였습니다
- 수정 사항 정리
  - 커서 기반 페이지네이션으로 수정
  - 회의 결과 방 검색 api의 request param 을
    - String 검색어 키워드
    - String category(nullable)
    - String sort
    - boolean isFinalized
    - String cursor(nullable)
    로 확정하였습니다
  
  - 이에 맞게 전반적인 코드 및 테스트 코드를 수정, 추가 하였습니다

- 현재는 QueryDSL 코드가 키워드를 포함하는 방 이름 or 책 제목을 select 합니다
```java
where.and(room.title.containsIgnoreCase(keyword)
                    .or(book.title.containsIgnoreCase(keyword)));
```

일단은 위와 같이 구현하였는데, 추후 성능적으로 개선할 방법이 있는지 고민해볼 포인트가 될 수 있을 것 같습니다!! 
해당 부분은 TODO 주석처리 해두었습니다!

## 📸 스크린샷

## 💬 리뷰 요구사항


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
