### PR TITLE
[Feat] 방 나가기 api 개발

### DIFF
--- a/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
@@ -141,7 +141,7 @@ public enum ErrorCode implements ResponseCode {
     INVALID_MY_ROOM_TYPE(HttpStatus.BAD_REQUEST, 140009, "유저가 참가한 방 목록 검색 요청에 유효하지 않은 MY ROOM type 이 있습니다."),
     INVALID_MY_ROOM_CURSOR(HttpStatus.BAD_REQUEST, 140010, "유저가 참가한 방 목록 검색 요청에 유효하지 않은 cursor 가 있습니다"),
     ROOM_ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN, 140011, "방 접근 권한이 없습니다."),
-
+    ROOM_HOST_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, 140012, "방장은 방을 나갈 수 없습니다."),
     /**
      * 150000 : Category error
      */

--- a/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
@@ -117,6 +117,11 @@ public enum SwaggerResponseDescription {
             ROOM_ACCESS_FORBIDDEN,
             ROOM_POST_TYPE_NOT_MATCH
     ))),
+    ROOM_LEAVE(new LinkedHashSet<>(Set.of(
+            ROOM_NOT_FOUND,
+            ROOM_PARTICIPANT_NOT_FOUND,
+            ROOM_HOST_CANNOT_LEAVE
+    ))),
 
 
     // Record

--- a/src/main/java/konkuk/thip/room/adapter/in/web/RoomCommandController.java
+++ b/src/main/java/konkuk/thip/room/adapter/in/web/RoomCommandController.java
@@ -17,12 +17,10 @@ import konkuk.thip.room.adapter.in.web.response.RoomPostIsLikeResponse;
 import konkuk.thip.room.adapter.in.web.response.RoomRecruitCloseResponse;
 import konkuk.thip.room.application.port.in.RoomCreateUseCase;
 import konkuk.thip.room.application.port.in.RoomJoinUseCase;
+import konkuk.thip.room.application.port.in.RoomParticipantDeleteUseCase;
 import konkuk.thip.room.application.port.in.RoomRecruitCloseUseCase;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static konkuk.thip.common.swagger.SwaggerResponseDescription.*;
 
@@ -34,6 +32,7 @@ public class RoomCommandController {
     private final RoomCreateUseCase roomCreateUseCase;
     private final RoomJoinUseCase roomJoinUsecase;
     private final RoomRecruitCloseUseCase roomRecruitCloseUsecase;
+    private final RoomParticipantDeleteUseCase roomParticipantDeleteUseCase;
     private final PostLikeUseCase postLikeUseCase;
 
     /**
@@ -101,5 +100,17 @@ public class RoomCommandController {
             @Parameter(description = "좋아요 상태를 변경하려는 방 게시물 ID", example = "1")@PathVariable("postId") final Long postId,
             @Parameter(hidden = true) @UserId final Long userId) {
         return BaseResponse.ok(RoomPostIsLikeResponse.of(postLikeUseCase.changeLikeStatusPost(request.toCommand(userId, postId))));
+    }
+
+    @Operation(
+            summary = "방 나가기",
+            description = "방장을 제외한 방의 멤버들이 방에서 나갑니다."
+    )
+    @ExceptionDescription(ROOM_LEAVE)
+    @DeleteMapping("/rooms/{roomId}/leave")
+    public BaseResponse<Void> deleteRoomParticipant(
+            @Parameter(hidden = true) @UserId final Long userId,
+            @Parameter(description = "나갈 방의 ID", example = "1") @PathVariable final Long roomId) {
+        return BaseResponse.ok(roomParticipantDeleteUseCase.leaveRoom(userId, roomId));
     }
 }

--- a/src/main/java/konkuk/thip/room/adapter/out/jpa/RoomJpaEntity.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/jpa/RoomJpaEntity.java
@@ -84,4 +84,7 @@ public class RoomJpaEntity extends BaseJpaEntity {
     public void updateIsPublic(boolean isPublic) {
         this.isPublic = isPublic;
     }
+
+    @VisibleForTesting
+    public void updateRoomPercentage(double roomPercentage) {this.roomPercentage = roomPercentage;}
 }

--- a/src/main/java/konkuk/thip/room/application/port/in/RoomParticipantDeleteUseCase.java
+++ b/src/main/java/konkuk/thip/room/application/port/in/RoomParticipantDeleteUseCase.java
@@ -1,0 +1,5 @@
+package konkuk.thip.room.application.port.in;
+
+public interface RoomParticipantDeleteUseCase {
+    Void leaveRoom(Long userId, Long roomId);
+}

--- a/src/main/java/konkuk/thip/room/application/port/out/RoomParticipantCommandPort.java
+++ b/src/main/java/konkuk/thip/room/application/port/out/RoomParticipantCommandPort.java
@@ -1,11 +1,12 @@
 package konkuk.thip.room.application.port.out;
 
 import konkuk.thip.common.exception.EntityNotFoundException;
-import konkuk.thip.common.exception.code.ErrorCode;
 import konkuk.thip.room.domain.RoomParticipant;
 
 import java.util.List;
 import java.util.Optional;
+
+import static konkuk.thip.common.exception.code.ErrorCode.ROOM_PARTICIPANT_NOT_FOUND;
 
 public interface RoomParticipantCommandPort {
 
@@ -13,7 +14,7 @@ public interface RoomParticipantCommandPort {
 
     default RoomParticipant getByUserIdAndRoomIdOrThrow(Long userId, Long roomId) {
         return findByUserIdAndRoomIdOptional(userId, roomId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ROOM_PARTICIPANT_NOT_FOUND));
+                .orElseThrow(() -> new EntityNotFoundException(ROOM_PARTICIPANT_NOT_FOUND));
     }
 
     List<RoomParticipant> findAllByRoomId(Long roomId);

--- a/src/main/java/konkuk/thip/room/application/service/RoomParticipantDeleteService.java
+++ b/src/main/java/konkuk/thip/room/application/service/RoomParticipantDeleteService.java
@@ -32,7 +32,7 @@ public class RoomParticipantDeleteService implements RoomParticipantDeleteUseCas
         roomParticipant.validateRoomLeavable();
 
         // 3. 방 멤버수 감소 / 방 진행률 업데이트
-        roomProgressManager.removeUserProgressAndUpdateRoomProgress(roomParticipant.getId(), room.getId());
+        roomProgressManager.removeUserProgressAndUpdateRoomProgress(roomParticipant.getId(), room);
 
         // 4. 방나가기
         roomParticipantCommandPort.deleteByUserIdAndRoomId(userId, room.getId());

--- a/src/main/java/konkuk/thip/room/application/service/RoomParticipantDeleteService.java
+++ b/src/main/java/konkuk/thip/room/application/service/RoomParticipantDeleteService.java
@@ -1,0 +1,41 @@
+package konkuk.thip.room.application.service;
+
+import konkuk.thip.room.application.port.in.RoomParticipantDeleteUseCase;
+import konkuk.thip.room.application.port.out.RoomCommandPort;
+import konkuk.thip.room.application.port.out.RoomParticipantCommandPort;
+import konkuk.thip.room.domain.Room;
+import konkuk.thip.room.domain.RoomParticipant;
+import konkuk.thip.roompost.application.service.manager.RoomProgressManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RoomParticipantDeleteService implements RoomParticipantDeleteUseCase {
+
+    private final RoomCommandPort roomCommandPort;
+    private final RoomParticipantCommandPort roomParticipantCommandPort;
+
+    private final RoomProgressManager roomProgressManager;
+
+    @Override
+    @Transactional
+    public Void leaveRoom(Long userId, Long roomId) {
+
+        // 1. 방 조회 및 검증
+        Room room = roomCommandPort.getByIdOrThrow(roomId);
+
+        // 2. 사용자가 방 참여자인지 확인
+        RoomParticipant roomParticipant = roomParticipantCommandPort.getByUserIdAndRoomIdOrThrow(userId, room.getId());
+        // 2-1. 방 나가기 권한 검증
+        roomParticipant.validateRoomLeavable();
+
+        // 3. 방 멤버수 감소 / 방 진행률 업데이트
+        roomProgressManager.removeUserProgressAndUpdateRoomProgress(roomParticipant.getId(), room.getId());
+
+        // 4. 방나가기
+        roomParticipantCommandPort.deleteByUserIdAndRoomId(userId, room.getId());
+        return null;
+    }
+}

--- a/src/main/java/konkuk/thip/room/domain/RoomParticipant.java
+++ b/src/main/java/konkuk/thip/room/domain/RoomParticipant.java
@@ -1,9 +1,12 @@
 package konkuk.thip.room.domain;
 
 import konkuk.thip.common.entity.BaseDomainEntity;
+import konkuk.thip.common.exception.InvalidStateException;
 import konkuk.thip.room.adapter.out.jpa.RoomParticipantRole;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
+
+import static konkuk.thip.common.exception.code.ErrorCode.ROOM_HOST_CANNOT_LEAVE;
 
 @Getter
 @SuperBuilder
@@ -68,5 +71,10 @@ public class RoomParticipant extends BaseDomainEntity {
         return this.roomParticipantRole.equals(roomParticipantRole.getType());
     }
 
+    public void validateRoomLeavable() {
+        if (isHost()) {
+            throw new InvalidStateException(ROOM_HOST_CANNOT_LEAVE);
+        }
+    }
 
 }

--- a/src/main/java/konkuk/thip/roompost/application/service/RecordCreateService.java
+++ b/src/main/java/konkuk/thip/roompost/application/service/RecordCreateService.java
@@ -61,7 +61,7 @@ public class RecordCreateService implements RecordCreateUseCase {
         Long newRecordId = recordCommandPort.saveRecord(record);
 
         // 5. RoomParticipant, Room progress 정보 update
-        roomProgressManager.updateUserAndRoomProgress(record.getCreatorId(), record.getRoomId(), record.getPage());
+        roomProgressManager.updateUserAndRoomProgress(roomParticipant, room, book, record.getPage());
 
         return RecordCreateResult.of(newRecordId, command.roomId());
     }

--- a/src/main/java/konkuk/thip/roompost/application/service/RecordDeleteService.java
+++ b/src/main/java/konkuk/thip/roompost/application/service/RecordDeleteService.java
@@ -5,6 +5,7 @@ import konkuk.thip.post.application.port.out.PostLikeCommandPort;
 import konkuk.thip.roompost.application.port.in.RecordDeleteUseCase;
 import konkuk.thip.roompost.application.port.in.dto.record.RecordDeleteCommand;
 import konkuk.thip.roompost.application.port.out.RecordCommandPort;
+import konkuk.thip.roompost.application.service.manager.RoomProgressManager;
 import konkuk.thip.roompost.domain.Record;
 import konkuk.thip.room.application.service.validator.RoomParticipantValidator;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ public class RecordDeleteService implements RecordDeleteUseCase {
     private final PostLikeCommandPort postLikeCommandPort;
 
     private final RoomParticipantValidator roomParticipantValidator;
+    private final RoomProgressManager roomProgressManager;
 
     @Override
     @Transactional
@@ -41,6 +43,7 @@ public class RecordDeleteService implements RecordDeleteUseCase {
         // 3-3. 기록 삭제
         recordCommandPort.delete(record);
 
+        //TODO// 4. 유저 방 진행도 업데이트
         return command.roomId();
     }
 }

--- a/src/main/java/konkuk/thip/roompost/application/service/VoteCreateService.java
+++ b/src/main/java/konkuk/thip/roompost/application/service/VoteCreateService.java
@@ -6,6 +6,7 @@ import konkuk.thip.room.application.port.out.RoomCommandPort;
 import konkuk.thip.room.application.port.out.RoomParticipantCommandPort;
 import konkuk.thip.room.application.service.validator.RoomParticipantValidator;
 import konkuk.thip.room.domain.Room;
+import konkuk.thip.room.domain.RoomParticipant;
 import konkuk.thip.roompost.application.service.manager.RoomProgressManager;
 import konkuk.thip.roompost.application.port.in.VoteCreateUseCase;
 import konkuk.thip.roompost.application.port.in.dto.vote.VoteCreateCommand;
@@ -47,6 +48,7 @@ public class VoteCreateService implements VoteCreateUseCase {
                 command.roomId()
         );
 
+        RoomParticipant roomParticipant = roomParticipantCommandPort.getByUserIdAndRoomIdOrThrow(command.userId(), command.roomId());
         Room room = roomCommandPort.getByIdOrThrow(vote.getRoomId());
         Book book = bookCommandPort.findById(room.getBookId());
         validateVote(vote, book);
@@ -64,7 +66,7 @@ public class VoteCreateService implements VoteCreateUseCase {
         voteCommandPort.saveAllVoteItems(voteItems);
 
         // 4. RoomParticipant, Room progress 정보 update
-        roomProgressManager.updateUserAndRoomProgress(vote.getCreatorId(), vote.getRoomId(), vote.getPage());
+        roomProgressManager.updateUserAndRoomProgress(roomParticipant, room, book, vote.getPage());
 
         return VoteCreateResult.of(savedVoteId, command.roomId());
     }

--- a/src/main/java/konkuk/thip/roompost/application/service/VoteDeleteService.java
+++ b/src/main/java/konkuk/thip/roompost/application/service/VoteDeleteService.java
@@ -41,6 +41,7 @@ public class VoteDeleteService implements VoteDeleteUseCase {
         // 3-3. 투표 삭제
         voteCommandPort.delete(vote);
 
+        //TODO// 4. 유저 방 진행도 업데이트
         return command.roomId();
     }
 }

--- a/src/main/java/konkuk/thip/roompost/application/service/manager/RoomProgressManager.java
+++ b/src/main/java/konkuk/thip/roompost/application/service/manager/RoomProgressManager.java
@@ -41,4 +41,23 @@ public class RoomProgressManager {
         roomCommandPort.update(room);
         roomParticipantCommandPort.update(roomParticipant);
     }
+
+    public void removeUserProgressAndUpdateRoomProgress(Long removeRoomParticipantId, Long roomId) {
+
+        Room room = roomCommandPort.getByIdOrThrow(roomId);
+
+        // 나간 유저를 제외한 방 평균 진행률 update
+        List<RoomParticipant> remainingParticipants = roomParticipantCommandPort.findAllByRoomId(roomId);
+        double total = remainingParticipants.stream()
+                .filter(p -> !p.getId().equals(removeRoomParticipantId)) // 나간 유저 제외
+                .mapToDouble(RoomParticipant::getUserPercentage)
+                .sum();
+        room.updateRoomPercentage(total / (remainingParticipants.size() - 1));
+
+        // 방 멤버 수 감소
+        room.decreaseMemberCount();
+        // 영속화
+        roomCommandPort.update(room);
+    }
+
 }

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomParticipantDeleteApiTest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomParticipantDeleteApiTest.java
@@ -1,0 +1,172 @@
+package konkuk.thip.room.adapter.in.web;
+
+import jakarta.persistence.EntityManager;
+import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.adapter.out.persistence.repository.BookJpaRepository;
+import konkuk.thip.common.exception.code.ErrorCode;
+import konkuk.thip.common.util.TestEntityFactory;
+import konkuk.thip.room.adapter.out.jpa.CategoryJpaEntity;
+import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
+import konkuk.thip.room.adapter.out.jpa.RoomParticipantJpaEntity;
+import konkuk.thip.room.adapter.out.jpa.RoomParticipantRole;
+import konkuk.thip.room.adapter.out.persistence.repository.RoomJpaRepository;
+import konkuk.thip.room.adapter.out.persistence.repository.category.CategoryJpaRepository;
+import konkuk.thip.room.adapter.out.persistence.repository.roomparticipant.RoomParticipantJpaRepository;
+import konkuk.thip.user.adapter.out.jpa.AliasJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.jpa.UserRole;
+import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.repository.alias.AliasJpaRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("[통합] 방 나가기(멤버) API 통합 테스트")
+class RoomParticipantDeleteApiTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private EntityManager em;
+    @Autowired private RoomJpaRepository roomJpaRepository;
+    @Autowired private RoomParticipantJpaRepository roomParticipantJpaRepository;
+    @Autowired private BookJpaRepository bookJpaRepository;
+    @Autowired private CategoryJpaRepository categoryJpaRepository;
+    @Autowired private UserJpaRepository userJpaRepository;
+    @Autowired private AliasJpaRepository aliasJpaRepository;
+
+    private RoomJpaEntity room;
+    private UserJpaEntity host;
+    private UserJpaEntity participant;
+    private RoomParticipantJpaEntity hostParticipation;
+    private RoomParticipantJpaEntity memberParticipation;
+
+    private void setUpWithOnlyHost() {
+        AliasJpaEntity alias = aliasJpaRepository.save(TestEntityFactory.createLiteratureAlias());
+        createUsers(alias);
+
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBook());
+        CategoryJpaEntity category = categoryJpaRepository.save(TestEntityFactory.createLiteratureCategory(alias));
+        createRoom(book, category,1); // 방장만 포함
+        roomParticipantJpaRepository.save(TestEntityFactory.createRoomParticipant(room, host, RoomParticipantRole.HOST, 0.0));
+    }
+
+    private void setUpWithParticipant() {
+        AliasJpaEntity alias = aliasJpaRepository.save(TestEntityFactory.createLiteratureAlias());
+        createUsers(alias);
+
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBook());
+        CategoryJpaEntity category = categoryJpaRepository.save(TestEntityFactory.createLiteratureCategory(alias));
+        createRoom(book, category,2); // 방장과 참여자 포함
+        hostParticipation = roomParticipantJpaRepository.save(TestEntityFactory.createRoomParticipant(room, host, RoomParticipantRole.HOST, 50.0));
+        memberParticipation = roomParticipantJpaRepository.save(TestEntityFactory.createRoomParticipant(room, participant, RoomParticipantRole.MEMBER, 30.0));
+    }
+
+    private void createRoom(BookJpaEntity book, CategoryJpaEntity category, int memberCount) {
+        room = roomJpaRepository.save(RoomJpaEntity.builder()
+                .title("방이름")
+                .description("설명")
+                .isPublic(true)
+                .startDate(LocalDate.now().plusDays(1))
+                .endDate(LocalDate.now().plusDays(30))
+                .recruitCount(3)
+                .bookJpaEntity(book)
+                .categoryJpaEntity(category)
+                .memberCount(memberCount) // 방장과 참여자 포함
+                .build());
+    }
+
+    private void createUsers(AliasJpaEntity alias) {
+        host = userJpaRepository.save(UserJpaEntity.builder()
+                .oauth2Id("kakao_432708231")
+                .nickname("user")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
+                .role(UserRole.USER)
+                .aliasForUserJpaEntity(alias)
+                .build());
+
+        participant = userJpaRepository.save(UserJpaEntity.builder()
+                .oauth2Id("kakao_12345678")
+                .nickname("user123")
+                .nicknameUpdatedAt(LocalDate.now().minusMonths(7))
+                .role(UserRole.USER)
+                .aliasForUserJpaEntity(alias)
+                .build());
+    }
+
+    private void updateRoomPercentage() {
+        hostParticipation.updateCurrentPage(50);
+        hostParticipation.updateUserPercentage(50.0); // 방장의 진행도 50
+        roomParticipantJpaRepository.save(hostParticipation);
+
+        memberParticipation.updateCurrentPage(30);
+        memberParticipation.updateUserPercentage(30.0); // 참여자 진행도 30
+        roomParticipantJpaRepository.save(memberParticipation);
+
+        room.updateRoomPercentage(40); // 방참여자들의 진행도 평균 40
+        roomJpaRepository.save(room);
+    }
+
+    @Test
+    @DisplayName("참여자가 정상적으로 방에서 나가면 유저의 방 참여 관계 삭제, 방 인원수 감소, 방 평균 진행도 업데이트 된다.")
+    void leaveRoom_success() throws Exception {
+        setUpWithParticipant();
+        updateRoomPercentage();
+
+        // 참여자(member)가 방에서 나가기 요청
+        mockMvc.perform(delete("/rooms/" + room.getRoomId() + "/leave")
+                        .requestAttr("userId", participant.getUserId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        // 방에서 참여자 정보가 사라졌는지 확인
+        boolean exists = roomParticipantJpaRepository.existsByUserIdAndRoomId(participant.getUserId(), room.getRoomId());
+        assertThat(exists).isFalse();
+
+        // 인원수 감소 확인
+        RoomJpaEntity updateRoom = roomJpaRepository.findById(room.getRoomId()).orElseThrow();
+        assertThat(updateRoom.getMemberCount()).isEqualTo(1); // 방장만 남음
+        // 평균 진행도 확인: 방에 남은 사람은 host만 → host의 진행도(50)와 방의 진행도가 같아야 함
+        assertThat(updateRoom.getRoomPercentage()).isEqualTo(50.0);
+    }
+
+    @Test
+    @DisplayName("참여하지 않은 사용자가 방에서 나가기를 시도하면 실패한다.")
+    void leaveRoom_notParticipated() throws Exception {
+        setUpWithOnlyHost(); // 참가자 없이 방장만 있는 방
+
+        // 참여하지 않은 사용자가 나가기 요청
+        mockMvc.perform(delete("/rooms/" + room.getRoomId() + "/leave")
+                        .requestAttr("userId", participant.getUserId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ErrorCode.ROOM_PARTICIPANT_NOT_FOUND.getCode()));
+    }
+
+    @Test
+    @DisplayName("호스트(방장)는 방을 나갈 수 없고 예외가 발생한다.")
+    void leaveRoom_hostCannotLeave() throws Exception {
+        setUpWithOnlyHost();
+
+        mockMvc.perform(delete("/rooms/" + room.getRoomId() + "/leave")
+                        .requestAttr("userId", host.getUserId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.ROOM_HOST_CANNOT_LEAVE.getCode()));
+    }
+}

--- a/src/test/java/konkuk/thip/room/domain/RoomParticipantTest.java
+++ b/src/test/java/konkuk/thip/room/domain/RoomParticipantTest.java
@@ -1,9 +1,12 @@
 package konkuk.thip.room.domain;
 
+import konkuk.thip.common.exception.InvalidStateException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static konkuk.thip.common.exception.code.ErrorCode.ROOM_HOST_CANNOT_LEAVE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("[단위] RoomParticipant 도메인 테스트")
 class RoomParticipantTest {
@@ -81,4 +84,27 @@ class RoomParticipantTest {
         double ratio = (double) roomParticipant.getCurrentPage() / totalPageCount;
         assertThat(roomParticipant.getUserPercentage()).isEqualTo(ratio * 100);
     }
+
+    @Test
+    @DisplayName("validateRoomLeavable: 방의 HOST가 방을 나가려고 하면 InvalidStateException이 발생한다.")
+    void host_cannot_leave_room_test() {
+        // given: HOST 참여자 생성
+        RoomParticipant host = RoomParticipant.hostWithoutId(1L,1L);
+
+        // when & then
+        InvalidStateException ex = assertThrows(InvalidStateException.class,
+                host::validateRoomLeavable);
+        assertEquals(ROOM_HOST_CANNOT_LEAVE, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("MEMBER는 방을 나갈 수 있다.")
+    void member_can_leave_room_test() {
+        // given: MEMBER 참여자 생성
+        RoomParticipant member = RoomParticipant.memberWithoutId(1L,1L);
+
+        // when & then
+        assertDoesNotThrow(member::validateRoomLeavable);
+    }
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #265

## 📝 작업 내용

- 방 나가기 api 흐름은 다음과같습니다.
- 방 검증 및 조회 -> 사용자가 방 참여자인지 검증 및 조회 -> 방 나갈수있는지 권한 검즘(호스트 불가) -> 방 멤버수 감소, 방 진행률 업데이트 -> 방 나가기

## 📸 스크린샷
<img width="414" height="324" alt="image" src="https://github.com/user-attachments/assets/268f0c06-2877-4bfb-9e62-03f5055886ae" />


## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 방 참여자가 방 나가기 API 추가(DELETE /rooms/{roomId}/leave).
  - 방 나가기 시 구성원 수와 평균 진행도 자동 갱신.
  - 방장에 대한 나가기 금지 규칙 및 전용 오류 코드/메시지 추가.

- 문서
  - Swagger 응답 스펙에 방 나가기 케이스(방 없음, 참여자 없음, 방장 나가기 불가 등) 추가.

- 테스트
  - 방 나가기 관련 통합 및 단위 테스트 추가로 동작 검증 보강.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->