### PR TITLE
[refactor] Post 관련 상속 전략 변경

### DIFF
--- a/src/main/java/konkuk/thip/feed/adapter/out/jpa/FeedJpaEntity.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/jpa/FeedJpaEntity.java
@@ -22,14 +22,14 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FeedJpaEntity extends PostJpaEntity {
 
-    @Column(name = "is_public", nullable = false)
+    @Column(name = "is_public")
     private Boolean isPublic;
 
-    @Column(name = "report_count", nullable = false)
+    @Column(name = "report_count")
     private int reportCount = 0;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "book_id", nullable = false)
+    @JoinColumn(name = "book_id")
     private BookJpaEntity bookJpaEntity;
 
     @OneToMany(mappedBy = "postJpaEntity", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/konkuk/thip/feed/adapter/out/jpa/FeedJpaEntity.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/jpa/FeedJpaEntity.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "feeds")
+//@Table(name = "feeds")
 @DiscriminatorValue("FEED")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/konkuk/thip/post/adapter/out/jpa/PostJpaEntity.java
+++ b/src/main/java/konkuk/thip/post/adapter/out/jpa/PostJpaEntity.java
@@ -18,7 +18,7 @@ import static konkuk.thip.common.exception.code.ErrorCode.POST_ALREADY_DELETED;
 @Entity
 @Table(name = "posts")
 @Getter
-@Inheritance(strategy = InheritanceType.JOINED)
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "dtype")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class PostJpaEntity extends BaseJpaEntity {

--- a/src/main/java/konkuk/thip/roompost/adapter/out/jpa/RecordJpaEntity.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/jpa/RecordJpaEntity.java
@@ -18,10 +18,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RecordJpaEntity extends PostJpaEntity {
 
+    @Column(name = "page")
     private Integer page;
 
-    @Column(name = "is_overview",nullable = false)
-    private boolean isOverview;
+    @Column(name = "is_overview")
+    private Boolean isOverview;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "room_id")

--- a/src/main/java/konkuk/thip/roompost/adapter/out/jpa/RecordJpaEntity.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/jpa/RecordJpaEntity.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "records")
+//@Table(name = "records")
 @DiscriminatorValue("RECORD")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/konkuk/thip/roompost/adapter/out/jpa/VoteJpaEntity.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/jpa/VoteJpaEntity.java
@@ -18,9 +18,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class VoteJpaEntity extends PostJpaEntity {
 
+    @Column(name = "page")
     private Integer page;
 
-    @Column(name = "is_overview",nullable = false)
+    @Column(name = "is_overview")
     private boolean isOverview;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/konkuk/thip/roompost/adapter/out/jpa/VoteJpaEntity.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/jpa/VoteJpaEntity.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "votes")
+//@Table(name = "votes")
 @DiscriminatorValue("VOTE")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/konkuk/thip/roompost/adapter/out/mapper/RecordMapper.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/mapper/RecordMapper.java
@@ -27,7 +27,7 @@ public class RecordMapper {
                 .content(recordJpaEntity.getContent())
                 .creatorId(recordJpaEntity.getUserJpaEntity().getUserId())
                 .page(recordJpaEntity.getPage())
-                .isOverview(recordJpaEntity.isOverview())
+                .isOverview(recordJpaEntity.getIsOverview())
                 .roomId(recordJpaEntity.getRoomJpaEntity().getRoomId())
                 .likeCount(recordJpaEntity.getLikeCount())
                 .commentCount(recordJpaEntity.getCommentCount())

--- a/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/record/RecordQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/record/RecordQueryRepositoryImpl.java
@@ -47,8 +47,8 @@ public class RecordQueryRepositoryImpl implements RecordQueryRepository {
         return queryFactory
                 .select(selectPostQueryDto())
                 .from(post)
-                .leftJoin(record).on(post.postId.eq(record.postId))
-                .leftJoin(vote).on(post.postId.eq(vote.postId))
+//                .leftJoin(record).on(post.postId.eq(record.postId))
+//                .leftJoin(vote).on(post.postId.eq(vote.postId))
                 .join(post.userJpaEntity, user)
                 .where(where)
                 .orderBy(getOrderSpecifiers(roomPostSortType))
@@ -84,8 +84,8 @@ public class RecordQueryRepositoryImpl implements RecordQueryRepository {
         return queryFactory
                 .select(selectPostQueryDto())
                 .from(post)
-                .leftJoin(record).on(post.postId.eq(record.postId))
-                .leftJoin(vote).on(post.postId.eq(vote.postId))
+//                .leftJoin(record).on(post.postId.eq(record.postId))
+//                .leftJoin(vote).on(post.postId.eq(vote.postId))
                 .join(post.userJpaEntity, user)
                 .where(where)
                 .orderBy(getOrderSpecifiers(roomPostSortType))


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #246 

## 📝 작업 내용

기존 Post <-> Vote, Record, Feed 간의 상속 전략을 JOINED에서 SINGLE_TABLE로 변경하였습니다. 

상속 전략을 변경하는 이유는 다음과 같습니다.
1. 구현 난이도 감소
2. 조회 성능 개선
구체적인 내용은 노션 참고해주세요~

전략 변경을 위해, 다음과 같은 작업을 수행했습니다.
1. 하위 필드 모두 nullable = true로 변경 (서비스 로직에게 null 검증 책임을 완전히 위임)
2. 기록장 조회시 명시적인 left join 제거 (이제는 붙여도 안붙여도 left join이 호출되지 않기 때문에 불필요한 코드라고 판단하여 제거하였습니다.)

추가적으로 현재 운영서버에 있는 DB를 모두 drop 시키지 않고 DB 마이그레이션을 통해 데이터를 옮길 생각입니다!

## 📸 스크린샷

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
