### PR TITLE
[hotfix] 사용자 팔로워 조회시 나인지 여부 반환 플래그 반환

### DIFF
--- a/src/main/java/konkuk/thip/user/adapter/in/web/response/UserFollowersResponse.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/response/UserFollowersResponse.java
@@ -18,7 +18,8 @@ public record UserFollowersResponse(
             String profileImageUrl,
             String aliasName,
             String aliasColor,
-            Integer followerCount
+            Integer followerCount,
+            boolean isMyself
     ){
 
     }

--- a/src/main/java/konkuk/thip/user/application/mapper/FollowQueryMapper.java
+++ b/src/main/java/konkuk/thip/user/application/mapper/FollowQueryMapper.java
@@ -3,13 +3,22 @@ package konkuk.thip.user.application.mapper;
 import konkuk.thip.user.adapter.in.web.response.UserFollowersResponse;
 import konkuk.thip.user.adapter.in.web.response.UserFollowingResponse;
 import konkuk.thip.user.application.port.out.dto.UserQueryDto;
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 
 @Mapper(componentModel = "spring")
 public interface FollowQueryMapper {
 
-    UserFollowersResponse.FollowerDto toFollowerDto(UserQueryDto dto);
+    // UserQueryDto의 userId와 Context로 넘어온 userId를 비교해서 true,false를 isMyself 필드에 주입
+    @Mapping(target = "isMyself", source = "dto.userId", qualifiedByName = "isMyself")
+    UserFollowersResponse.FollowerDto toFollowerDto(UserQueryDto dto, @Context Long loginUserId);
+
+    @Named("isMyself")
+    default boolean isMyself(Long userId, @Context Long loginUserId) {
+        return userId != null && userId.equals(loginUserId);
+    }
 
     @Mapping(target = "isFollowing", constant = "true")
     UserFollowingResponse.FollowingDto toFollowingDto(UserQueryDto dto);

--- a/src/main/java/konkuk/thip/user/application/service/following/UserGetFollowService.java
+++ b/src/main/java/konkuk/thip/user/application/service/following/UserGetFollowService.java
@@ -36,7 +36,7 @@ public class UserGetFollowService implements UserGetFollowUsecase {
         );
 
         var followers = result.contents().stream()
-                .map(followQueryMapper::toFollowerDto)
+                .map(dto -> followQueryMapper.toFollowerDto(dto, userId))
                 .toList();
 
         return UserFollowersResponse.builder()

--- a/src/test/java/konkuk/thip/feed/adapter/in/web/FeedRelatedWithBookApiTest.java
+++ b/src/test/java/konkuk/thip/feed/adapter/in/web/FeedRelatedWithBookApiTest.java
@@ -263,7 +263,7 @@ class FeedRelatedWithBookApiTest {
     }
 
     @Test
-    @DisplayName("비공개 피드 제외 및 자기 자신 피드 제외 검증")
+    @DisplayName("비공개 피드 제외 검증")
     void getFeedsByBook_visibility_and_self_filter() throws Exception {
         // given
         AliasJpaEntity alias = aliasJpaRepository.save(TestEntityFactory.createLiteratureAlias());
@@ -304,7 +304,7 @@ class FeedRelatedWithBookApiTest {
         JsonNode feeds = root.path("data").path("feeds");
 
         // 자기 자신 글 제외 비공개 제외로 인해 only othersPublic 만 남아야 함
-        assertThat(feeds.size()).isEqualTo(1);
+        assertThat(feeds.size()).isEqualTo(2);
         assertThat(feeds.get(0).path("creatorId").asLong()).isEqualTo(other.getUserId());
         assertThat(feeds.get(0).path("isWriter").asBoolean()).isFalse();
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #268 

## 📝 작업 내용

@heeeeyong 님의 요청에 따라 사용자 팔로워 조회시에 로그인한 사용자인지 아닌지를 구분하는 isMyself 플래그를 추가합니다.

추가적으로 앞에서 수정했던 특정 책으로 작성된 피드 조회에서 내 피드도 조회되도록 수정하였는데 이에 따른 통합 테스트도 수정하였습니다.

## 📸 스크린샷

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
