### PR TITLE
[fix] 저장한 책 또는 참여 중 모임의 책 조회 쿼리 수정

### DIFF
--- a/src/main/java/konkuk/thip/book/adapter/out/persistence/repository/BookJpaRepository.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/persistence/repository/BookJpaRepository.java
@@ -10,19 +10,21 @@ import java.util.Optional;
 public interface BookJpaRepository extends JpaRepository<BookJpaEntity, Long> {
     Optional<BookJpaEntity> findByIsbn(String isbn);
 
-    @Query("SELECT DISTINCT b FROM BookJpaEntity b " +
+    @Query("SELECT b FROM BookJpaEntity b " +
             "JOIN SavedBookJpaEntity s ON s.bookJpaEntity.bookId = b.bookId " +
             "WHERE s.userJpaEntity.userId = :userId " +
-            "ORDER BY s.createdAt DESC")
+            "GROUP BY b " +
+            "ORDER BY MAX(s.createdAt) DESC")
     List<BookJpaEntity> findSavedBooksByUserId(Long userId);
 
-    @Query("SELECT DISTINCT b FROM BookJpaEntity b " +
+    @Query("SELECT b FROM BookJpaEntity b " +
             "JOIN RoomJpaEntity r ON r.bookJpaEntity.bookId = b.bookId " +
             "JOIN RoomParticipantJpaEntity rp ON rp.roomJpaEntity.roomId = r.roomId " +
             "WHERE rp.userJpaEntity.userId = :userId " +
-            "AND r.status = 'ACTIVE' " +
-            "AND r.startDate <= CURRENT_TIMESTAMP " + // 진행 중인 방만 조회 (모집 중 / 만료된 방 x)
-            "ORDER BY r.roomPercentage DESC")  // 방의 진행률이 높은 순서로 정렬
+            "  AND r.status = 'ACTIVE' " +
+            "  AND r.startDate <= CURRENT_TIMESTAMP " + // 진행 중인 방만 조회 (모집 중 / 만료된 방 x)
+            "GROUP BY b " +
+            "ORDER BY MAX(r.roomPercentage) DESC") // 방의 진행률이 높은 순서로 정렬
     List<BookJpaEntity> findJoiningRoomsBooksByUserId(Long userId);
 
     boolean existsByIsbn(String isbn);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #252 

## 📝 작업 내용

개발서버에서 DISTINCT 문에 의해서 오류가 발생하고 있어, 고민을 해보니 정렬을 SavedBook과 RoomParticipant 필드로 하고 있는데 Book을 조회하면서 DISTINCT문을 사용하고 있기 때문에 정렬 조건이 상쇄되는 문제가 있어서 500 에러가 뜨는 걸로 추정하였습니다.

따라서, group by와 집계합수 max를 사용하는 방식으로 수정하였습니다.

## 📸 스크린샷

<img width="733" height="364" alt="스크린샷 2025-08-18 오후 6 09 23" src="https://github.com/user-attachments/assets/642252e3-c920-4b86-b2dc-d6e8f610e01d" />

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 저장한 도서 목록이 중복 없이 최신 저장 순으로 정확히 정렬되도록 개선했습니다.
  * 참여 중인 방의 도서 목록이 진행도가 높은 순으로 안정적으로 정렬되며, 중복 노출을 방지했습니다.
  * 활성화된 진행 중인 방 기준의 필터링/정렬 정확도를 향상해 목록 일관성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->