### PR TITLE
[Hotfix] 모집중인 방 상세보기 response 수정 및 최근검색어 삭제 스웨거 수정

### DIFF
--- a/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
@@ -84,7 +84,9 @@ public enum SwaggerResponseDescription {
             ROOM_PASSWORD_NOT_REQUIRED
     ))),
     ROOM_RECRUITING_DETAIL_VIEW(new LinkedHashSet<>(Set.of(
-            ROOM_NOT_FOUND
+            ROOM_NOT_FOUND,
+            BOOK_NOT_FOUND,
+            ROOM_RECRUITMENT_PERIOD_EXPIRED
     ))),
     ROOM_GET_HOME_JOINED_LIST(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND

--- a/src/main/java/konkuk/thip/common/util/DateUtil.java
+++ b/src/main/java/konkuk/thip/common/util/DateUtil.java
@@ -46,6 +46,29 @@ public class DateUtil {
         return minutes + "분 뒤";
     }
 
+    public static String RecruitingRoomFormatAfterTime(LocalDate date) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime dateTime = date.atStartOfDay();
+        Duration d = Duration.between(now, dateTime);
+
+        if (d.isNegative() || d.isZero()) {
+            return "??";
+        }
+
+        long days = d.toDays();
+        if (days > 0) {
+            return days + "일 남음";
+        }
+
+        long hours = d.toHours();
+        if (hours >= 1) {
+            return hours + "시간 남음";
+        }
+
+        return "마감 임박";
+    }
+
+
     public static String formatDate(LocalDate date) {
         return date.format(DATE_FORMATTER);
     }

--- a/src/main/java/konkuk/thip/recentSearch/adapter/in/web/RecentSearchCommandController.java
+++ b/src/main/java/konkuk/thip/recentSearch/adapter/in/web/RecentSearchCommandController.java
@@ -1,6 +1,7 @@
 package konkuk.thip.recentSearch.adapter.in.web;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import konkuk.thip.common.dto.BaseResponse;
 import konkuk.thip.common.security.annotation.UserId;
@@ -25,7 +26,7 @@ public class RecentSearchCommandController {
     @DeleteMapping("/recent-searches/{recentSearchId}")
     public BaseResponse<Void> deleteRecentSearch(
             @PathVariable(value = "recentSearchId") final Long recentSearchId,
-            @UserId final Long userId
+            @Parameter(hidden = true) @UserId final Long userId
     ) {
         return BaseResponse.ok(recentSearchDeleteUseCase.deleteRecentSearch(recentSearchId, userId));
     }

--- a/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomRecruitingDetailViewResponse.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/response/RoomRecruitingDetailViewResponse.java
@@ -31,7 +31,7 @@ public record RoomRecruitingDetailViewResponse(
     @Builder
     public record RecommendRoom(
             Long roomId,
-            String roomImageUrl,
+            String bookImageUrl,
             String roomName,
             int memberCount,
             int recruitCount,

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomQueryRepositoryImpl.java
@@ -178,8 +178,9 @@ public class RoomQueryRepositoryImpl implements RoomQueryRepository {
     public List<RoomRecruitingDetailViewResponse.RecommendRoom> findOtherRecruitingRoomsByCategoryOrderByStartDateAsc(Long roomId, String category, int count) {
         NumberExpression<Long> memberCountExpr = participant.roomParticipantId.count();
         List<Tuple> tuples = queryFactory
-                .select(room.roomId, room.title, memberCountExpr, room.recruitCount, room.startDate)
+                .select(room.roomId, room.title, memberCountExpr, room.recruitCount, room.startDate, book.imageUrl)
                 .from(room)
+                .join(room.bookJpaEntity, book)
                 .leftJoin(participant).on(participant.roomJpaEntity.eq(room))
                 .where(
                         room.categoryJpaEntity.value.eq(category)
@@ -195,7 +196,7 @@ public class RoomQueryRepositoryImpl implements RoomQueryRepository {
         return tuples.stream()
                 .map(t -> RoomRecruitingDetailViewResponse.RecommendRoom.builder()
                         .roomId(t.get(room.roomId))
-                        .roomImageUrl(null)     // roomImageUrl은 추후 구현
+                        .bookImageUrl(t.get(book.imageUrl))
                         .roomName(t.get(room.title))
                         .memberCount(t.get(memberCountExpr).intValue())
                         .recruitCount(t.get(room.recruitCount))

--- a/src/main/java/konkuk/thip/room/application/service/RoomShowRecruitingDetailViewService.java
+++ b/src/main/java/konkuk/thip/room/application/service/RoomShowRecruitingDetailViewService.java
@@ -33,6 +33,8 @@ public class RoomShowRecruitingDetailViewService implements RoomShowRecruitingDe
     public RoomRecruitingDetailViewResponse getRecruitingRoomDetailView(Long userId, Long roomId) {
         // 1. Room 조회, Book 조회
         Room room = roomCommandPort.getByIdOrThrow(roomId);
+        room.validateRoomRecruitExpired(); // 모집기간 지난 방 예외처리
+
         Book book = bookCommandPort.findById(room.getBookId());
 
         // 2. Room과 연관된 UserRoom 조회, RoomParticipants 일급 컬렉션 생성
@@ -62,7 +64,7 @@ public class RoomShowRecruitingDetailViewService implements RoomShowRecruitingDe
                 .isPublic(room.isPublic())
                 .progressStartDate(DateUtil.formatDate(room.getStartDate()))
                 .progressEndDate(DateUtil.formatDate(room.getEndDate()))
-                .recruitEndDate(DateUtil.formatAfterTime(room.getStartDate()))
+                .recruitEndDate(DateUtil.RecruitingRoomFormatAfterTime(room.getStartDate()))
                 .category(room.getCategory().getValue())
                 .categoryColor(roomQueryPort.findAliasColorOfCategory(room.getCategory()))      // TODO : 리펙토링 대상
                 .roomDescription(room.getDescription())

--- a/src/main/java/konkuk/thip/room/domain/Room.java
+++ b/src/main/java/konkuk/thip/room/domain/Room.java
@@ -135,7 +135,7 @@ public class Room extends BaseDomainEntity {
         if (isRecruitmentPeriodExpired()) {
             String message = String.format("모집기간(%s까지)이 만료된 방에는 참여할 수 없습니다.", deadline);
             throw new InvalidStateException(
-                    ErrorCode.ROOM_RECRUITMENT_PERIOD_EXPIRED, new IllegalArgumentException(message)
+                    ROOM_RECRUITMENT_PERIOD_EXPIRED, new IllegalArgumentException(message)
             );
         }
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #249 
> closes #261

## 📝 작업 내용

- 모집중인 방 상세보기 조회시 추천 모임을 보내줄때 방이미지가아닌 책이미지가 보내지도록 수정
- 모집마감된 방이 모집중인 방 상세보기 api 요청이 올때 예외처리 추가
- 모집중인 방 상세보기 한정 마감일을 보여주는 데이터 포맷을 ~ 남음 으로 수정 추가로 1시간미만은 마감 임박으로 보여주도록 수정
- 최근검색어 삭제 스웨거에 userId 히든값추가

## 📸 스크린샷

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
