### PR TITLE
[hotfix] 개발된 모든 api의 response inner class 네이밍 수정

### DIFF
--- a/src/main/java/konkuk/thip/book/adapter/in/web/response/BookRecruitingRoomsResponse.java
+++ b/src/main/java/konkuk/thip/book/adapter/in/web/response/BookRecruitingRoomsResponse.java
@@ -3,16 +3,16 @@ package konkuk.thip.book.adapter.in.web.response;
 import java.util.List;
 
 public record BookRecruitingRoomsResponse(
-        List<RecruitingRoomDto> recruitingRoomList,
+        List<BookRecruitingRoomDto> recruitingRoomList,
         Integer totalRoomCount,
         String nextCursor,
         boolean isLast
 ) {
-    public static BookRecruitingRoomsResponse of(List<RecruitingRoomDto> recruitingRoomList, Integer totalRoomCount, String nextCursor, boolean isLast) {
+    public static BookRecruitingRoomsResponse of(List<BookRecruitingRoomDto> recruitingRoomList, Integer totalRoomCount, String nextCursor, boolean isLast) {
         return new BookRecruitingRoomsResponse(recruitingRoomList, totalRoomCount, nextCursor, isLast);
     }
 
-    public record RecruitingRoomDto(
+    public record BookRecruitingRoomDto(
             Long roomId,
             String bookImageUrl,
             String roomName,

--- a/src/main/java/konkuk/thip/book/adapter/in/web/response/BookSearchListResponse.java
+++ b/src/main/java/konkuk/thip/book/adapter/in/web/response/BookSearchListResponse.java
@@ -7,7 +7,7 @@ import java.util.List;
 import static konkuk.thip.book.adapter.out.api.naver.NaverApiUtil.PAGE_SIZE;
 
 public record BookSearchListResponse(
-        List<BookDto> searchResult, // 책 목록
+        List<BookSearchDto> searchResult, // 책 목록
         int page,                   // 현재 페이지 (1부터 시작)
         int size,                   // 한 페이지에 포함되는 데이터 수 (페이지 크기)
         long totalElements,         // 전체 데이터 개수
@@ -21,12 +21,12 @@ public record BookSearchListResponse(
         boolean last = (page >= totalPages);
         boolean first = (page == 1);
 
-        List<BookDto> bookDtos = result.naverBooks().stream()
-                .map(BookDto::of)
+        List<BookSearchDto> bookSearchDtos = result.naverBooks().stream()
+                .map(BookSearchDto::of)
                 .toList();
 
         return new BookSearchListResponse(
-                bookDtos,
+                bookSearchDtos,
                 page,
                 PAGE_SIZE,
                 totalElements,
@@ -35,15 +35,15 @@ public record BookSearchListResponse(
                 first
         );
     }
-    public record BookDto(
+    public record BookSearchDto(
             String title,
             String imageUrl,
             String authorName,
             String publisher,
             String isbn
     ) {
-        public static BookDto of(NaverBookParseResult.NaverBook naverBook) {
-            return new BookDto(
+        public static BookSearchDto of(NaverBookParseResult.NaverBook naverBook) {
+            return new BookSearchDto(
                     naverBook.title(),
                     naverBook.imageUrl(),
                     naverBook.author(),

--- a/src/main/java/konkuk/thip/book/application/mapper/BookQueryMapper.java
+++ b/src/main/java/konkuk/thip/book/application/mapper/BookQueryMapper.java
@@ -22,9 +22,9 @@ public interface BookQueryMapper {
             target = "deadlineEndDate",
             expression = "java(DateUtil.formatAfterTime(dto.endDate()))"
     )
-    BookRecruitingRoomsResponse.RecruitingRoomDto toRecruitingRoomDto(RoomQueryDto dto);
+    BookRecruitingRoomsResponse.BookRecruitingRoomDto toRecruitingRoomDto(RoomQueryDto dto);
 
-    List<BookRecruitingRoomsResponse.RecruitingRoomDto> toRecruitingRoomDtoList(List<RoomQueryDto> roomDtos);
+    List<BookRecruitingRoomsResponse.BookRecruitingRoomDto> toRecruitingRoomDtoList(List<RoomQueryDto> roomDtos);
 
     @Mapping(target = "bookId", source = "book.id")
     @Mapping(target = "bookTitle", source = "book.title")

--- a/src/main/java/konkuk/thip/feed/adapter/in/web/response/FeedShowAllResponse.java
+++ b/src/main/java/konkuk/thip/feed/adapter/in/web/response/FeedShowAllResponse.java
@@ -3,11 +3,11 @@ package konkuk.thip.feed.adapter.in.web.response;
 import java.util.List;
 
 public record FeedShowAllResponse(
-        List<FeedDto> feedList,
+        List<FeedShowAllDto> feedList,
         String nextCursor,
         boolean isLast
 ) {
-    public record FeedDto(
+    public record FeedShowAllDto(
             Long feedId,
             Long creatorId,
             String creatorNickname,

--- a/src/main/java/konkuk/thip/feed/adapter/in/web/response/FeedShowByUserResponse.java
+++ b/src/main/java/konkuk/thip/feed/adapter/in/web/response/FeedShowByUserResponse.java
@@ -7,7 +7,7 @@ import java.util.List;
 @Schema(description = "특정 유저의 피드 목록 조회 응답 DTO")
 public record FeedShowByUserResponse(
         @Schema(description = "조회된 피드 목록")
-        List<FeedShowByUserResponse.FeedDto> feedList,
+        List<FeedShowByUserDto> feedList,
 
         @Schema(description = "다음 페이지를 요청할 때 사용할 커서")
         String nextCursor,
@@ -16,7 +16,7 @@ public record FeedShowByUserResponse(
         boolean isLast
 ) {
     @Schema(description = "피드 단일 항목 정보")
-    public record FeedDto(
+    public record FeedShowByUserDto(
             Long feedId,
             String postDate,
             String isbn,

--- a/src/main/java/konkuk/thip/feed/adapter/in/web/response/FeedShowMineResponse.java
+++ b/src/main/java/konkuk/thip/feed/adapter/in/web/response/FeedShowMineResponse.java
@@ -3,11 +3,11 @@ package konkuk.thip.feed.adapter.in.web.response;
 import java.util.List;
 
 public record FeedShowMineResponse(
-        List<FeedDto> feedList,
+        List<FeedShowMineDto> feedList,
         String nextCursor,
         boolean isLast
 ) {
-    public record FeedDto(
+    public record FeedShowMineDto(
             Long feedId,
             String postDate,
             String isbn,

--- a/src/main/java/konkuk/thip/feed/application/mapper/FeedQueryMapper.java
+++ b/src/main/java/konkuk/thip/feed/application/mapper/FeedQueryMapper.java
@@ -32,7 +32,7 @@ public interface FeedQueryMapper {
             expression = "java(DateUtil.formatBeforeTime(dto.createdAt()))"
     )
     @Mapping(target = "isWriter", source = "dto.creatorId", qualifiedByName = "isWriter")
-    FeedShowAllResponse.FeedDto toFeedShowAllResponse(
+    FeedShowAllResponse.FeedShowAllDto toFeedShowAllResponse(
             FeedQueryDto dto,
             Set<Long> savedFeedIds,
             Set<Long> likedFeedIds,
@@ -41,9 +41,9 @@ public interface FeedQueryMapper {
 
     @Mapping(target = "postDate", expression = "java(DateUtil.formatBeforeTime(dto.createdAt()))")
     @Mapping(target = "isWriter", source = "dto.creatorId", qualifiedByName = "isWriter")
-    FeedShowMineResponse.FeedDto toFeedShowMineDto(FeedQueryDto dto, @Context Long userId);
+    FeedShowMineResponse.FeedShowMineDto toFeedShowMineDto(FeedQueryDto dto, @Context Long userId);
 
-    List<FeedShowMineResponse.FeedDto> toFeedShowMineResponse(List<FeedQueryDto> dtos, @Context Long userId);
+    List<FeedShowMineResponse.FeedShowMineDto> toFeedShowMineResponse(List<FeedQueryDto> dtos, @Context Long userId);
 
     @Mapping(target = "isSaved", expression = "java(savedFeedIds.contains(dto.feedId()))")
     @Mapping(target = "isLiked", expression = "java(likedFeedIds.contains(dto.feedId()))")
@@ -52,7 +52,7 @@ public interface FeedQueryMapper {
             expression = "java(DateUtil.formatBeforeTime(dto.createdAt()))"
     )
     @Mapping(target = "isWriter", source = "dto.creatorId", qualifiedByName = "isWriter")
-    FeedShowByUserResponse.FeedDto toFeedShowByUserResponse(
+    FeedShowByUserResponse.FeedShowByUserDto toFeedShowByUserResponse(
             FeedQueryDto dto,
             Set<Long> savedFeedIds,
             Set<Long> likedFeedIds,

--- a/src/main/java/konkuk/thip/feed/application/service/BasicFeedShowAllService.java
+++ b/src/main/java/konkuk/thip/feed/application/service/BasicFeedShowAllService.java
@@ -52,7 +52,7 @@ public class BasicFeedShowAllService implements FeedShowAllUseCase {
         Set<Long> likedFeedIdsByUser = postLikeQueryPort.findPostIdsLikedByUser(feedIds, userId);
 
         // 4. response 로의 매핑
-        List<FeedShowAllResponse.FeedDto> feedList = result.contents().stream()
+        List<FeedShowAllResponse.FeedShowAllDto> feedList = result.contents().stream()
                 .map(dto -> feedQueryMapper.toFeedShowAllResponse(dto, savedFeedIdsByUser, likedFeedIdsByUser, userId))
                 .toList();
 

--- a/src/main/java/konkuk/thip/feed/application/service/FeedShowAllOfUserService.java
+++ b/src/main/java/konkuk/thip/feed/application/service/FeedShowAllOfUserService.java
@@ -59,7 +59,7 @@ public class FeedShowAllOfUserService implements FeedShowAllOfUserUseCase {
         Set<Long> likedFeedIdsByUser = postLikeQueryPort.findPostIdsLikedByUser(feedIds, userId);
 
         // 4. response 로의 매핑
-        List<FeedShowByUserResponse.FeedDto> feedList = result.contents().stream()
+        List<FeedShowByUserResponse.FeedShowByUserDto> feedList = result.contents().stream()
                 .map(dto -> feedQueryMapper.toFeedShowByUserResponse(dto, savedFeedIdsByUser, likedFeedIdsByUser, userId))
                 .toList();
 

--- a/src/main/java/konkuk/thip/feed/application/service/FollowingPriorityFeedShowAllService.java
+++ b/src/main/java/konkuk/thip/feed/application/service/FollowingPriorityFeedShowAllService.java
@@ -51,7 +51,7 @@ public class FollowingPriorityFeedShowAllService implements FeedShowAllUseCase {
         Set<Long> likedFeedIdsByUser = postLikeQueryPort.findPostIdsLikedByUser(feedIds, userId);
 
         // 4. response 로의 매핑
-        List<FeedShowAllResponse.FeedDto> feedList = result.contents().stream()
+        List<FeedShowAllResponse.FeedShowAllDto> feedList = result.contents().stream()
                 .map(dto -> feedQueryMapper.toFeedShowAllResponse(dto, savedFeedIdsByUser, likedFeedIdsByUser, userId))
                 .toList();
 

--- a/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomGetDeadlinePopularResponse.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomGetDeadlinePopularResponse.java
@@ -3,10 +3,10 @@ package konkuk.thip.room.adapter.in.web.response;
 import java.util.List;
 
 public record RoomGetDeadlinePopularResponse(
-        List<RoomDto> deadlineRoomList,
-        List<RoomDto> popularRoomList
+        List<RoomGetDeadlinePopularDto> deadlineRoomList,
+        List<RoomGetDeadlinePopularDto> popularRoomList
 ) {
-    public record RoomDto(
+    public record RoomGetDeadlinePopularDto(
             Long roomId,
             String bookImageUrl,
             String roomName,
@@ -16,7 +16,7 @@ public record RoomGetDeadlinePopularResponse(
     ) {
     }
 
-    public static RoomGetDeadlinePopularResponse of(List<RoomDto> deadlineRoomList, List<RoomDto> popularRoomList) {
+    public static RoomGetDeadlinePopularResponse of(List<RoomGetDeadlinePopularDto> deadlineRoomList, List<RoomGetDeadlinePopularDto> popularRoomList) {
         return new RoomGetDeadlinePopularResponse(deadlineRoomList, popularRoomList);
     }
 }

--- a/src/main/java/konkuk/thip/room/application/mapper/RoomQueryMapper.java
+++ b/src/main/java/konkuk/thip/room/application/mapper/RoomQueryMapper.java
@@ -28,9 +28,9 @@ public interface RoomQueryMapper {
             target = "deadlineDate",
             expression = "java(DateUtil.formatAfterTime(dto.endDate()))"
     )
-    RoomGetDeadlinePopularResponse.RoomDto toDeadlinePopularRoomDto(RoomQueryDto dto);
+    RoomGetDeadlinePopularResponse.RoomGetDeadlinePopularDto toDeadlinePopularRoomDto(RoomQueryDto dto);
 
-    List<RoomGetDeadlinePopularResponse.RoomDto> toDeadlinePopularRoomDtoList(List<RoomQueryDto> roomQueryDtos);
+    List<RoomGetDeadlinePopularResponse.RoomGetDeadlinePopularDto> toDeadlinePopularRoomDtoList(List<RoomQueryDto> roomQueryDtos);
 
 
 

--- a/src/main/java/konkuk/thip/roompost/adapter/in/web/response/RoomPostSearchResponse.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/in/web/response/RoomPostSearchResponse.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 @Builder
 public record RoomPostSearchResponse(
-    List<RoomPostDto> postList,
+    List<RoomPostSearchDto> postList,
     Long roomId,
     String isbn,
     boolean isOverviewEnabled,
@@ -14,7 +14,7 @@ public record RoomPostSearchResponse(
     Boolean isLast
 ){
     @Builder
-    public record RoomPostDto(
+    public record RoomPostSearchDto(
             Long postId,
             String postDate,
             String postType,

--- a/src/main/java/konkuk/thip/roompost/application/mapper/RoomPostQueryMapper.java
+++ b/src/main/java/konkuk/thip/roompost/application/mapper/RoomPostQueryMapper.java
@@ -27,12 +27,12 @@ public interface RoomPostQueryMapper {
     @Mapping(target = "isWriter",       source = "isWriter")
     @Mapping(target = "isLocked",       source = "isLocked")
     @Mapping(target = "voteItems",      source = "voteItems")
-    RoomPostSearchResponse.RoomPostDto toPostDto(
+    RoomPostSearchResponse.RoomPostSearchDto toPostDto(
             RoomPostQueryDto dto,
             String content,
             boolean isLiked,
             boolean isWriter,
             boolean isLocked,
-            List<RoomPostSearchResponse.RoomPostDto.VoteItemDto> voteItems
+            List<RoomPostSearchResponse.RoomPostSearchDto.VoteItemDto> voteItems
     );
 }

--- a/src/main/java/konkuk/thip/roompost/application/service/RoomPostSearchService.java
+++ b/src/main/java/konkuk/thip/roompost/application/service/RoomPostSearchService.java
@@ -105,7 +105,7 @@ public class RoomPostSearchService implements RoomPostSearchUseCase {
                     boolean isLiked  = likedPostIds.contains(dto.postId());
                     String content   = isLocked ? roomPostAccessValidator.createBlurredString(dto.content()) : dto.content();
 
-                    List<RoomPostSearchResponse.RoomPostDto.VoteItemDto> voteItems =
+                    List<RoomPostSearchResponse.RoomPostSearchDto.VoteItemDto> voteItems =
                             getVoteItemDtosIfApplicable(dto, voteItemQueryMap, isLocked);
 
                     return roomPostQueryMapper.toPostDto(dto, content, isLiked, isWriter, isLocked, voteItems);
@@ -133,7 +133,7 @@ public class RoomPostSearchService implements RoomPostSearchUseCase {
     }
 
     // 투표 게시물인 경우 VoteItem DTO 목록을 생성하는 메서드
-    private List<RoomPostSearchResponse.RoomPostDto.VoteItemDto> getVoteItemDtosIfApplicable(RoomPostQueryDto dto, Map<Long, List<VoteItemQueryDto>> voteItemMap, boolean isLocked) {
+    private List<RoomPostSearchResponse.RoomPostSearchDto.VoteItemDto> getVoteItemDtosIfApplicable(RoomPostQueryDto dto, Map<Long, List<VoteItemQueryDto>> voteItemMap, boolean isLocked) {
         if (RECORD.getType().equals(dto.postType())) {
             return List.of();
         }
@@ -143,7 +143,7 @@ public class RoomPostSearchService implements RoomPostSearchUseCase {
     }
 
     // VoteItemQueryDto 목록을 RecordSearchResponse.PostDto.VoteItemDto 목록으로 변환하는 메서드
-    private List<RoomPostSearchResponse.RoomPostDto.VoteItemDto> mapToVoteItemDtos(List<VoteItemQueryDto> items, boolean isLocked) {
+    private List<RoomPostSearchResponse.RoomPostSearchDto.VoteItemDto> mapToVoteItemDtos(List<VoteItemQueryDto> items, boolean isLocked) {
         // voteCount를 모아 리스트로 변환
         List<Integer> counts = items.stream()
                 .map(VoteItemQueryDto::voteCount)
@@ -154,7 +154,7 @@ public class RoomPostSearchService implements RoomPostSearchUseCase {
 
         // 계산 결과를 이용해 DTO 조립
         return IntStream.range(0, items.size())
-                .mapToObj(i -> RoomPostSearchResponse.RoomPostDto.VoteItemDto.of(
+                .mapToObj(i -> RoomPostSearchResponse.RoomPostSearchDto.VoteItemDto.of(
                         items.get(i).voteItemId(),
                         isLocked ? roomPostAccessValidator.createBlurredString(items.get(i).itemName()) : items.get(i).itemName(),
                         percentages.get(i),

--- a/src/main/java/konkuk/thip/user/adapter/in/web/response/UserSearchResponse.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/response/UserSearchResponse.java
@@ -3,9 +3,9 @@ package konkuk.thip.user.adapter.in.web.response;
 import java.util.List;
 
 public record UserSearchResponse(
-        List<UserDto> userList
+        List<UserSearchDto> userList
 ) {
-    public record UserDto(
+    public record UserSearchDto(
             Long userId,
             String nickname,
             String profileImageUrl,
@@ -15,7 +15,7 @@ public record UserSearchResponse(
     ) {
     }
 
-    public static UserSearchResponse of(List<UserDto> userList) {
+    public static UserSearchResponse of(List<UserSearchDto> userList) {
         return new UserSearchResponse(userList);
     }
 }

--- a/src/main/java/konkuk/thip/user/adapter/in/web/response/UserSignupResponse.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/response/UserSignupResponse.java
@@ -5,7 +5,7 @@ import konkuk.thip.user.application.port.in.dto.UserSignupResult;
 public record UserSignupResponse(
         Long userId,
         String accessToken
-        ) {
+) {
     public static UserSignupResponse of(UserSignupResult userSignupResult) {
         return new UserSignupResponse(userSignupResult.userId(), userSignupResult.accessToken());
     }

--- a/src/main/java/konkuk/thip/user/application/mapper/UserQueryMapper.java
+++ b/src/main/java/konkuk/thip/user/application/mapper/UserQueryMapper.java
@@ -11,7 +11,7 @@ import java.util.List;
 public interface UserQueryMapper {
 
     // List<QueryDto> -> List<DTO>
-    List<UserSearchResponse.UserDto> toUserDtoList(List<UserQueryDto> userQueryDtos);
+    List<UserSearchResponse.UserSearchDto> toUserDtoList(List<UserQueryDto> userQueryDtos);
 
     // 단건 매핑: UserQueryDto -> RecentWriter
     UserFollowingRecentWritersResponse.RecentWriter toRecentWriter(UserQueryDto dto);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #237 

## 📝 작업 내용

api response의 inner class 의 이름이 같을 경우, 스웨거가 이를 제대로 구분하지 못하여 FE분들에게 혼동을 드리는 일이 계속 발생하고 있었습니다.

따라서 지금까지 개발된 모든 api들의 response에 대해서 이름이 동일한 inner class의 네이밍을 수정하였습니다

## 📸 스크린샷

## 💬 리뷰 요구사항


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  - 도서 검색 결과에 페이지네이션 정보(totalPages, first/last) 추가.
  - 모집중/마감·인기 독서방 카드에 인원수, 모집 인원, 마감일 등 추가 표시.
  - 피드 목록(전체/내 피드/사용자별) 항목 정보 확장: 책 제목/저자, 본문·이미지, 좋아요/댓글 수, 공개/저장/좋아요 여부, 작성자 여부 등 제공.
  - 방 게시글 검색 결과 항목 명칭 정리(동일 정보 유지).
  - 사용자 검색 결과에 별칭, 색상, 팔로워 수 추가 노출.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->