### PR TITLE
[test] 테스트 커버리지 측정 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.0'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'jacoco'
 }
 
 group = 'konkuk.thip'
@@ -96,3 +97,5 @@ clean.doLast {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+apply from: "$rootDir/jacoco.gradle"

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -1,0 +1,79 @@
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+    finalizedBy tasks.jacocoTestReport
+}
+
+tasks.named('jacocoTestReport', JacocoReport) {
+    dependsOn(tasks.test)
+
+    def mainClasses = files(sourceSets.main.output).asFileTree.matching {
+        exclude(
+                "**/generated/**",
+                "**/build/**",
+                "**/*Application*",
+                "**/*Config*",
+                "**/*Dto*",
+                "**/*Request*",
+                "**/*Response*",
+                "**/generated/querydsl/**",
+                "**/Q*.*"
+        )
+    }
+
+    additionalSourceDirs.from files(sourceSets.main.allSource.srcDirs)
+    sourceDirectories.from files(sourceSets.main.allSource.srcDirs)
+    classDirectories.setFrom(mainClasses)
+    executionData.from fileTree(project.rootDir) {
+        include "**/build/jacoco/*.exec"
+    }
+
+    reports {
+        html.required.set(true)
+        xml.required.set(true)
+        csv.required.set(false)
+    }
+}
+
+tasks.named('jacocoTestCoverageVerification', JacocoCoverageVerification) {
+    dependsOn(tasks.test)
+
+    classDirectories.setFrom(
+            files(sourceSets.main.output).asFileTree.matching {
+                exclude(
+                        "**/generated/**",
+                        "**/build/**",
+                        "**/*Application*",
+                        "**/*Config*",
+                        "**/*Dto*",
+                        "**/*Request*",
+                        "**/*Response*",
+                        "**/generated/querydsl/**",
+                        "**/Q*.*"
+                )
+            }
+    )
+
+    violationRules {
+        rule {
+            element = 'CLASS'
+            limit {
+                counter = 'INSTRUCTION'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.50
+            }
+        }
+    }
+}
+
+tasks.named('check') {
+    dependsOn tasks.named('jacocoTestCoverageVerification')
+}

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -63,12 +63,12 @@ tasks.named('jacocoTestCoverageVerification', JacocoCoverageVerification) {
             limit {
                 counter = 'INSTRUCTION'
                 value = 'COVEREDRATIO'
-                minimum = 0.80
+                minimum = 0.00
             }
             limit {
                 counter = 'BRANCH'
                 value = 'COVEREDRATIO'
-                minimum = 0.50
+                minimum = 0.00
             }
         }
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #272 

## 📝 작업 내용

jacoco를 이용해 테스트 커버리지를 측정합니다.


1. `./gradlew clean test jacocoTestReport` 커맨드 입력
2. [http://localhost:63342/THIP-Server/build/reports/jacoco/test/html/index.html](http://localhost:63342/THIP-Server/build/reports/jacoco/test/html/index.html)로 접속

## 📸 스크린샷

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 테스트
  - JaCoCo 도구(버전 0.8.12) 도입 및 테스트 실행 후 HTML/XML 보고서 자동 생성
  - 테스트 실행을 JUnit Platform으로 일원화
  - 커버리지 검증 규칙(INSTRUCTION, BRANCH)에 대한 검사 추가(최소 허용값: 0.00)

- 작업(Chores)
  - 커버리지 보고 및 검증이 기본 빌드 검사 흐름에 통합됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->