### PR TITLE
[hotfix] 내가 참여한 모임방 api 의 영속성 코드 수정

### DIFF
--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomQueryRepository.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomQueryRepository.java
@@ -27,7 +27,7 @@ public interface RoomQueryRepository {
 
     List<RoomQueryDto> findPlayingRoomsUserParticipated(Long userId, LocalDate dateCursor, Long roomIdCursor, int pageSize);
 
-    List<RoomQueryDto> findPlayingAndRecruitingRoomsUserParticipated(Long userId, LocalDate dateCursor, Long roomIdCursor, int pageSize);
+    List<RoomQueryDto> findPlayingAndRecruitingRoomsUserParticipated(Long userId, Integer priorityCursor, LocalDate dateCursor, Long roomIdCursor, int pageSize);
 
     List<RoomQueryDto> findExpiredRoomsUserParticipated(Long userId, LocalDate dateCursor, Long roomIdCursor, int pageSize);
 

--- a/src/main/java/konkuk/thip/room/application/port/out/dto/RoomQueryDto.java
+++ b/src/main/java/konkuk/thip/room/application/port/out/dto/RoomQueryDto.java
@@ -1,12 +1,12 @@
 package konkuk.thip.room.application.port.out.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
-import jakarta.annotation.Nullable;
 import lombok.Builder;
 import org.springframework.util.Assert;
 
 import java.time.LocalDate;
 
+// TODO : RoomStatus 도입 + RoomQueryRepositoryImpl 코드 수정
 @Builder
 public record RoomQueryDto(
         Long roomId,
@@ -18,7 +18,7 @@ public record RoomQueryDto(
         LocalDate endDate,       // 방 진행 마감일 or 방 모집 마감일
         Boolean isPublic        // 공개방 여부
 ) {
-    // 내가 참여한 모임방(모집중, 진행중, 모집+진행중z, 완료된) 조회 시 활용
+    // 내가 참여한 모임방(모집중, 진행중, 모집+진행중, 완료된) 조회 시 활용
     @QueryProjection
     public RoomQueryDto {
         Assert.notNull(roomId, "roomId must not be null");

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomShowMineApiTest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomShowMineApiTest.java
@@ -492,4 +492,91 @@ class RoomShowMineApiTest {
                 .andExpect(jsonPath("$.data.roomList[1].roomName", is("과학-방-1일뒤-활동시작")))
                 .andExpect(jsonPath("$.data.roomList[1].memberCount", is(6)));       // 기존 5명 + user
     }
+
+    @Test
+    @DisplayName("혼합(진행+모집) 무한스크롤: (priority, date, id) 키셋으로 중복/누락 없이 페이징된다.")
+    void get_my_playing_and_recruiting_rooms_pagination() throws Exception {
+        // given
+        // 진행중인 방 6개 (endDate 임박 순서: +1d ~ +6d)
+        RoomJpaEntity playing1 = saveScienceRoom("진행중인방-책-P1", "pisbn1", "과학-방-1일뒤-활동마감", LocalDate.now().minusDays(10), LocalDate.now().plusDays(1), 10);
+        changeRoomMemberCount(playing1, 3);
+        RoomJpaEntity playing2 = saveScienceRoom("진행중인방-책-P2", "pisbn2", "과학-방-2일뒤-활동마감", LocalDate.now().minusDays(10), LocalDate.now().plusDays(2), 10);
+        changeRoomMemberCount(playing2, 4);
+        RoomJpaEntity playing3 = saveScienceRoom("진행중인방-책-P3", "pisbn3", "과학-방-3일뒤-활동마감", LocalDate.now().minusDays(10), LocalDate.now().plusDays(3), 10);
+        changeRoomMemberCount(playing3, 5);
+        RoomJpaEntity playing4 = saveScienceRoom("진행중인방-책-P4", "pisbn4", "과학-방-4일뒤-활동마감", LocalDate.now().minusDays(10), LocalDate.now().plusDays(4), 10);
+        changeRoomMemberCount(playing4, 6);
+        RoomJpaEntity playing5 = saveScienceRoom("진행중인방-책-P5", "pisbn5", "과학-방-5일뒤-활동마감", LocalDate.now().minusDays(10), LocalDate.now().plusDays(5), 10);
+        changeRoomMemberCount(playing5, 7);
+        RoomJpaEntity playing6 = saveScienceRoom("진행중인방-책-P6", "pisbn6", "과학-방-6일뒤-활동마감", LocalDate.now().minusDays(10), LocalDate.now().plusDays(6), 10);
+        changeRoomMemberCount(playing6, 8);
+
+        // 모집중인 방 6개 (startDate 임박 순서: +1d ~ +6d)
+        RoomJpaEntity recruiting1 = saveScienceRoom("모집중인방-책-R1", "risbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruiting1, 3);
+        RoomJpaEntity recruiting2 = saveScienceRoom("모집중인방-책-R2", "risbn2", "과학-방-2일뒤-활동시작", LocalDate.now().plusDays(2), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruiting2, 4);
+        RoomJpaEntity recruiting3 = saveScienceRoom("모집중인방-책-R3", "risbn3", "과학-방-3일뒤-활동시작", LocalDate.now().plusDays(3), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruiting3, 5);
+        RoomJpaEntity recruiting4 = saveScienceRoom("모집중인방-책-R4", "risbn4", "과학-방-4일뒤-활동시작", LocalDate.now().plusDays(4), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruiting4, 6);
+        RoomJpaEntity recruiting5 = saveScienceRoom("모집중인방-책-R5", "risbn5", "과학-방-5일뒤-활동시작", LocalDate.now().plusDays(5), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruiting5, 7);
+        RoomJpaEntity recruiting6 = saveScienceRoom("모집중인방-책-R6", "risbn6", "과학-방-6일뒤-활동시작", LocalDate.now().plusDays(6), LocalDate.now().plusDays(30), 10);
+        changeRoomMemberCount(recruiting6, 8);
+
+        Alias alias = TestEntityFactory.createScienceAlias();
+        UserJpaEntity user = userJpaRepository.save(TestEntityFactory.createUser(alias));
+
+        // 유저 참여
+        saveSingleUserToRoom(playing1, user);
+        saveSingleUserToRoom(playing2, user);
+        saveSingleUserToRoom(playing3, user);
+        saveSingleUserToRoom(playing4, user);
+        saveSingleUserToRoom(playing5, user);
+        saveSingleUserToRoom(playing6, user);
+        saveSingleUserToRoom(recruiting1, user);
+        saveSingleUserToRoom(recruiting2, user);
+        saveSingleUserToRoom(recruiting3, user);
+        saveSingleUserToRoom(recruiting4, user);
+        saveSingleUserToRoom(recruiting5, user);
+        saveSingleUserToRoom(recruiting6, user);
+
+        // when: 첫 페이지 (type 파라미터 없음 -> 혼합 조회)
+        ResultActions page1 = mockMvc.perform(get("/rooms/my")
+                .requestAttr("userId", user.getUserId()));
+
+        // then: 첫 페이지는 10개, 진행중(6) 먼저, 이후 모집중(4)
+        page1.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.isLast", is(false)))
+                .andExpect(jsonPath("$.data.roomList", hasSize(10)))
+                // 진행중 6개 (endDate 임박순)
+                .andExpect(jsonPath("$.data.roomList[0].roomName", is("과학-방-1일뒤-활동마감")))
+                .andExpect(jsonPath("$.data.roomList[1].roomName", is("과학-방-2일뒤-활동마감")))
+                .andExpect(jsonPath("$.data.roomList[2].roomName", is("과학-방-3일뒤-활동마감")))
+                .andExpect(jsonPath("$.data.roomList[3].roomName", is("과학-방-4일뒤-활동마감")))
+                .andExpect(jsonPath("$.data.roomList[4].roomName", is("과학-방-5일뒤-활동마감")))
+                .andExpect(jsonPath("$.data.roomList[5].roomName", is("과학-방-6일뒤-활동마감")))
+                // 이어서 모집중 4개 (startDate 임박순)
+                .andExpect(jsonPath("$.data.roomList[6].roomName", is("과학-방-1일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[7].roomName", is("과학-방-2일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[8].roomName", is("과학-방-3일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[9].roomName", is("과학-방-4일뒤-활동시작")));
+
+        // 다음 페이지 커서: 첫 페이지의 마지막 레코드 = recruiting4
+        // 혼합 커서 형식 = priority|deadlineDate|roomId (priority: 진행=0, 모집=1; deadlineDate: 진행=endDate, 모집=startDate)
+        String nextCursor = "1|" + recruiting4.getStartDate() + "|" + recruiting4.getRoomId();
+
+        // when: 두 번째 페이지
+        ResultActions page2 = mockMvc.perform(get("/rooms/my")
+                .requestAttr("userId", user.getUserId())
+                .param("cursor", nextCursor));
+
+        // then: 남은 모집중 2개, isLast=true, 중복/누락 없음
+        page2.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.isLast", is(true)))
+                .andExpect(jsonPath("$.data.roomList", hasSize(2)))
+                .andExpect(jsonPath("$.data.roomList[0].roomName", is("과학-방-5일뒤-활동시작")))
+                .andExpect(jsonPath("$.data.roomList[1].roomName", is("과학-방-6일뒤-활동시작")));
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #290 

## 📝 작업 내용

- 수정사항 1
  - 유저가 참여한 모임방 중, 모집중인 방의 경우 api response 의 endDate 는 '방 모집마감일 == 방 진행 시작일' 이어야 하는데, 기존 코드에서는 '방 진행 마감일' 로 잘못 매핑되어 있었습니다.
  - QueryDsl 코드에서 RoomQueryDto 를 반환하는 부분을 수정하였습니다.
  - 로컬 서버에서 테스트 해보았습니다
  - 데이터 : 9월 10일(= 6일 뒤) 에 start 하는 방에 참여한 상황을 가정
    <img width="907" height="886" alt="image" src="https://github.com/user-attachments/assets/96645c4b-20cd-4343-b03b-f52ec5dbc8cb" />

- 수정사항 2
  - request 로 내가 참여한 모임방 중 '모집 + 진행 중인 방 조회' 를 받을 경우, 진행중인 방 -> 모집중인 방 의 순서로 응답을 해야하는 요구사항이 있습니다
    - 정렬 기준
      <img width="535" height="120" alt="image" src="https://github.com/user-attachments/assets/49b824e3-97ba-4e53-88b9-8a3b76b499b9" />

  - 기존코드에서는 무한 스크롤 기능을 위한 response의 lastCursor 값에 마지막 데이터의 우선순위(= priority) 값을 포함하지 않아 누락 or 중복되는 데이터가 발생할 수 있는 이슈가 있었습니다
  - 따라서 priority 값을 cursor 에 추가하여 3중 복합 커서를 활용하여 QueryDsl 코드에서 조회를 하도록 수정하였습니다
  - 관련해서 api 통합 테스트 코드를 통해서 무한 스크롤 기능이 정상동작함을 확인했습니다

## 📸 스크린샷

## 💬 리뷰 요구사항

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 내 모임(진행중+모집중) 혼합 목록의 페이지네이션을 개선했습니다. 우선순위 기반 커서를 사용해 정렬과 이어보기가 안정적이며, 첫 페이지는 최대 10개를 반환하고 다음 페이지 커서를 제공합니다. 중복/누락 없이 연속 조회가 가능하고 마지막 페이지 여부가 정확히 표시됩니다.
- Tests
  - 혼합 목록 페이지네이션 동작(정렬, 커서 이동, isLast 표시)을 검증하는 통합 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->