### PR TITLE
[feat] 오늘의 한마디 삭제 api 개발

### DIFF
--- a/src/main/java/konkuk/thip/TestTokenController.java
+++ b/src/main/java/konkuk/thip/TestTokenController.java
@@ -1,0 +1,19 @@
+package konkuk.thip;
+
+import konkuk.thip.common.security.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TestTokenController {
+
+    private final JwtUtil jwtUtil;
+
+    @GetMapping("/api/test/token/access")
+    public String generateAccessToken(@RequestParam Long userId) {
+        return jwtUtil.createAccessToken(userId);
+    }
+}

--- a/src/main/java/konkuk/thip/TestTokenController.java
+++ b/src/main/java/konkuk/thip/TestTokenController.java
@@ -2,12 +2,14 @@ package konkuk.thip;
 
 import konkuk.thip.common.security.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "thip.test-api.enabled", havingValue = "true")
 public class TestTokenController {
 
     private final JwtUtil jwtUtil;

--- a/src/main/java/konkuk/thip/common/entity/BaseJpaEntity.java
+++ b/src/main/java/konkuk/thip/common/entity/BaseJpaEntity.java
@@ -35,4 +35,6 @@ public abstract class BaseJpaEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     protected StatusType status = StatusType.ACTIVE;
+
+    // TODO : status를 private로 변경, status를 변경하는 protected 메서드 추가
 }

--- a/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
@@ -207,7 +207,7 @@ public enum ErrorCode implements ResponseCode {
      */
     ATTENDANCE_CHECK_WRITE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, 195000, "오늘의 한마디 작성 가능 횟수를 초과하였습니다."),
     ATTENDANCE_CHECK_NOT_FOUND(HttpStatus.NOT_FOUND, 195001, "존재하지 않는 ATTENDANCE CHECK 입니다."),
-    ATTENDANCE_CHECK_CAN_NOT_DELETE(HttpStatus.BAD_REQUEST, 195002, "오늘의 한마디는 본인만 삭제할 수 있습니다."),
+    ATTENDANCE_CHECK_CAN_NOT_DELETE(HttpStatus.FORBIDDEN, 195002, "오늘의 한마디는 본인만 삭제할 수 있습니다."),
 
 
     ;

--- a/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
@@ -207,6 +207,8 @@ public enum ErrorCode implements ResponseCode {
      */
     ATTENDANCE_CHECK_WRITE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, 195000, "오늘의 한마디 작성 가능 횟수를 초과하였습니다."),
     ATTENDANCE_CHECK_NOT_FOUND(HttpStatus.NOT_FOUND, 195001, "존재하지 않는 ATTENDANCE CHECK 입니다."),
+    ATTENDANCE_CHECK_CAN_NOT_DELETE(HttpStatus.BAD_REQUEST, 195002, "오늘의 한마디는 본인만 삭제할 수 있습니다."),
+
 
     ;
 

--- a/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
@@ -311,6 +311,12 @@ public enum SwaggerResponseDescription {
             ROOM_ACCESS_FORBIDDEN
     ))),
 
+    ATTENDANCE_CHECK_DELETE(new LinkedHashSet<>(Set.of(
+            ROOM_ACCESS_FORBIDDEN,
+            ATTENDANCE_CHECK_NOT_FOUND,
+            ATTENDANCE_CHECK_CAN_NOT_DELETE
+    ))),
+
   ;
     private final Set<ErrorCode> errorCodeList;
     SwaggerResponseDescription(Set<ErrorCode> errorCodeList) {

--- a/src/main/java/konkuk/thip/config/SecurityConfig.java
+++ b/src/main/java/konkuk/thip/config/SecurityConfig.java
@@ -54,6 +54,8 @@ public class SecurityConfig {
             "/login/oauth2/code/**", "/actuator/health",
             "/auth/users", "/auth/token",
 
+            "/api/test/**",  // for test
+
             "/auth/exchange-temp-token", "/auth/set-cookie", // deprecated
     };
 

--- a/src/main/java/konkuk/thip/post/adapter/out/jpa/PostJpaEntity.java
+++ b/src/main/java/konkuk/thip/post/adapter/out/jpa/PostJpaEntity.java
@@ -58,6 +58,7 @@ public abstract class PostJpaEntity extends BaseJpaEntity {
         this.userJpaEntity = userJpaEntity;
     }
 
+    // TODO : Base Entity 의 status를 private 로 변경 & 상태변경을 위한 protected method 추가 후 수정
     public void softDelete() {
         if(this.status.equals(INACTIVE)){
             throw new InvalidStateException(POST_ALREADY_DELETED);

--- a/src/main/java/konkuk/thip/roompost/adapter/in/web/RoomPostCommandController.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/in/web/RoomPostCommandController.java
@@ -66,6 +66,23 @@ public class RoomPostCommandController {
         return BaseResponse.ok(RecordDeleteResponse.of(recordDeleteUseCase.deleteRecord(new RecordDeleteCommand(roomId, recordId, userId))));
     }
 
+    @Operation(
+            summary = "기록 수정",
+            description = "사용자가 방 기록을 수정합니다. (기록 내용만 수정 가능)"
+    )
+    @PatchMapping("/rooms/{roomId}/records/{recordId}")
+    @ExceptionDescription(RECORD_UPDATE)
+    public BaseResponse<RecordUpdateResponse> updateRecord(
+            @Parameter(hidden = true) @UserId Long userId,
+            @Parameter(description = "수정할 방 ID", example = "1") @PathVariable Long roomId,
+            @Parameter(description = "수정할 기록 ID", example = "1") @PathVariable Long recordId,
+            @RequestBody @Valid final RecordUpdateRequest request
+    ) {
+        return BaseResponse.ok(RecordUpdateResponse.of(
+                roomPostUpdateUseCase.updateRecord(request.toCommand(userId, roomId, recordId))
+        ));
+    }
+
     /**
      * 투표 관련
      */
@@ -113,6 +130,23 @@ public class RoomPostCommandController {
         return BaseResponse.ok(VoteDeleteResponse.of(voteDeleteUseCase.deleteVote(new VoteDeleteCommand(roomId, voteId, userId))));
     }
 
+    @Operation(
+            summary = "투표 수정",
+            description = "사용자가 방 투표를 수정합니다. (투표 내용만 수정 가능)"
+    )
+    @PatchMapping("/rooms/{roomId}/votes/{voteId}")
+    @ExceptionDescription(VOTE_UPDATE)
+    public BaseResponse<VoteUpdateResponse> updateVote(
+            @Parameter(hidden = true) @UserId Long userId,
+            @Parameter(description = "수정할 방 ID", example = "1") @PathVariable Long roomId,
+            @Parameter(description = "수정할 투표 ID", example = "1") @PathVariable Long voteId,
+            @RequestBody @Valid final VoteUpdateRequest request
+    ) {
+        return BaseResponse.ok(VoteUpdateResponse.of(
+                roomPostUpdateUseCase.updateVote(request.toCommand(userId, roomId, voteId))
+        ));
+    }
+
     /**
      * 오늘의 한마디 관련
      */
@@ -128,40 +162,6 @@ public class RoomPostCommandController {
             @Parameter(hidden = true) @UserId final Long userId) {
         return BaseResponse.ok(AttendanceCheckCreateResponse.of(
                 attendanceCheckCreateUseCase.create(request.toCommand(userId, roomId))
-        ));
-    }
-
-    @Operation(
-            summary = "기록 수정",
-            description = "사용자가 방 기록을 수정합니다. (기록 내용만 수정 가능)"
-    )
-    @PatchMapping("/rooms/{roomId}/records/{recordId}")
-    @ExceptionDescription(RECORD_UPDATE)
-    public BaseResponse<RecordUpdateResponse> updateRecord(
-            @Parameter(hidden = true) @UserId Long userId,
-            @Parameter(description = "수정할 방 ID", example = "1") @PathVariable Long roomId,
-            @Parameter(description = "수정할 기록 ID", example = "1") @PathVariable Long recordId,
-            @RequestBody @Valid final RecordUpdateRequest request
-    ) {
-        return BaseResponse.ok(RecordUpdateResponse.of(
-                roomPostUpdateUseCase.updateRecord(request.toCommand(userId, roomId, recordId))
-        ));
-    }
-
-    @Operation(
-            summary = "투표 수정",
-            description = "사용자가 방 투표를 수정합니다. (투표 내용만 수정 가능)"
-    )
-    @PatchMapping("/rooms/{roomId}/votes/{voteId}")
-    @ExceptionDescription(VOTE_UPDATE)
-    public BaseResponse<VoteUpdateResponse> updateVote(
-            @Parameter(hidden = true) @UserId Long userId,
-            @Parameter(description = "수정할 방 ID", example = "1") @PathVariable Long roomId,
-            @Parameter(description = "수정할 투표 ID", example = "1") @PathVariable Long voteId,
-            @RequestBody @Valid final VoteUpdateRequest request
-    ) {
-        return BaseResponse.ok(VoteUpdateResponse.of(
-                roomPostUpdateUseCase.updateVote(request.toCommand(userId, roomId, voteId))
         ));
     }
 

--- a/src/main/java/konkuk/thip/roompost/adapter/in/web/RoomPostCommandController.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/in/web/RoomPostCommandController.java
@@ -35,6 +35,7 @@ public class RoomPostCommandController {
     private final VoteUseCase voteUseCase;
 
     private final AttendanceCheckCreateUseCase attendanceCheckCreateUseCase;
+    private final AttendanceCheckDeleteUseCase attendanceCheckDeleteUseCase;
 
     /**
      * 기록 관련
@@ -117,7 +118,7 @@ public class RoomPostCommandController {
     }
 
     /**
-     * 오늘의 한마디 작성
+     * 오늘의 한마디 관련
      */
     @Operation(
             summary = "오늘의 한마디 작성",
@@ -125,12 +126,27 @@ public class RoomPostCommandController {
     )
     @ExceptionDescription(ATTENDANCE_CHECK_CREATE)
     @PostMapping("/rooms/{roomId}/daily-greeting")
-    public BaseResponse<AttendanceCheckCreateResponse> createFeed(
+    public BaseResponse<AttendanceCheckCreateResponse> createAttendanceCheck(
             @RequestBody @Valid final AttendanceCheckCreateRequest request,
             @Parameter(description = "오늘의 한마디를 작성할 방 id값") @PathVariable("roomId") final Long roomId,
             @Parameter(hidden = true) @UserId final Long userId) {
         return BaseResponse.ok(AttendanceCheckCreateResponse.of(
                 attendanceCheckCreateUseCase.create(request.toCommand(userId, roomId))
+        ));
+    }
+
+    @Operation(
+            summary = "오늘의 한마디 삭제",
+            description = "오늘의 한마디 작성자가 본인이 작성한 오늘의 한마디를 삭제합니다."
+    )
+    @ExceptionDescription(ATTENDANCE_CHECK_DELETE)
+    @DeleteMapping("/rooms/{roomId}/daily-greeting/{attendanceCheckId}")
+    public BaseResponse<AttendanceCheckDeleteResponse> deleteAttendanceCheck(
+            @Parameter(description = "오늘의 한마디를 삭제할 방 id값") @PathVariable("roomId") final Long roomId,
+            @Parameter(description = "삭제할 오늘의 한마디 id값") @PathVariable("attendanceCheckId") final Long attendanceCheckId,
+            @Parameter(hidden = true) @UserId final Long userId) {
+        return BaseResponse.ok(AttendanceCheckDeleteResponse.of(
+                attendanceCheckDeleteUseCase.delete(userId, roomId, attendanceCheckId)
         ));
     }
 }

--- a/src/main/java/konkuk/thip/roompost/adapter/in/web/RoomPostCommandController.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/in/web/RoomPostCommandController.java
@@ -121,7 +121,7 @@ public class RoomPostCommandController {
             summary = "투표 삭제",
             description = "사용자가 투표를 삭제합니다."
     )
-    @ExceptionDescription(RECORD_DELETE)
+    @ExceptionDescription(VOTE_DELETE)
     @DeleteMapping("/rooms/{roomId}/vote/{voteId}")
     public BaseResponse<VoteDeleteResponse> deleteVote(
             @Parameter(description = "삭제하려는 투표 ID", example = "1") @PathVariable("voteId") final Long voteId,

--- a/src/main/java/konkuk/thip/roompost/adapter/in/web/response/AttendanceCheckDeleteResponse.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/in/web/response/AttendanceCheckDeleteResponse.java
@@ -1,0 +1,9 @@
+package konkuk.thip.roompost.adapter.in.web.response;
+
+public record AttendanceCheckDeleteResponse(
+        Long roomId
+) {
+    public static AttendanceCheckDeleteResponse of(Long roomId) {
+        return new AttendanceCheckDeleteResponse(roomId);
+    }
+}

--- a/src/main/java/konkuk/thip/roompost/adapter/out/jpa/AttendanceCheckJpaEntity.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/jpa/AttendanceCheckJpaEntity.java
@@ -5,6 +5,7 @@ import konkuk.thip.common.entity.BaseJpaEntity;
 import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
 import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
 
 @Entity
 @Table(name = "attendance_checks")
@@ -12,6 +13,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@SQLDelete(sql = "UPDATE attendance_checks SET status = 'INACTIVE' WHERE attendancecheck_id = ?")
 public class AttendanceCheckJpaEntity extends BaseJpaEntity {
 
     @Id

--- a/src/main/java/konkuk/thip/roompost/adapter/out/persistence/AttendanceCheckCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/persistence/AttendanceCheckCommandPersistenceAdapter.java
@@ -1,5 +1,7 @@
 package konkuk.thip.roompost.adapter.out.persistence;
 
+import konkuk.thip.common.entity.StatusType;
+import konkuk.thip.roompost.adapter.out.jpa.AttendanceCheckJpaEntity;
 import konkuk.thip.roompost.adapter.out.mapper.AttendanceCheckMapper;
 import konkuk.thip.roompost.adapter.out.persistence.repository.attendancecheck.AttendanceCheckJpaRepository;
 import konkuk.thip.roompost.application.port.out.AttendanceCheckCommandPort;
@@ -14,8 +16,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
-import static konkuk.thip.common.exception.code.ErrorCode.ROOM_NOT_FOUND;
-import static konkuk.thip.common.exception.code.ErrorCode.USER_NOT_FOUND;
+import static konkuk.thip.common.exception.code.ErrorCode.*;
 
 @Repository
 @RequiredArgsConstructor
@@ -43,7 +44,16 @@ public class AttendanceCheckCommandPersistenceAdapter implements AttendanceCheck
 
     @Override
     public Optional<AttendanceCheck> findById(Long id) {
-        return attendanceCheckJpaRepository.findById(id)
+        return attendanceCheckJpaRepository.findByAttendanceCheckIdAndStatus(id, StatusType.ACTIVE)
                 .map(attendanceCheckMapper::toDomainEntity);
+    }
+
+    @Override
+    public void delete(AttendanceCheck attendanceCheck) {
+        AttendanceCheckJpaEntity attendanceCheckJpaEntity = attendanceCheckJpaRepository.findByAttendanceCheckIdAndStatus(attendanceCheck.getId(), StatusType.ACTIVE).orElseThrow(
+                () -> new EntityNotFoundException(ATTENDANCE_CHECK_NOT_FOUND)
+        );
+
+        attendanceCheckJpaRepository.delete(attendanceCheckJpaEntity);
     }
 }

--- a/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/attendancecheck/AttendanceCheckJpaRepository.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/attendancecheck/AttendanceCheckJpaRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public interface AttendanceCheckJpaRepository extends JpaRepository<AttendanceCheckJpaEntity, Long>, AttendanceCheckQueryRepository {
 
@@ -18,4 +19,6 @@ public interface AttendanceCheckJpaRepository extends JpaRepository<AttendanceCh
             "AND a.createdAt >= :startOfDay " +
             "AND a.createdAt < :endOfDay")
     int countByUserIdAndRoomIdAndCreatedAtBetween(@Param("userId") Long userId, @Param("roomId") Long roomId, @Param("startOfDay") LocalDateTime startOfDay, @Param("endOfDay") LocalDateTime endOfDay, @Param("status")StatusType status);
+
+    Optional<AttendanceCheckJpaEntity> findByAttendanceCheckIdAndStatus(Long attendanceCheckId, StatusType status);
 }

--- a/src/main/java/konkuk/thip/roompost/application/port/in/AttendanceCheckDeleteUseCase.java
+++ b/src/main/java/konkuk/thip/roompost/application/port/in/AttendanceCheckDeleteUseCase.java
@@ -1,0 +1,7 @@
+package konkuk.thip.roompost.application.port.in;
+
+public interface AttendanceCheckDeleteUseCase {
+
+    Long delete(Long creatorId, Long roomId, Long attendanceCheckId);
+
+}

--- a/src/main/java/konkuk/thip/roompost/application/port/out/AttendanceCheckCommandPort.java
+++ b/src/main/java/konkuk/thip/roompost/application/port/out/AttendanceCheckCommandPort.java
@@ -17,4 +17,6 @@ public interface AttendanceCheckCommandPort {
         return findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(ATTENDANCE_CHECK_NOT_FOUND));
     }
+
+    void delete(AttendanceCheck attendanceCheck);
 }

--- a/src/main/java/konkuk/thip/roompost/application/service/AttendanceCheckDeleteService.java
+++ b/src/main/java/konkuk/thip/roompost/application/service/AttendanceCheckDeleteService.java
@@ -1,0 +1,32 @@
+package konkuk.thip.roompost.application.service;
+
+import konkuk.thip.room.application.service.validator.RoomParticipantValidator;
+import konkuk.thip.roompost.application.port.in.AttendanceCheckDeleteUseCase;
+import konkuk.thip.roompost.application.port.out.AttendanceCheckCommandPort;
+import konkuk.thip.roompost.domain.AttendanceCheck;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AttendanceCheckDeleteService implements AttendanceCheckDeleteUseCase {
+
+    private final AttendanceCheckCommandPort attendanceCheckCommandPort;
+    private final RoomParticipantValidator roomParticipantValidator;
+
+    @Override
+    @Transactional
+    public Long delete(Long creatorId, Long roomId, Long attendanceCheckId) {
+        // 1. creator 가 room participant인지 검증
+        roomParticipantValidator.validateUserIsRoomMember(roomId, creatorId);
+
+        // 2. creator 겁증
+        AttendanceCheck attendanceCheck = attendanceCheckCommandPort.getByIdOrThrow(attendanceCheckId);
+        attendanceCheck.validateCreator(creatorId);
+
+        // 3. 오늘의 한마디 삭제
+        attendanceCheckCommandPort.delete(attendanceCheck);
+        return roomId;
+    }
+}

--- a/src/main/java/konkuk/thip/roompost/application/service/RoomPostUpdateService.java
+++ b/src/main/java/konkuk/thip/roompost/application/service/RoomPostUpdateService.java
@@ -10,6 +10,7 @@ import konkuk.thip.roompost.domain.Record;
 import konkuk.thip.roompost.domain.Vote;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +21,7 @@ public class RoomPostUpdateService implements RoomPostUpdateUseCase {
     private final VoteCommandPort voteCommandPort;
 
     @Override
+    @Transactional
     public Long updateRecord(RecordUpdateCommand command) {
         // 1. 사용자가 방의 참가자인지 검증
         roomParticipantValidator.validateUserIsRoomMember(command.roomId(), command.userId());
@@ -36,6 +38,7 @@ public class RoomPostUpdateService implements RoomPostUpdateUseCase {
     }
 
     @Override
+    @Transactional
     public Long updateVote(VoteUpdateCommand command) {
         // 1. 사용자가 방의 참가자인지 검증
         roomParticipantValidator.validateUserIsRoomMember(command.roomId(), command.userId());

--- a/src/main/java/konkuk/thip/roompost/domain/AttendanceCheck.java
+++ b/src/main/java/konkuk/thip/roompost/domain/AttendanceCheck.java
@@ -5,6 +5,7 @@ import konkuk.thip.common.exception.InvalidStateException;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
+import static konkuk.thip.common.exception.code.ErrorCode.ATTENDANCE_CHECK_CAN_NOT_DELETE;
 import static konkuk.thip.common.exception.code.ErrorCode.ATTENDANCE_CHECK_WRITE_LIMIT_EXCEEDED;
 
 @Getter
@@ -34,6 +35,12 @@ public class AttendanceCheck extends BaseDomainEntity {
     private static void validateWriteCount(int alreadyWrittenCountTodayOfUser) {
         if (alreadyWrittenCountTodayOfUser >= LIMIT_WRITE_COUNT_PER_DAY) {
             throw new InvalidStateException(ATTENDANCE_CHECK_WRITE_LIMIT_EXCEEDED);
+        }
+    }
+
+    public void validateCreator(Long userId) {
+        if (!creatorId.equals(userId)) {
+            throw new InvalidStateException(ATTENDANCE_CHECK_CAN_NOT_DELETE);
         }
     }
 }

--- a/src/test/java/konkuk/thip/roompost/adapter/in/web/AttendanceCheckDeleteApiTest.java
+++ b/src/test/java/konkuk/thip/roompost/adapter/in/web/AttendanceCheckDeleteApiTest.java
@@ -1,0 +1,140 @@
+package konkuk.thip.roompost.adapter.in.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.adapter.out.persistence.repository.BookJpaRepository;
+import konkuk.thip.common.util.TestEntityFactory;
+import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
+import konkuk.thip.room.adapter.out.jpa.RoomParticipantRole;
+import konkuk.thip.room.adapter.out.persistence.repository.RoomJpaRepository;
+import konkuk.thip.room.adapter.out.persistence.repository.roomparticipant.RoomParticipantJpaRepository;
+import konkuk.thip.room.domain.value.Category;
+import konkuk.thip.roompost.adapter.out.jpa.AttendanceCheckJpaEntity;
+import konkuk.thip.roompost.adapter.out.persistence.repository.attendancecheck.AttendanceCheckJpaRepository;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.domain.value.Alias;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static konkuk.thip.common.entity.StatusType.INACTIVE;
+import static konkuk.thip.common.exception.code.ErrorCode.ATTENDANCE_CHECK_CAN_NOT_DELETE;
+import static konkuk.thip.common.exception.code.ErrorCode.ROOM_ACCESS_FORBIDDEN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("[통합] 오늘의 한마디 삭제 api 통합 테스트")
+class AttendanceCheckDeleteApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserJpaRepository userJpaRepository;
+    @Autowired private BookJpaRepository bookJpaRepository;
+    @Autowired private RoomJpaRepository roomJpaRepository;
+    @Autowired private RoomParticipantJpaRepository roomParticipantJpaRepository;
+    @Autowired private AttendanceCheckJpaRepository attendanceCheckJpaRepository;
+
+    @AfterEach
+    void tearDown() {
+        attendanceCheckJpaRepository.deleteAllInBatch();
+        roomParticipantJpaRepository.deleteAllInBatch();
+        roomJpaRepository.deleteAllInBatch();
+        bookJpaRepository.deleteAllInBatch();
+        userJpaRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("오늘의 한마디 작성자는 본인이 작성한 오늘의 한마디를 삭제(= soft delete) 할 수 있다.")
+    void attendance_check_delete_test() throws Exception {
+        //given
+        Alias a0 = TestEntityFactory.createScienceAlias();
+        UserJpaEntity me = userJpaRepository.save(TestEntityFactory.createUser(a0, "me"));
+
+        Category c0 = TestEntityFactory.createScienceCategory();
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBook());
+        RoomJpaEntity room = roomJpaRepository.save(TestEntityFactory.createRoom(book, c0));
+
+        // me 가 room에 참여중인 상황
+        roomParticipantJpaRepository.save(TestEntityFactory.createRoomParticipant(room, me, RoomParticipantRole.MEMBER, 0.0));
+
+        // me가 오늘의 한마디 작성한 상황
+        AttendanceCheckJpaEntity ac1 = attendanceCheckJpaRepository.save(TestEntityFactory.createAttendanceCheck("오한1", room, me));
+
+        //when //then
+        mockMvc.perform(delete("/rooms/{roomId}/daily-greeting/{attendanceCheckId}", room.getRoomId().intValue(), ac1.getAttendanceCheckId().intValue())
+                        .requestAttr("userId", me.getUserId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.roomId", is(room.getRoomId().intValue())));
+
+        AttendanceCheckJpaEntity deleted = attendanceCheckJpaRepository.findById(ac1.getAttendanceCheckId()).orElse(null);
+        Assertions.assertNotNull(deleted);
+        assertThat(deleted.getStatus()).isEqualTo(INACTIVE);
+    }
+
+    @Test
+    @DisplayName("방 참여자가 아닌 사람이 오늘의 한마디 삭제 요청을 할 경우, 403 error 를 반환한다.")
+    void attendance_check_delete_not_room_participant_test() throws Exception {
+        //given
+        Alias a0 = TestEntityFactory.createScienceAlias();
+        UserJpaEntity me = userJpaRepository.save(TestEntityFactory.createUser(a0, "me"));
+        UserJpaEntity user1 = userJpaRepository.save(TestEntityFactory.createUser(a0, "user1"));
+
+        Category c0 = TestEntityFactory.createScienceCategory();
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBook());
+        RoomJpaEntity room = roomJpaRepository.save(TestEntityFactory.createRoom(book, c0));
+
+        // me 가 room에 참여중인 상황 (user1은 참여 안함)
+        roomParticipantJpaRepository.save(TestEntityFactory.createRoomParticipant(room, me, RoomParticipantRole.MEMBER, 0.0));
+
+        // me가 오늘의 한마디 작성한 상황
+        AttendanceCheckJpaEntity ac1 = attendanceCheckJpaRepository.save(TestEntityFactory.createAttendanceCheck("오한1", room, me));
+
+        //when //then
+        mockMvc.perform(delete("/rooms/{roomId}/daily-greeting/{attendanceCheckId}", room.getRoomId().intValue(), ac1.getAttendanceCheckId().intValue())
+                        .requestAttr("userId", user1.getUserId()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message", containsString(ROOM_ACCESS_FORBIDDEN.getMessage())));
+    }
+
+    @Test
+    @DisplayName("다른 사람이 작성한 오늘의 한마디의 삭제 요청을 할 경우, 400 error 를 반환한다.")
+    void attendance_check_delete_not_creator_test() throws Exception {
+        //given
+        Alias a0 = TestEntityFactory.createScienceAlias();
+        UserJpaEntity me = userJpaRepository.save(TestEntityFactory.createUser(a0, "me"));
+        UserJpaEntity user1 = userJpaRepository.save(TestEntityFactory.createUser(a0, "user1"));
+
+        Category c0 = TestEntityFactory.createScienceCategory();
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBook());
+        RoomJpaEntity room = roomJpaRepository.save(TestEntityFactory.createRoom(book, c0));
+
+        // me, user1 이 room에 참여중인 상황
+        roomParticipantJpaRepository.save(TestEntityFactory.createRoomParticipant(room, me, RoomParticipantRole.MEMBER, 0.0));
+        roomParticipantJpaRepository.save(TestEntityFactory.createRoomParticipant(room, user1, RoomParticipantRole.MEMBER, 0.0));
+
+        // me, user1 이 오늘의 한마디 작성한 상황
+        AttendanceCheckJpaEntity ac1 = attendanceCheckJpaRepository.save(TestEntityFactory.createAttendanceCheck("me-오한1", room, me));
+        AttendanceCheckJpaEntity ac2 = attendanceCheckJpaRepository.save(TestEntityFactory.createAttendanceCheck("user1-오한1", room, user1));
+
+        //when //then : me가 user1이 작성한 오늘의 한마디를 삭제 요청
+        mockMvc.perform(delete("/rooms/{roomId}/daily-greeting/{attendanceCheckId}", room.getRoomId().intValue(), ac2.getAttendanceCheckId().intValue())
+                        .requestAttr("userId", me.getUserId()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message", containsString(ATTENDANCE_CHECK_CAN_NOT_DELETE.getMessage())));
+    }
+}

--- a/src/test/java/konkuk/thip/roompost/adapter/in/web/AttendanceCheckDeleteApiTest.java
+++ b/src/test/java/konkuk/thip/roompost/adapter/in/web/AttendanceCheckDeleteApiTest.java
@@ -134,7 +134,7 @@ class AttendanceCheckDeleteApiTest {
         //when //then : me가 user1이 작성한 오늘의 한마디를 삭제 요청
         mockMvc.perform(delete("/rooms/{roomId}/daily-greeting/{attendanceCheckId}", room.getRoomId().intValue(), ac2.getAttendanceCheckId().intValue())
                         .requestAttr("userId", me.getUserId()))
-                .andExpect(status().isBadRequest())
+                .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.message", containsString(ATTENDANCE_CHECK_CAN_NOT_DELETE.getMessage())));
     }
 }

--- a/src/test/java/konkuk/thip/roompost/adapter/in/web/AttendanceCheckDeleteApiTest.java
+++ b/src/test/java/konkuk/thip/roompost/adapter/in/web/AttendanceCheckDeleteApiTest.java
@@ -112,7 +112,7 @@ class AttendanceCheckDeleteApiTest {
     }
 
     @Test
-    @DisplayName("다른 사람이 작성한 오늘의 한마디의 삭제 요청을 할 경우, 400 error 를 반환한다.")
+    @DisplayName("다른 사람이 작성한 오늘의 한마디의 삭제 요청을 할 경우, 403 error 를 반환한다.")
     void attendance_check_delete_not_creator_test() throws Exception {
         //given
         Alias a0 = TestEntityFactory.createScienceAlias();

--- a/src/test/java/konkuk/thip/roompost/domain/AttendanceCheckTest.java
+++ b/src/test/java/konkuk/thip/roompost/domain/AttendanceCheckTest.java
@@ -4,6 +4,8 @@ import konkuk.thip.common.exception.InvalidStateException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static konkuk.thip.common.exception.code.ErrorCode.ATTENDANCE_CHECK_CAN_NOT_DELETE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("[단위] AttendanceCheck 도메인 테스트")
@@ -43,5 +45,37 @@ class AttendanceCheckTest {
         // when // then
         assertThrows(InvalidStateException.class,
                 () -> AttendanceCheck.withoutId(roomId, userId, todayComment, alreadyWrittenCountTodayOfUser));
+    }
+
+    @Test
+    @DisplayName("오늘의 한마디 작성자가 맞을 경우, 예외를 터뜨리지 않는다.")
+    void validate_creator_success() throws Exception {
+        //given
+        AttendanceCheck ac = AttendanceCheck.builder()
+                .id(1L)
+                .creatorId(1L)
+                .todayComment("오늘의 한마디!!!")
+                .roomId(1L)
+                .build();
+
+        //when //then
+        assertDoesNotThrow(() -> ac.validateCreator(1L));
+    }
+
+    @Test
+    @DisplayName("오늘의 한마디 작성자가 아닐 경우, InvalidStateException 을 터뜨린다.")
+    void validate_creator_fail() throws Exception {
+        //given
+        AttendanceCheck ac = AttendanceCheck.builder()
+                .id(1L)
+                .creatorId(1L)
+                .todayComment("오늘의 한마디!!!")
+                .roomId(1L)
+                .build();
+
+        //when //then
+        assertThatThrownBy(() -> ac.validateCreator(2L))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessage(ATTENDANCE_CHECK_CAN_NOT_DELETE.getMessage());
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #276 

## 📝 작업 내용

오늘의 한마디를 삭제하는 api를 개발하였습니다

- 주요 코드 설명
  - service
    - 오늘의 한마디 삭제 요청을 보내는 유저가 방 참여자인지를 검증
    - 오늘의 한마디 삭제 요청을 보내는 유저가 삭제하려는 오늘의 한마디 작성자인지를 검증
    - 문제없을 경우, 오늘의 한마디 삭제 진행 (jpa entity의 @SQLDelete 어노테이션을 통해 soft delete 진행)
  - api 통합 test
    - 오늘의 한마디 삭제 이후, DB 데이터의 status 가 INACTIVE 인지를 검증하였습니다

- 추가로 오늘의 한마디 entity 의 조회 관련 영속성 코드에서 soft delete 임에도 불구하고 status 조건 없이 entity를 find 하고 있어서, findByIdAndStatus 메서드를 통해 entity를 find 하도록 수정하였습니다
- 위처럼 soft delete 대상인 entity들의 조회 관련 코드에 status 조건이 빠진 부분이 아직 남아있는것 같아, api feature 개발 이후 전체 코드에 대해서 점검을 해보겠습니다

- 또한 개발 편의를 위해 access token 을 발급하는 테스트 용 api 를 뚫어놨습니다

## 📸 스크린샷
<img width="586" height="665" alt="image" src="https://github.com/user-attachments/assets/a4eca384-7341-42ec-8b2a-7f569b204ce3" /><img width="1468" height="376" alt="image" src="https://github.com/user-attachments/assets/8d12e052-30cd-4d8e-9fe6-a71a96d562ac" />


## 💬 리뷰 요구사항

개발 편의를 위해 access token 을 발급하는 테스트 용 api 를 추가했는데, 배포환경에서 해당 api 가 악용되는 것을 막기 위해 access token 발급 controller 에 property 조건을 추가하였습니다

또한 dev yml, prod yml 에 해당 property 의 값을 false로 정의하여 github secret 값을 update 해두었습니다!

local yml 에서는 true 로 설정해서 사용하시면 됩니다! (노션 yml 정리 파일 참고해주시면 됩니다)

사전에 의논이 된 부분은 아니지만, 로컬 서버에서의 테스트 용이성을 위해 access token 을 발급하는 개발 편의용 api 가 있으면 좋겠다 싶어서 추가해봤습니다!
추후에 개발 편의용 api 가 추가될 경우 동일한 방식으로 관리하면 좋을 것 같습니다!

관련해서 의견 자유롭게 주시면 감사하겠습니다!!

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 오늘의 한마디 삭제 기능 추가: DELETE /rooms/{roomId}/daily-greeting/{attendanceCheckId} (작성자만 삭제 가능, 삭제 시 roomId 반환)
  * 기록/투표 수정 엔드포인트 추가: PATCH /rooms/{roomId}/records/{recordId}, PATCH /rooms/{roomId}/votes/{voteId}
* **Documentation**
  * 삭제 API 스웨거 응답 및 오류 케이스 문서화(권한 없음, 존재하지 않음, 본인만 삭제 가능 — "오늘의 한마디는 본인만 삭제할 수 있습니다.")
* **Refactor**
  * 오늘의 한마디 소프트 삭제 도입으로 데이터 보존 강화
* **Tests / Chores**
  * 삭제 API 통합·단위 테스트 추가
  * 테스트용 토큰 엔드포인트(/api/test/token/access) 및 보안 화이트리스트 추가 (테스트 모드)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->