### PR TITLE
[hotfix] 피드 단일 조회 api response 수정

### DIFF
--- a/src/main/java/konkuk/thip/feed/adapter/in/web/response/FeedShowSingleResponse.java
+++ b/src/main/java/konkuk/thip/feed/adapter/in/web/response/FeedShowSingleResponse.java
@@ -9,6 +9,7 @@ public record FeedShowSingleResponse(
         String aliasColor,
         String postDate,
         String bookTitle,
+        String bookImageUrl,
         String isbn,
         String bookAuthor,
         String contentBody,
@@ -18,6 +19,7 @@ public record FeedShowSingleResponse(
         boolean isSaved,
         boolean isLiked,
         boolean isWriter,
-        String[] tagList
+        String[] tagList,
+        boolean isPublic
 ) {
 }

--- a/src/main/java/konkuk/thip/feed/application/mapper/FeedQueryMapper.java
+++ b/src/main/java/konkuk/thip/feed/application/mapper/FeedQueryMapper.java
@@ -90,6 +90,7 @@ public interface FeedQueryMapper {
     @Mapping(target = "aliasColor", source = "feedCreator.alias.color")
     @Mapping(target = "postDate", expression = "java(DateUtil.formatBeforeTime(feed.getCreatedAt()))")
     @Mapping(target = "bookTitle", source = "book.title")
+    @Mapping(target = "bookImageUrl", source = "book.imageUrl")
     @Mapping(target = "isbn", source = "book.isbn")
     @Mapping(target = "bookAuthor", source = "book.authorName")
     @Mapping(target = "contentBody", source = "feed.content")
@@ -100,6 +101,7 @@ public interface FeedQueryMapper {
     @Mapping(target = "isLiked", source = "isLiked")
     @Mapping(target = "isWriter", source = "feedCreator.id", qualifiedByName = "isWriter")
     @Mapping(target = "tagList", source = "feed.tagList", qualifiedByName = "mapTagList")
+    @Mapping(target = "isPublic", source = "feed.isPublic")
     FeedShowSingleResponse toFeedShowSingleResponse(Feed feed, User feedCreator, Book book, boolean isSaved, boolean isLiked, @Context Long userId);
 
     @Named("mapContentList")


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #243

## 📝 작업 내용

@rbqks529 님의 요청으로 피드 단일 조회 api의 response에 isPublic, bookImageUrl 데이터 추가하였습니다

## 📸 스크린샷
<img width="663" height="737" alt="image" src="https://github.com/user-attachments/assets/28571bd2-0b26-4003-878b-b7efe025e931" />


## 💬 리뷰 요구사항


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 피드 단건 조회 응답에 도서 이미지 URL과 공개 여부가 포함되어, 클라이언트에서 책 표지와 공개 상태를 직접 표시할 수 있습니다.
  * 사용자별 피드 조회에서도 도서 이미지가 제공되어 목록/카드에서 시각적 정보를 강화합니다.
  * 추가 필드 제공으로 썸네일 렌더링과 공개 상태 배지 등의 UI 요소 구성이 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->