### PR TITLE
[Feat] 회원 탈퇴 구현 및 투표 조회시 투표 득표수 보여주도록 수정

### DIFF
--- a/src/main/java/konkuk/thip/book/adapter/out/persistence/BookCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/persistence/BookCommandPersistenceAdapter.java
@@ -92,4 +92,9 @@ public class BookCommandPersistenceAdapter implements BookCommandPort {
     public void deleteAllByIdInBatch(Set<Long> unusedBookIds) {
         bookJpaRepository.deleteAllByIdInBatch(unusedBookIds);
     }
+
+    @Override
+    public void deleteAllSavedBookByUserId(Long userId) {
+        savedBookJpaRepository.deleteAllByUserId(userId);
+    }
 }

--- a/src/main/java/konkuk/thip/book/adapter/out/persistence/repository/SavedBookJpaRepository.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/persistence/repository/SavedBookJpaRepository.java
@@ -13,5 +13,9 @@ public interface SavedBookJpaRepository extends JpaRepository<SavedBookJpaEntity
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM SavedBookJpaEntity s WHERE s.userJpaEntity.userId = :userId AND s.bookJpaEntity.bookId = :bookId")
-    void deleteByUserIdAndBookId(Long userId, Long bookId);
+    void deleteByUserIdAndBookId(@Param("userId") Long userId, @Param("bookId") Long bookId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM SavedBookJpaEntity s WHERE s.userJpaEntity.userId = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/konkuk/thip/book/application/port/out/BookCommandPort.java
+++ b/src/main/java/konkuk/thip/book/application/port/out/BookCommandPort.java
@@ -29,4 +29,6 @@ public interface BookCommandPort {
     void deleteSavedBook(Long userId, Long bookId);
 
     void deleteAllByIdInBatch(Set<Long> unusedBookIds);
+
+    void deleteAllSavedBookByUserId(Long userId);
 }

--- a/src/main/java/konkuk/thip/comment/adapter/out/jpa/CommentJpaEntity.java
+++ b/src/main/java/konkuk/thip/comment/adapter/out/jpa/CommentJpaEntity.java
@@ -38,7 +38,6 @@ public class CommentJpaEntity extends BaseJpaEntity {
     @Column(name = "like_count", nullable = false)
     private int likeCount = 0;
 
-    //TODO 상속구조 해지하면서 postType만 가질지, postId + postType가질지 논의 필요
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "post_id", nullable = false)
     private PostJpaEntity postJpaEntity;
@@ -57,11 +56,6 @@ public class CommentJpaEntity extends BaseJpaEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private CommentJpaEntity parent;
-
-    // 삭제용 댓글 좋아요 양방향 매핑 관계
-    @Builder.Default
-    @OneToMany(mappedBy = "commentJpaEntity", cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private List<CommentLikeJpaEntity> commentLikeList = new ArrayList<>();
 
     public CommentJpaEntity updateFrom(Comment comment) {
         this.reportCount = comment.getReportCount();

--- a/src/main/java/konkuk/thip/comment/adapter/out/jpa/CommentJpaEntity.java
+++ b/src/main/java/konkuk/thip/comment/adapter/out/jpa/CommentJpaEntity.java
@@ -10,9 +10,6 @@ import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Entity
 @Table(name = "comments")
 @Getter
@@ -34,6 +31,11 @@ public class CommentJpaEntity extends BaseJpaEntity {
     @Column(name = "report_count", nullable = false)
     private int reportCount = 0;
 
+    /**
+     * -- SETTER --
+     *  회원 탈퇴용
+     */
+    @Setter
     @Builder.Default
     @Column(name = "like_count", nullable = false)
     private int likeCount = 0;

--- a/src/main/java/konkuk/thip/comment/adapter/out/persistence/CommentCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/comment/adapter/out/persistence/CommentCommandPersistenceAdapter.java
@@ -111,7 +111,7 @@ public class CommentCommandPersistenceAdapter implements CommentCommandPort {
             return; //early return
         }
         // 2. 탈퇴한 유저의 모든 댓글, 댓글의 좋아요 삭제
-        commentLikeJpaRepository.deleteAllByUserId(userId);
+        commentLikeJpaRepository.deleteAllByCommentAuthorUserId(userId);
         commentJpaRepository.deleteAllByUserId(userId);
         // 3. 게시글 타입별로 댓글 수 감소가 필요한 게시글 Map 생성
         Map<PostType, List<PostJpaEntity>> postsByType = new HashMap<>();

--- a/src/main/java/konkuk/thip/comment/adapter/out/persistence/CommentCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/comment/adapter/out/persistence/CommentCommandPersistenceAdapter.java
@@ -7,12 +7,9 @@ import konkuk.thip.comment.adapter.out.persistence.repository.CommentLikeJpaRepo
 import konkuk.thip.comment.application.port.out.CommentCommandPort;
 import konkuk.thip.comment.domain.Comment;
 import konkuk.thip.common.exception.EntityNotFoundException;
-import konkuk.thip.feed.adapter.out.jpa.FeedJpaEntity;
 import konkuk.thip.post.domain.PostType;
 import konkuk.thip.feed.adapter.out.persistence.repository.FeedJpaRepository;
 import konkuk.thip.post.adapter.out.jpa.PostJpaEntity;
-import konkuk.thip.roompost.adapter.out.jpa.RecordJpaEntity;
-import konkuk.thip.roompost.adapter.out.jpa.VoteJpaEntity;
 import konkuk.thip.roompost.adapter.out.persistence.repository.record.RecordJpaRepository;
 import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
@@ -61,17 +58,6 @@ public class CommentCommandPersistenceAdapter implements CommentCommandPort {
         ).getCommentId();
     }
 
-    private PostJpaEntity findPostJpaEntity(PostType postType, Long postId) {
-        return switch (postType) {
-            case FEED -> feedJpaRepository.findByPostId(postId)
-                    .orElseThrow(() -> new EntityNotFoundException(FEED_NOT_FOUND));
-            case RECORD -> recordJpaRepository.findByPostId(postId)
-                    .orElseThrow(() -> new EntityNotFoundException(RECORD_NOT_FOUND));
-            case VOTE -> voteJpaRepository.findByPostId(postId)
-                    .orElseThrow(() -> new EntityNotFoundException(VOTE_NOT_FOUND));
-        };
-    }
-
     @Override
     public Optional<Comment> findById(Long id) {
         return commentJpaRepository.findByCommentId(id)
@@ -101,37 +87,6 @@ public class CommentCommandPersistenceAdapter implements CommentCommandPort {
         commentJpaRepository.softDeleteAllByPostId(postId);
     }
 
-//    @Override
-//    public void deleteAllByUserId(Long userId) {
-//
-//        // 1. 탈퇴 유저가 작성한 댓글과 연관된 게시글을 JOIN FETCH로 함께 조회
-//        List<CommentJpaEntity> commentsWithPosts = commentJpaRepository.findAllCommentsWithPostsByUserId(userId);
-//        if (commentsWithPosts == null || commentsWithPosts.isEmpty()) {
-//            return; //early return
-//        }
-//        // 2. 탈퇴한 유저의 모든 댓글, 댓글의 좋아요 삭제
-//        commentLikeJpaRepository.deleteAllByCommentAuthorUserId(userId);
-//        commentJpaRepository.softDeleteAllByUserId(userId);
-//
-//        // 3) Post 엔티티 기준으로 감소해야 할 횟수를 그룹핑하여 집계
-//        Map<PostJpaEntity, Long> decMap = commentsWithPosts.stream()
-//                .collect(Collectors.groupingBy(CommentJpaEntity::getPostJpaEntity, Collectors.counting()));
-//
-//        // 4) 타입별로 묶어 한 번만 감소 적용 후 저장
-//        Map<PostType, List<PostJpaEntity>> postsByType = new EnumMap<>(PostType.class);
-//
-//        decMap.forEach((post, dec) -> {
-//            // 댓글 수를 집계만큼 한 번에 감소
-//            int newCount = Math.max(0, post.getCommentCount() - dec.intValue());
-//            post.setCommentCount(newCount);
-//
-//            PostType postType = PostType.from(post.getDtype());
-//            postsByType.computeIfAbsent(postType, k -> new ArrayList<>()).add(post);
-//        });
-//        // 5. 게시글 타입별로 저장 처리
-//        postsByType.forEach(this::savePostsJpaEntities);
-//    }
-
     @Override
     public void deleteAllByUserId(Long userId) {
         // 1. 탈퇴 유저가 작성한 댓글과 연관된 게시글을 JOIN FETCH로 함께 조회
@@ -144,37 +99,25 @@ public class CommentCommandPersistenceAdapter implements CommentCommandPort {
         Map<PostJpaEntity, Long> decMap = commentsWithPosts.stream()
                 .collect(Collectors.groupingBy(CommentJpaEntity::getPostJpaEntity, Collectors.counting()));
 
+        // 3. 댓글 수를 집계만큼 한 번에 감소
         for (PostJpaEntity p : decMap.keySet()) {
             long dec = decMap.getOrDefault(p, 0L);
             p.setCommentCount(Math.max(0, p.getCommentCount() - (int) dec));
         }
 
-        // 3. 탈퇴한 유저의 모든 댓글, 댓글의 좋아요 삭제
+        // 4. 탈퇴한 유저의 모든 댓글, 댓글의 좋아요 삭제
         commentLikeJpaRepository.deleteAllByCommentAuthorUserId(userId);
         commentJpaRepository.softDeleteAllByUserId(userId);
     }
 
-    private void savePostsJpaEntities(PostType postType, List<PostJpaEntity> posts) {
-        switch (postType) {
-            case FEED:
-                feedJpaRepository.saveAll(posts.stream()
-                        .filter(p -> p instanceof FeedJpaEntity)
-                        .map(p -> (FeedJpaEntity) p)
-                        .collect(Collectors.toList()));
-                break;
-            case RECORD:
-                recordJpaRepository.saveAll(posts.stream()
-                        .filter(p -> p instanceof RecordJpaEntity)
-                        .map(p -> (RecordJpaEntity) p)
-                        .collect(Collectors.toList()));
-                break;
-            case VOTE:
-                voteJpaRepository.saveAll(posts.stream()
-                        .filter(p -> p instanceof VoteJpaEntity)
-                        .map(p -> (VoteJpaEntity) p)
-                        .collect(Collectors.toList()));
-                voteJpaRepository.flush();
-                break;
-        }
+    private PostJpaEntity findPostJpaEntity(PostType postType, Long postId) {
+        return switch (postType) {
+            case FEED -> feedJpaRepository.findByPostId(postId)
+                    .orElseThrow(() -> new EntityNotFoundException(FEED_NOT_FOUND));
+            case RECORD -> recordJpaRepository.findByPostId(postId)
+                    .orElseThrow(() -> new EntityNotFoundException(RECORD_NOT_FOUND));
+            case VOTE -> voteJpaRepository.findByPostId(postId)
+                    .orElseThrow(() -> new EntityNotFoundException(VOTE_NOT_FOUND));
+        };
     }
 }

--- a/src/main/java/konkuk/thip/comment/adapter/out/persistence/CommentLikeCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/comment/adapter/out/persistence/CommentLikeCommandPersistenceAdapter.java
@@ -57,13 +57,9 @@ public class CommentLikeCommandPersistenceAdapter implements CommentLikeCommandP
             return; //early return
         }
         // 2. 탈퇴한 유저의 모든 댓글 좋아요 관계 삭제
-        commentLikeJpaRepository.deleteAllByUserId(userId);
-        // 3. 해당 ID들로 JPA 엔티티 직접 조회
-        List<CommentJpaEntity> commentEntities = commentJpaRepository.findAllById(likedCommentIds);
-        // 4. 엔티티에서 직접 좋아요 수 감소
-        commentEntities.forEach(entity ->
-                entity.setLikeCount(Math.max(0, entity.getLikeCount() - 1)));
-        commentJpaRepository.saveAll(commentEntities);
+        commentLikeJpaRepository.deleteAllByLikerUserId(userId);
+        // 3. 탈퇴 유저가 좋아요 누른 댓글의 좋아요 수 감소
+        commentJpaRepository.bulkDecrementLikeCountByIds(likedCommentIds);
     }
 
 }

--- a/src/main/java/konkuk/thip/comment/adapter/out/persistence/repository/CommentJpaRepository.java
+++ b/src/main/java/konkuk/thip/comment/adapter/out/persistence/repository/CommentJpaRepository.java
@@ -24,9 +24,13 @@ public interface CommentJpaRepository extends JpaRepository<CommentJpaEntity, Lo
     @Query("UPDATE CommentJpaEntity c SET c.status = 'INACTIVE' WHERE c.userJpaEntity.userId = :userId")
     void softDeleteAllByUserId(@Param("userId") Long userId);
 
+//    @Query("SELECT c FROM CommentJpaEntity c JOIN FETCH c.postJpaEntity p " +
+//            "WHERE (TYPE(p) = FeedJpaEntity OR TYPE(p) = RecordJpaEntity OR TYPE(p) = VoteJpaEntity) " +
+//            "AND c.userJpaEntity.userId = :userId")
+//    List<CommentJpaEntity> findAllCommentsWithPostsByUserId(@Param("userId") Long userId);
+
     @Query("SELECT c FROM CommentJpaEntity c JOIN FETCH c.postJpaEntity p " +
-            "WHERE (TYPE(p) = FeedJpaEntity OR TYPE(p) = RecordJpaEntity OR TYPE(p) = VoteJpaEntity) " +
-            "AND c.userJpaEntity.userId = :userId")
+            "WHERE c.userJpaEntity.userId = :userId")
     List<CommentJpaEntity> findAllCommentsWithPostsByUserId(@Param("userId") Long userId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)

--- a/src/main/java/konkuk/thip/comment/adapter/out/persistence/repository/CommentJpaRepository.java
+++ b/src/main/java/konkuk/thip/comment/adapter/out/persistence/repository/CommentJpaRepository.java
@@ -30,4 +30,10 @@ public interface CommentJpaRepository extends JpaRepository<CommentJpaEntity, Lo
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE CommentJpaEntity c SET c.status = 'INACTIVE' WHERE c.postJpaEntity.postId IN :postIds")
     void softDeleteAllByPostIds(@Param("postIds") List<Long> postIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE CommentJpaEntity c " +
+            "SET c.likeCount = CASE WHEN c.likeCount > 0 THEN c.likeCount - 1 ELSE 0 END " +
+            "WHERE c.commentId IN :likedCommentIds")
+    void bulkDecrementLikeCountByIds(@Param("likedCommentIds") List<Long> likedCommentIds);
 }

--- a/src/main/java/konkuk/thip/comment/adapter/out/persistence/repository/CommentJpaRepository.java
+++ b/src/main/java/konkuk/thip/comment/adapter/out/persistence/repository/CommentJpaRepository.java
@@ -22,9 +22,11 @@ public interface CommentJpaRepository extends JpaRepository<CommentJpaEntity, Lo
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE CommentJpaEntity c SET c.status = 'INACTIVE' WHERE c.userJpaEntity.userId = :userId")
-    void deleteAllByUserId(@Param("userId") Long userId);
+    void softDeleteAllByUserId(@Param("userId") Long userId);
 
-    @Query("SELECT c FROM CommentJpaEntity c JOIN FETCH c.postJpaEntity WHERE c.userJpaEntity.userId = :userId")
+    @Query("SELECT c FROM CommentJpaEntity c JOIN FETCH c.postJpaEntity p " +
+            "WHERE (TYPE(p) = FeedJpaEntity OR TYPE(p) = RecordJpaEntity OR TYPE(p) = VoteJpaEntity) " +
+            "AND c.userJpaEntity.userId = :userId")
     List<CommentJpaEntity> findAllCommentsWithPostsByUserId(@Param("userId") Long userId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)

--- a/src/main/java/konkuk/thip/comment/adapter/out/persistence/repository/CommentJpaRepository.java
+++ b/src/main/java/konkuk/thip/comment/adapter/out/persistence/repository/CommentJpaRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CommentJpaRepository extends JpaRepository<CommentJpaEntity, Long>, CommentQueryRepository {
@@ -19,4 +20,14 @@ public interface CommentJpaRepository extends JpaRepository<CommentJpaEntity, Lo
     @Query("UPDATE CommentJpaEntity c SET c.status = 'INACTIVE' WHERE c.postJpaEntity.postId = :postId")
     void softDeleteAllByPostId(@Param("postId") Long postId);
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE CommentJpaEntity c SET c.status = 'INACTIVE' WHERE c.userJpaEntity.userId = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT c FROM CommentJpaEntity c JOIN FETCH c.postJpaEntity WHERE c.userJpaEntity.userId = :userId")
+    List<CommentJpaEntity> findAllCommentsWithPostsByUserId(@Param("userId") Long userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE CommentJpaEntity c SET c.status = 'INACTIVE' WHERE c.postJpaEntity.postId IN :postIds")
+    void softDeleteAllByPostIds(@Param("postIds") List<Long> postIds);
 }

--- a/src/main/java/konkuk/thip/comment/adapter/out/persistence/repository/CommentJpaRepository.java
+++ b/src/main/java/konkuk/thip/comment/adapter/out/persistence/repository/CommentJpaRepository.java
@@ -24,11 +24,6 @@ public interface CommentJpaRepository extends JpaRepository<CommentJpaEntity, Lo
     @Query("UPDATE CommentJpaEntity c SET c.status = 'INACTIVE' WHERE c.userJpaEntity.userId = :userId")
     void softDeleteAllByUserId(@Param("userId") Long userId);
 
-//    @Query("SELECT c FROM CommentJpaEntity c JOIN FETCH c.postJpaEntity p " +
-//            "WHERE (TYPE(p) = FeedJpaEntity OR TYPE(p) = RecordJpaEntity OR TYPE(p) = VoteJpaEntity) " +
-//            "AND c.userJpaEntity.userId = :userId")
-//    List<CommentJpaEntity> findAllCommentsWithPostsByUserId(@Param("userId") Long userId);
-
     @Query("SELECT c FROM CommentJpaEntity c JOIN FETCH c.postJpaEntity p " +
             "WHERE c.userJpaEntity.userId = :userId")
     List<CommentJpaEntity> findAllCommentsWithPostsByUserId(@Param("userId") Long userId);

--- a/src/main/java/konkuk/thip/comment/adapter/out/persistence/repository/CommentLikeJpaRepository.java
+++ b/src/main/java/konkuk/thip/comment/adapter/out/persistence/repository/CommentLikeJpaRepository.java
@@ -40,4 +40,28 @@ public interface CommentLikeJpaRepository extends JpaRepository<CommentLikeJpaEn
            )
            """)
     void deleteAllByPostId(@Param("postId") Long postId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+       DELETE FROM CommentLikeJpaEntity cl
+       WHERE cl.commentJpaEntity.commentId IN (
+           SELECT c.commentId FROM CommentJpaEntity c
+           WHERE c.userJpaEntity.userId = :userId
+       )
+       """)
+    void deleteAllByUserId(@Param("userId") Long userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("SELECT cl.commentJpaEntity.commentId FROM CommentLikeJpaEntity cl WHERE cl.userJpaEntity.userId = :userId")
+    List<Long> findAllCommentIdsByUserId(@Param("userId") Long userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+       DELETE FROM CommentLikeJpaEntity cl
+       WHERE cl.commentJpaEntity.commentId IN (
+           SELECT c.commentId FROM CommentJpaEntity c
+           WHERE c.postJpaEntity.postId IN :postIds
+       )
+       """)
+    void deleteAllByPostIds(@Param("postIds") List<Long> postIds);
 }

--- a/src/main/java/konkuk/thip/comment/adapter/out/persistence/repository/CommentLikeJpaRepository.java
+++ b/src/main/java/konkuk/thip/comment/adapter/out/persistence/repository/CommentLikeJpaRepository.java
@@ -49,9 +49,12 @@ public interface CommentLikeJpaRepository extends JpaRepository<CommentLikeJpaEn
            WHERE c.userJpaEntity.userId = :userId
        )
        """)
-    void deleteAllByUserId(@Param("userId") Long userId);
+    void deleteAllByCommentAuthorUserId(@Param("userId") Long userId);
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+     @Modifying(clearAutomatically = true, flushAutomatically = true)
+     @Query("DELETE FROM CommentLikeJpaEntity cl WHERE cl.userJpaEntity.userId = :userId")
+    void deleteAllByLikerUserId(@Param("userId") Long userId);
+
     @Query("SELECT cl.commentJpaEntity.commentId FROM CommentLikeJpaEntity cl WHERE cl.userJpaEntity.userId = :userId")
     List<Long> findAllCommentIdsByUserId(@Param("userId") Long userId);
 

--- a/src/main/java/konkuk/thip/comment/application/port/out/CommentCommandPort.java
+++ b/src/main/java/konkuk/thip/comment/application/port/out/CommentCommandPort.java
@@ -24,4 +24,6 @@ public interface CommentCommandPort {
     void delete(Comment comment);
 
     void softDeleteAllByPostId(Long postId);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/konkuk/thip/comment/application/port/out/CommentLikeCommandPort.java
+++ b/src/main/java/konkuk/thip/comment/application/port/out/CommentLikeCommandPort.java
@@ -5,4 +5,5 @@ public interface CommentLikeCommandPort {
     void save(Long userId, Long commentId);
     void delete(Long userId, Long commentId);
     void deleteAllByCommentId(Long commentId);
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode implements ResponseCode {
     USER_NOT_SIGNED_UP(HttpStatus.BAD_REQUEST, 70008, "가입되지 않은 사용자입니다."),
     USER_CANNOT_DELETE_ROOM_HOST(HttpStatus.BAD_REQUEST, 70009, "모집/진행 중인 방의 방장은 회원탈퇴를 할 수 없습니다."),
     USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, 70010, "이미 삭제된 사용자 입니다."),
+    USER_OAUTH2ID_CANNOT_BE_NULL(HttpStatus.INTERNAL_SERVER_ERROR, 70011, "유저의 OAuth2Id 값이 null일 수 없습니다."),
 
     /**
      * 75000 : follow error

--- a/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
@@ -49,8 +49,8 @@ public enum ErrorCode implements ResponseCode {
     USER_NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, 70006, "다른 사용자가 이미 사용중인 닉네임입니다."),
     USER_ALREADY_SIGNED_UP(HttpStatus.BAD_REQUEST, 70007, "이미 가입된 사용자입니다."),
     USER_NOT_SIGNED_UP(HttpStatus.BAD_REQUEST, 70008, "가입되지 않은 사용자입니다."),
-    USER_CANNOT_DELETE_ROOM_HOST(HttpStatus.BAD_REQUEST, 70009, "모집/진행 중인 방의 host는 회원탈퇴를 할 수 없습니다."),
-    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, 70010, "이미 삭제된 유저 입니다."),
+    USER_CANNOT_DELETE_ROOM_HOST(HttpStatus.BAD_REQUEST, 70009, "모집/진행 중인 방의 방장은 회원탈퇴를 할 수 없습니다."),
+    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, 70010, "이미 삭제된 사용자 입니다."),
 
     /**
      * 75000 : follow error

--- a/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode implements ResponseCode {
     AUTH_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, 40104, "로그인에 실패했습니다."),
     AUTH_UNSUPPORTED_SOCIAL_LOGIN(HttpStatus.UNAUTHORIZED, 40105, "지원하지 않는 소셜 로그인입니다."),
     AUTH_INVALID_LOGIN_TOKEN_KEY(HttpStatus.UNAUTHORIZED, 40106, "유효하지 않은 로그인 토큰 키입니다."),
+    AUTH_BLACKLIST_TOKEN(HttpStatus.UNAUTHORIZED, 40107, "블랙리스트에 등록된 토큰입니다."),
 
     JSON_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50100, "JSON 직렬화/역직렬화에 실패했습니다."),
     AWS_BUCKET_BASE_URL_NOT_CONFIGURED(HttpStatus.INTERNAL_SERVER_ERROR, 50101, "aws s3 bucket base url 설정이 누락되었습니다."),
@@ -48,6 +49,8 @@ public enum ErrorCode implements ResponseCode {
     USER_NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, 70006, "다른 사용자가 이미 사용중인 닉네임입니다."),
     USER_ALREADY_SIGNED_UP(HttpStatus.BAD_REQUEST, 70007, "이미 가입된 사용자입니다."),
     USER_NOT_SIGNED_UP(HttpStatus.BAD_REQUEST, 70008, "가입되지 않은 사용자입니다."),
+    USER_CANNOT_DELETE_ROOM_HOST(HttpStatus.BAD_REQUEST, 70009, "모집/진행 중인 방의 host는 회원탈퇴를 할 수 없습니다."),
+    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, 70010, "이미 삭제된 유저 입니다."),
 
     /**
      * 75000 : follow error

--- a/src/main/java/konkuk/thip/common/security/annotation/AuthToken.java
+++ b/src/main/java/konkuk/thip/common/security/annotation/AuthToken.java
@@ -1,0 +1,10 @@
+package konkuk.thip.common.security.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthToken {}

--- a/src/main/java/konkuk/thip/common/security/argument_resolver/AuthTokenArgumentResolver.java
+++ b/src/main/java/konkuk/thip/common/security/argument_resolver/AuthTokenArgumentResolver.java
@@ -32,7 +32,6 @@ public class AuthTokenArgumentResolver implements HandlerMethodArgumentResolver 
                                   WebDataBinderFactory binderFactory) {
 
         Object token = ((HttpServletRequest) webRequest.getNativeRequest()).getAttribute("token");
-        log.info("ArgumentResolver에서 토큰 추출: {}", token);
         if (token == null) {
             throw new AuthException(AUTH_TOKEN_NOT_FOUND);
         }

--- a/src/main/java/konkuk/thip/common/security/argument_resolver/AuthTokenArgumentResolver.java
+++ b/src/main/java/konkuk/thip/common/security/argument_resolver/AuthTokenArgumentResolver.java
@@ -1,0 +1,41 @@
+package konkuk.thip.common.security.argument_resolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import konkuk.thip.common.exception.AuthException;
+import konkuk.thip.common.security.annotation.AuthToken;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static konkuk.thip.common.exception.code.ErrorCode.AUTH_TOKEN_NOT_FOUND;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class AuthTokenArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthToken.class)
+            && parameter.getParameterType().equals(String.class);
+    }
+
+    @Override
+    public String resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+
+        Object token = ((HttpServletRequest) webRequest.getNativeRequest()).getAttribute("token");
+        log.info("ArgumentResolver에서 토큰 추출: {}", token);
+        if (token == null) {
+            throw new AuthException(AUTH_TOKEN_NOT_FOUND);
+        }
+        return (String) token;
+    }
+}

--- a/src/main/java/konkuk/thip/common/security/constant/AuthParameters.java
+++ b/src/main/java/konkuk/thip/common/security/constant/AuthParameters.java
@@ -12,6 +12,7 @@ public enum AuthParameters {
     GOOGLE_PROVIDER_ID_KEY("sub"),
     JWT_ACCESS_TOKEN_KEY("userId"),
     JWT_SIGNUP_TOKEN_KEY("oauth2Id"),
+    JWT_TOKEN_ATTRIBUTE("token"),
     REDIRECT_SIGNUP_URL("/signup"),
     REDIRECT_HOME_URL("/feed"),
 

--- a/src/main/java/konkuk/thip/common/security/util/JwtUtil.java
+++ b/src/main/java/konkuk/thip/common/security/util/JwtUtil.java
@@ -1,9 +1,6 @@
 package konkuk.thip.common.security.util;
 
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.*;
 import konkuk.thip.common.security.oauth2.LoginUser;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -86,4 +83,17 @@ public class JwtUtil {
         }
         return LoginUser.createExistingUser(oauth2Id, userId);
     }
+
+    public Date getExpirationAllowExpired(String token) {
+        try {
+            Jws<Claims> jwt = Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token);
+            return jwt.getPayload().getExpiration();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims().getExpiration();
+        }
+    }
+
 }

--- a/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
@@ -35,7 +35,11 @@ public enum SwaggerResponseDescription {
             USER_NICKNAME_UPDATE_TOO_FREQUENT,
             USER_NICKNAME_ALREADY_EXISTS
     ))),
-
+    USER_DELETE(new LinkedHashSet<>(Set.of(
+            USER_CANNOT_DELETE_ROOM_HOST,
+            USER_NOT_FOUND,
+            USER_ALREADY_DELETED
+    ))),
 
     // Follow
     CHANGE_FOLLOW_STATE(new LinkedHashSet<>(Set.of(
@@ -348,6 +352,7 @@ public enum SwaggerResponseDescription {
 //                AUTH_TOKEN_NOT_FOUND
 //                AUTH_LOGIN_FAILED,
 //                AUTH_UNSUPPORTED_SOCIAL_LOGIN,
+//                AUTH_BLACKLIST_TOKEN,
 
 //                JSON_PROCESSING_ERROR
         )));

--- a/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
@@ -38,7 +38,8 @@ public enum SwaggerResponseDescription {
     USER_DELETE(new LinkedHashSet<>(Set.of(
             USER_CANNOT_DELETE_ROOM_HOST,
             USER_NOT_FOUND,
-            USER_ALREADY_DELETED
+            USER_ALREADY_DELETED,
+            USER_OAUTH2ID_CANNOT_BE_NULL
     ))),
 
     // Follow

--- a/src/main/java/konkuk/thip/config/WebMvcConfig.java
+++ b/src/main/java/konkuk/thip/config/WebMvcConfig.java
@@ -1,5 +1,6 @@
 package konkuk.thip.config;
 
+import konkuk.thip.common.security.argument_resolver.AuthTokenArgumentResolver;
 import konkuk.thip.common.security.argument_resolver.Oauth2IdArgumentResolver;
 import konkuk.thip.common.security.argument_resolver.UserIdArgumentResolver;
 import lombok.RequiredArgsConstructor;
@@ -15,10 +16,12 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     private final UserIdArgumentResolver userIdArgumentResolver;
     private final Oauth2IdArgumentResolver oauth2IdArgumentResolver;
+    private final AuthTokenArgumentResolver authTokenArgumentResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(userIdArgumentResolver);
         resolvers.add(oauth2IdArgumentResolver);
+        resolvers.add(authTokenArgumentResolver);
     }
 }

--- a/src/main/java/konkuk/thip/feed/adapter/out/jpa/FeedJpaEntity.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/jpa/FeedJpaEntity.java
@@ -40,10 +40,6 @@ public class FeedJpaEntity extends PostJpaEntity {
     @Column(name = "content_list", columnDefinition = "TEXT")
     private ContentList contentList = ContentList.empty();
 
-    // 삭제용 피드 저장 양방향 매핑 관계
-    @OneToMany(mappedBy = "feedJpaEntity", cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private List<SavedFeedJpaEntity> savedFeeds = new ArrayList<>();
-
     @Column(name = "tag_list", columnDefinition = "TEXT")
     @Convert(converter = TagListJsonConverter.class)
     private TagList tagList = TagList.empty();

--- a/src/main/java/konkuk/thip/feed/adapter/out/persistence/FeedCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/persistence/FeedCommandPersistenceAdapter.java
@@ -95,7 +95,6 @@ public class FeedCommandPersistenceAdapter implements FeedCommandPort {
 
     @Override
     public void deleteAllFeedByUserId(Long userId) {
-
         // 1. 유저가 작성한 피드 게시글 ID 리스트 조회
         List<Long> feedIds = feedJpaRepository.findFeedIdsByUserId(userId);
         // 1. 유저가 작성한 피드 게시글 ID 리스트 조회
@@ -110,8 +109,8 @@ public class FeedCommandPersistenceAdapter implements FeedCommandPort {
         postLikeJpaRepository.deleteAllByPostIds(feedIds);
         // 4. 피드 저장 일괄 삭제
         savedFeedJpaRepository.deleteAllByFeedIds(feedIds);
-        // 5. 탈퇴한 유저가 작성한 피드 게시글 일괄 삭제
-        feedJpaRepository.deleteAllByUserId(userId);
+        // 5. 탈퇴한 유저가 작성한 피드 게시글 soft delete 일괄 처리
+        feedJpaRepository.softDeleteAllByUserId(userId);
     }
 
     @Override

--- a/src/main/java/konkuk/thip/feed/adapter/out/persistence/FeedCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/persistence/FeedCommandPersistenceAdapter.java
@@ -2,6 +2,8 @@ package konkuk.thip.feed.adapter.out.persistence;
 
 import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
 import konkuk.thip.book.adapter.out.persistence.repository.BookJpaRepository;
+import konkuk.thip.comment.adapter.out.persistence.repository.CommentJpaRepository;
+import konkuk.thip.comment.adapter.out.persistence.repository.CommentLikeJpaRepository;
 import konkuk.thip.common.exception.EntityNotFoundException;
 import konkuk.thip.feed.adapter.out.jpa.*;
 import konkuk.thip.feed.adapter.out.mapper.FeedMapper;
@@ -9,11 +11,13 @@ import konkuk.thip.feed.adapter.out.persistence.repository.FeedJpaRepository;
 import konkuk.thip.feed.adapter.out.persistence.repository.SavedFeedJpaRepository;
 import konkuk.thip.feed.application.port.out.FeedCommandPort;
 import konkuk.thip.feed.domain.Feed;
+import konkuk.thip.post.adapter.out.persistence.PostLikeJpaRepository;
 import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import static konkuk.thip.common.exception.code.ErrorCode.*;
@@ -26,6 +30,10 @@ public class FeedCommandPersistenceAdapter implements FeedCommandPort {
     private final UserJpaRepository userJpaRepository;
     private final BookJpaRepository bookJpaRepository;
     private final SavedFeedJpaRepository savedFeedJpaRepository;
+
+    private final CommentJpaRepository commentJpaRepository;
+    private final CommentLikeJpaRepository commentLikeJpaRepository;
+    private final PostLikeJpaRepository postLikeJpaRepository;
 
     private final FeedMapper feedMapper;
 
@@ -78,6 +86,32 @@ public class FeedCommandPersistenceAdapter implements FeedCommandPort {
     @Override
     public void deleteSavedFeed(Long userId, Long feedId) {
         savedFeedJpaRepository.deleteByUserIdAndFeedId(userId, feedId);
+    }
+
+    @Override
+    public void deleteAllSavedFeedByUserId(Long userId) {
+        savedFeedJpaRepository.deleteAllByUserId(userId);
+    }
+
+    @Override
+    public void deleteAllFeedByUserId(Long userId) {
+
+        // 1. 유저가 작성한 피드 게시글 ID 리스트 조회
+        List<Long> feedIds = feedJpaRepository.findFeedIdsByUserId(userId);
+        // 1. 유저가 작성한 피드 게시글 ID 리스트 조회
+        if (feedIds == null || feedIds.isEmpty()) {
+            return; // early return
+        }
+        // 2-1. 댓글 좋아요 일괄 삭제
+        commentLikeJpaRepository.deleteAllByPostIds(feedIds);
+        // 2-2. 댓글 soft delete 일괄 처리
+        commentJpaRepository.softDeleteAllByPostIds(feedIds);
+        // 3. 게시글 좋아요 일괄 삭제
+        postLikeJpaRepository.deleteAllByPostIds(feedIds);
+        // 4. 피드 저장 일괄 삭제
+        savedFeedJpaRepository.deleteAllByFeedIds(feedIds);
+        // 5. 탈퇴한 유저가 작성한 피드 게시글 일괄 삭제
+        feedJpaRepository.deleteAllByUserId(userId);
     }
 
     @Override

--- a/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/FeedJpaRepository.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/FeedJpaRepository.java
@@ -27,6 +27,6 @@ public interface FeedJpaRepository extends JpaRepository<FeedJpaEntity, Long>, F
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE FeedJpaEntity f SET f.status = 'INACTIVE' WHERE f.userJpaEntity.userId = :userId")
-    void deleteAllByUserId(@Param("userId") Long userId);
+    void softDeleteAllByUserId(@Param("userId") Long userId);
 
 }

--- a/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/FeedJpaRepository.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/FeedJpaRepository.java
@@ -2,9 +2,11 @@ package konkuk.thip.feed.adapter.out.persistence.repository;
 
 import konkuk.thip.feed.adapter.out.jpa.FeedJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FeedJpaRepository extends JpaRepository<FeedJpaEntity, Long>, FeedQueryRepository {
@@ -19,4 +21,12 @@ public interface FeedJpaRepository extends JpaRepository<FeedJpaEntity, Long>, F
 
     @Query("SELECT COUNT(f) FROM FeedJpaEntity f WHERE f.userJpaEntity.userId = :userId AND f.isPublic = TRUE")
     long countPublicFeedsByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT f.postId FROM FeedJpaEntity f WHERE f.userJpaEntity.userId = :userId")
+    List<Long> findFeedIdsByUserId(@Param("userId") Long userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE FeedJpaEntity f SET f.status = 'INACTIVE' WHERE f.userJpaEntity.userId = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
+
 }

--- a/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/SavedFeedJpaRepository.java
+++ b/src/main/java/konkuk/thip/feed/adapter/out/persistence/repository/SavedFeedJpaRepository.java
@@ -25,7 +25,15 @@ public interface SavedFeedJpaRepository extends JpaRepository<SavedFeedJpaEntity
     @Query("DELETE FROM SavedFeedJpaEntity sf WHERE sf.feedJpaEntity.postId = :feedId")
     int deleteAllByFeedId(@Param("feedId") Long feedId);
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM SavedFeedJpaEntity sf WHERE sf.userJpaEntity.userId = :userId")
+    int deleteAllByUserId(@Param("userId") Long userId);
+
     @Query("SELECT CASE WHEN COUNT(s) > 0 THEN true ELSE false END FROM SavedFeedJpaEntity s " +
             "WHERE s.userJpaEntity.userId = :userId AND s.feedJpaEntity.postId = :feedId")
     boolean existsByUserIdAndFeedId(@Param("userId") Long userId, @Param("feedId") Long feedId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM SavedFeedJpaEntity sf WHERE sf.feedJpaEntity.postId IN :feedIds")
+    void deleteAllByFeedIds(@Param("feedIds") List<Long> feedIds);
 }

--- a/src/main/java/konkuk/thip/feed/application/port/out/FeedCommandPort.java
+++ b/src/main/java/konkuk/thip/feed/application/port/out/FeedCommandPort.java
@@ -19,4 +19,6 @@ public interface FeedCommandPort {
     void delete(Feed feed);
     void saveSavedFeed(Long userId, Long feedId);
     void deleteSavedFeed(Long userId, Long feedId);
+    void deleteAllSavedFeedByUserId(Long userId);
+    void deleteAllFeedByUserId(Long userId);
 }

--- a/src/main/java/konkuk/thip/post/adapter/out/jpa/PostJpaEntity.java
+++ b/src/main/java/konkuk/thip/post/adapter/out/jpa/PostJpaEntity.java
@@ -43,14 +43,6 @@ public abstract class PostJpaEntity extends BaseJpaEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private UserJpaEntity userJpaEntity;
 
-    // 삭제용 게시물 댓글 양방향 매핑 관계
-    @OneToMany(mappedBy = "postJpaEntity", cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private List<CommentJpaEntity> commentList = new ArrayList<>();
-
-    // 삭제용 게시물 좋아요 양방향 매핑 관계
-    @OneToMany(mappedBy = "postJpaEntity", cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private List<PostLikeJpaEntity> postLikeList = new ArrayList<>();
-
     public PostJpaEntity(String content, Integer likeCount, Integer commentCount, UserJpaEntity userJpaEntity) {
         this.content = content;
         this.likeCount = likeCount;

--- a/src/main/java/konkuk/thip/post/adapter/out/jpa/PostJpaEntity.java
+++ b/src/main/java/konkuk/thip/post/adapter/out/jpa/PostJpaEntity.java
@@ -1,16 +1,13 @@
 package konkuk.thip.post.adapter.out.jpa;
 
 import jakarta.persistence.*;
-import konkuk.thip.comment.adapter.out.jpa.CommentJpaEntity;
 import konkuk.thip.common.entity.BaseJpaEntity;
 import konkuk.thip.common.exception.InvalidStateException;
 import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
+import lombok.Setter;
 
 import static konkuk.thip.common.entity.StatusType.INACTIVE;
 import static konkuk.thip.common.exception.code.ErrorCode.POST_ALREADY_DELETED;
@@ -31,8 +28,18 @@ public abstract class PostJpaEntity extends BaseJpaEntity {
     @Column(length = 6100, nullable = false)
     protected String content;
 
+    /**
+     * -- SETTER --
+     *  회원 탈퇴용
+     */
+    @Setter
     protected Integer likeCount = 0;
 
+    /**
+     * -- SETTER --
+     *  회원 탈퇴용
+     */
+    @Setter
     protected Integer commentCount = 0;
 
     // type 구분을 위한 조회용 컬럼

--- a/src/main/java/konkuk/thip/post/adapter/out/persistence/PostLikeJpaRepository.java
+++ b/src/main/java/konkuk/thip/post/adapter/out/persistence/PostLikeJpaRepository.java
@@ -1,5 +1,6 @@
 package konkuk.thip.post.adapter.out.persistence;
 
+import konkuk.thip.post.adapter.out.jpa.PostJpaEntity;
 import konkuk.thip.post.adapter.out.jpa.PostLikeJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -7,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Set;
 
 @Repository
@@ -28,4 +30,15 @@ public interface PostLikeJpaRepository extends JpaRepository<PostLikeJpaEntity, 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM PostLikeJpaEntity pl WHERE pl.postJpaEntity.postId = :postId")
     void deleteAllByPostId(@Param("postId") Long postId);
+
+    @Query("SELECT pl.postJpaEntity FROM PostLikeJpaEntity pl JOIN pl.postJpaEntity WHERE pl.userJpaEntity.userId = :userId")
+    List<PostJpaEntity> findAllPostsWithTypeByUserId(@Param("userId") Long userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM PostLikeJpaEntity pl WHERE pl.userJpaEntity.userId = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM PostLikeJpaEntity pl WHERE pl.postJpaEntity.postId IN :postIds")
+    void deleteAllByPostIds(@Param("postIds") List<Long> postIds);
 }

--- a/src/main/java/konkuk/thip/post/application/port/out/PostLikeCommandPort.java
+++ b/src/main/java/konkuk/thip/post/application/port/out/PostLikeCommandPort.java
@@ -6,4 +6,5 @@ public interface PostLikeCommandPort {
     void save(Long userId, Long postId, PostType postType);
     void delete(Long userId, Long postId);
     void deleteAllByPostId(Long postId);
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/konkuk/thip/recentSearch/adapter/out/persistence/RecentSearchCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/recentSearch/adapter/out/persistence/RecentSearchCommandPersistenceAdapter.java
@@ -56,5 +56,10 @@ public class RecentSearchCommandPersistenceAdapter implements RecentSearchComman
         recentSearchJpaRepository.updateModifiedAt(recentSearch.getId());
     }
 
+    @Override
+    public void deleteAllByUserId(Long userId) {
+        recentSearchJpaRepository.deleteAllByUserId(userId);
+    }
+
 
 }

--- a/src/main/java/konkuk/thip/recentSearch/adapter/out/persistence/repository/RecentSearchJpaRepository.java
+++ b/src/main/java/konkuk/thip/recentSearch/adapter/out/persistence/repository/RecentSearchJpaRepository.java
@@ -12,4 +12,8 @@ public interface RecentSearchJpaRepository extends JpaRepository<RecentSearchJpa
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE RecentSearchJpaEntity r SET r.modifiedAt = CURRENT_TIMESTAMP WHERE r.recentSearchId = :recentSearchId")
     void updateModifiedAt(@Param("recentSearchId") Long recentSearchId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM RecentSearchJpaEntity r WHERE r.userJpaEntity.userId = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/konkuk/thip/recentSearch/application/port/out/RecentSearchCommandPort.java
+++ b/src/main/java/konkuk/thip/recentSearch/application/port/out/RecentSearchCommandPort.java
@@ -21,4 +21,6 @@ public interface RecentSearchCommandPort {
     void delete(Long id);
 
     void touch(RecentSearch recentSearch); // modifiedAt 갱신용 메서드
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/konkuk/thip/room/adapter/out/jpa/RoomJpaEntity.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/jpa/RoomJpaEntity.java
@@ -46,6 +46,11 @@ public class RoomJpaEntity extends BaseJpaEntity {
     @Column(name = "recruit_count",nullable = false)
     private int recruitCount;
 
+    /**
+     * -- SETTER --
+     *  회원 탈퇴용
+     */
+    @Setter
     @Builder.Default
     @Column(name = "member_count",nullable = false)
     private int memberCount = 1;

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomParticipantCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomParticipantCommandPersistenceAdapter.java
@@ -77,6 +77,8 @@ public class RoomParticipantCommandPersistenceAdapter implements RoomParticipant
 
     @Override
     public void deleteAllByUserId(Long userId) {
+        // 방 참여 관계 삭제 (member는 진행/모집/만료, host는 만료)
+        // 방 멤버수 감소, 방 진행도 업데이트
 
         // 1. 유저가 참여한 방 ID 리스트 조회
         List<Long> roomIds = roomParticipantJpaRepository.findRoomIdsByUserId(userId);
@@ -84,7 +86,7 @@ public class RoomParticipantCommandPersistenceAdapter implements RoomParticipant
             return; // early return
         }
         // 2. 유저의 모든 방 참여 관계 일괄 삭제
-        roomParticipantJpaRepository.deleteAllByUserId(userId);
+        roomParticipantJpaRepository.softDeleteAllByUserId(userId);
         // 3. 해당 ID들로 JPA 엔티티 직접 조회
         List<RoomJpaEntity> roomJpaEntities = roomJpaRepository.findAllByIds(roomIds);
 
@@ -104,7 +106,6 @@ public class RoomParticipantCommandPersistenceAdapter implements RoomParticipant
             room.setMemberCount(roomParticipantEntities.size()); // 남은 참가자 수로 설정
 
         }
-        roomJpaRepository.saveAll(roomJpaEntities);
     }
 
     @Override

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomParticipantCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomParticipantCommandPersistenceAdapter.java
@@ -8,7 +8,7 @@ import konkuk.thip.room.adapter.out.mapper.RoomParticipantMapper;
 import konkuk.thip.room.adapter.out.persistence.repository.RoomJpaRepository;
 import konkuk.thip.room.adapter.out.persistence.repository.roomparticipant.RoomParticipantJpaRepository;
 import konkuk.thip.room.application.port.out.RoomParticipantCommandPort;
-import konkuk.thip.room.adapter.out.persistence.projection.RoomStatsRow;
+import konkuk.thip.room.adapter.out.persistence.projection.RoomAggregateProjection;
 import konkuk.thip.room.domain.RoomParticipant;
 import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
@@ -90,10 +90,10 @@ public class RoomParticipantCommandPersistenceAdapter implements RoomParticipant
         roomParticipantJpaRepository.softDeleteAllByUserId(userId);
 
         // 3. 남은 ACTIVE 참여자 기준 방별 평균/인원 집계
-        List<RoomStatsRow> stats = roomParticipantJpaRepository.aggregateStatsByRoomIds(roomIds);
+        List<RoomAggregateProjection> stats = roomParticipantJpaRepository.aggregateStatsByRoomIds(roomIds);
 
         // 4. 방 정보(진행률, 멤버수) 업데이트
-        for (RoomStatsRow row : stats) {
+        for (RoomAggregateProjection row : stats) {
             roomJpaRepository.updateRoomStats(
                     row.getRoomId(),
                     row.getAvgPercentage() == null ? 0.0 : row.getAvgPercentage(),

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomParticipantCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomParticipantCommandPersistenceAdapter.java
@@ -71,6 +71,43 @@ public class RoomParticipantCommandPersistenceAdapter implements RoomParticipant
     }
 
     @Override
+    public boolean existsHostUserInActiveRoom(Long userId) {
+        return roomParticipantJpaRepository.existsHostUserInActiveRoom(userId);
+    }
+
+    @Override
+    public void deleteAllByUserId(Long userId) {
+
+        // 1. 유저가 참여한 방 ID 리스트 조회
+        List<Long> roomIds = roomParticipantJpaRepository.findRoomIdsByUserId(userId);
+        if (roomIds.isEmpty()) {
+            return; // early return
+        }
+        // 2. 유저의 모든 방 참여 관계 일괄 삭제
+        roomParticipantJpaRepository.deleteAllByUserId(userId);
+        // 3. 해당 ID들로 JPA 엔티티 직접 조회
+        List<RoomJpaEntity> roomJpaEntities = roomJpaRepository.findAllByIds(roomIds);
+
+        // 4. 유저가 탈퇴 처리된 각 방에 대해 진행률 및 멤버 수 업데이트
+        for (RoomJpaEntity room : roomJpaEntities) {
+            // 현재 방의 참가자 전체 조회 (탈퇴한 유저는 이미 삭제됨)
+            List<RoomParticipantJpaEntity> roomParticipantEntities = roomParticipantJpaRepository.findAllByRoomId(room.getRoomId());
+
+            // 평균 진행률 계산
+            double totalProgress = roomParticipantEntities.stream()
+                    .mapToDouble(RoomParticipantJpaEntity::getUserPercentage)
+                    .sum();
+            double avgProgress = roomParticipantEntities.isEmpty() ? 0.0 : (totalProgress / roomParticipantEntities.size());
+
+            // 방 정보(진행률, 멤버수) 업데이트
+            room.updateRoomPercentage(avgProgress);
+            room.setMemberCount(roomParticipantEntities.size()); // 남은 참가자 수로 설정
+
+        }
+        roomJpaRepository.saveAll(roomJpaEntities);
+    }
+
+    @Override
     public Optional<RoomParticipant> findByUserIdAndRoomIdOptional(Long userId, Long roomId) {
         return roomParticipantJpaRepository.findByUserIdAndRoomId(userId, roomId)
                 .map(roomParticipantMapper::toDomainEntity);

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/projection/RoomAggregateProjection.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/projection/RoomAggregateProjection.java
@@ -1,6 +1,6 @@
 package konkuk.thip.room.adapter.out.persistence.projection;
 
-public interface RoomStatsRow {
+public interface RoomAggregateProjection {
     Long getRoomId();
     Double getAvgPercentage();
     Long getMemberCount();

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/projection/RoomStatsRow.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/projection/RoomStatsRow.java
@@ -1,0 +1,7 @@
+package konkuk.thip.room.adapter.out.persistence.projection;
+
+public interface RoomStatsRow {
+    Long getRoomId();
+    Double getAvgPercentage();
+    Long getMemberCount();
+}

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomJpaRepository.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomJpaRepository.java
@@ -2,11 +2,11 @@ package konkuk.thip.room.adapter.out.persistence.repository;
 
 import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
 
 public interface RoomJpaRepository extends JpaRepository<RoomJpaEntity, Long>, RoomQueryRepository {
@@ -21,6 +21,12 @@ public interface RoomJpaRepository extends JpaRepository<RoomJpaEntity, Long>, R
             "AND r.startDate > :currentDate")
     int countActiveRoomsByBookIdAndStartDateAfter(@Param("isbn") String isbn, @Param("currentDate") LocalDate currentDate);
 
-    @Query("SELECT r FROM RoomJpaEntity r WHERE r.roomId IN :roomIds")
-    List<RoomJpaEntity> findAllByIds(@Param("roomIds") List<Long> roomIds);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+           update RoomJpaEntity r
+           set r.roomPercentage = :avg,
+               r.memberCount    = :count
+           where r.roomId = :roomId
+        """)
+    void updateRoomStats(@Param("roomId") Long roomId, @Param("avg") double avg, @Param("count") int count);
 }

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomJpaRepository.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomJpaRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface RoomJpaRepository extends JpaRepository<RoomJpaEntity, Long>, RoomQueryRepository {
@@ -20,4 +21,6 @@ public interface RoomJpaRepository extends JpaRepository<RoomJpaEntity, Long>, R
             "AND r.startDate > :currentDate")
     int countActiveRoomsByBookIdAndStartDateAfter(@Param("isbn") String isbn, @Param("currentDate") LocalDate currentDate);
 
+    @Query("SELECT r FROM RoomJpaEntity r WHERE r.roomId IN :roomIds")
+    List<RoomJpaEntity> findAllByIds(@Param("roomIds") List<Long> roomIds);
 }

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/roomparticipant/RoomParticipantJpaRepository.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/roomparticipant/RoomParticipantJpaRepository.java
@@ -1,7 +1,7 @@
 package konkuk.thip.room.adapter.out.persistence.repository.roomparticipant;
 
 import konkuk.thip.room.adapter.out.jpa.RoomParticipantJpaEntity;
-import konkuk.thip.room.adapter.out.persistence.projection.RoomStatsRow;
+import konkuk.thip.room.adapter.out.persistence.projection.RoomAggregateProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -56,5 +56,5 @@ public interface RoomParticipantJpaRepository extends JpaRepository<RoomParticip
            where rp.roomJpaEntity.roomId in :roomIds
            group by rp.roomJpaEntity.roomId
         """)
-    List<RoomStatsRow> aggregateStatsByRoomIds(@Param("roomIds") List<Long> roomIds);
+    List<RoomAggregateProjection> aggregateStatsByRoomIds(@Param("roomIds") List<Long> roomIds);
 }

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/roomparticipant/RoomParticipantJpaRepository.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/roomparticipant/RoomParticipantJpaRepository.java
@@ -41,7 +41,7 @@ public interface RoomParticipantJpaRepository extends JpaRepository<RoomParticip
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE RoomParticipantJpaEntity rp SET rp.status = 'INACTIVE' WHERE rp.userJpaEntity.userId = :userId")
-    void deleteAllByUserId(@Param("userId") Long userId);
+    void softDeleteAllByUserId(@Param("userId") Long userId);
 
     @Query("SELECT rp.roomJpaEntity.roomId FROM RoomParticipantJpaEntity rp WHERE rp.userJpaEntity.userId = :userId")
     List<Long> findRoomIdsByUserId(@Param("userId") Long userId);

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/roomparticipant/RoomParticipantJpaRepository.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/roomparticipant/RoomParticipantJpaRepository.java
@@ -1,6 +1,7 @@
 package konkuk.thip.room.adapter.out.persistence.repository.roomparticipant;
 
 import konkuk.thip.room.adapter.out.jpa.RoomParticipantJpaEntity;
+import konkuk.thip.room.adapter.out.persistence.projection.RoomStatsRow;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -45,4 +46,15 @@ public interface RoomParticipantJpaRepository extends JpaRepository<RoomParticip
 
     @Query("SELECT rp.roomJpaEntity.roomId FROM RoomParticipantJpaEntity rp WHERE rp.userJpaEntity.userId = :userId")
     List<Long> findRoomIdsByUserId(@Param("userId") Long userId);
+
+
+    @Query("""
+            select rp.roomJpaEntity.roomId as roomId,
+                  avg(rp.userPercentage)  as avgPercentage,
+                  count(rp)               as memberCount
+           from RoomParticipantJpaEntity rp
+           where rp.roomJpaEntity.roomId in :roomIds
+           group by rp.roomJpaEntity.roomId
+        """)
+    List<RoomStatsRow> aggregateStatsByRoomIds(@Param("roomIds") List<Long> roomIds);
 }

--- a/src/main/java/konkuk/thip/room/application/port/out/RoomParticipantCommandPort.java
+++ b/src/main/java/konkuk/thip/room/application/port/out/RoomParticipantCommandPort.java
@@ -24,4 +24,9 @@ public interface RoomParticipantCommandPort {
     void deleteByUserIdAndRoomId(Long userId, Long roomId);
 
     void update(RoomParticipant roomParticipant);
+
+    boolean existsHostUserInActiveRoom(Long userId);
+
+    void deleteAllByUserId(Long userId);
+
 }

--- a/src/main/java/konkuk/thip/roompost/adapter/in/web/response/RoomPostSearchResponse.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/in/web/response/RoomPostSearchResponse.java
@@ -34,11 +34,11 @@ public record RoomPostSearchResponse(
         public record VoteItemDto(
                 Long voteItemId,
                 String itemName,
-                int percentage,
+                int count,
                 boolean isVoted
         ) {
-            public static VoteItemDto of(Long voteItemId, String itemName, int percentage, boolean isVoted) {
-                return new VoteItemDto(voteItemId, itemName, percentage, isVoted);
+            public static VoteItemDto of(Long voteItemId, String itemName, int count, boolean isVoted) {
+                return new VoteItemDto(voteItemId, itemName, count, isVoted);
             }
         }
     }

--- a/src/main/java/konkuk/thip/roompost/adapter/out/jpa/VoteItemJpaEntity.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/jpa/VoteItemJpaEntity.java
@@ -21,6 +21,11 @@ public class VoteItemJpaEntity extends BaseJpaEntity {
     @Column(name = "item_name",length = 70, nullable = false)
     private String itemName;
 
+    /**
+     * -- SETTER --
+     *  회원 탈퇴용
+     */
+    @Setter
     @Builder.Default
     @Column(nullable = false)
     private int count = 0;

--- a/src/main/java/konkuk/thip/roompost/adapter/out/persistence/AttendanceCheckCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/persistence/AttendanceCheckCommandPersistenceAdapter.java
@@ -58,6 +58,6 @@ public class AttendanceCheckCommandPersistenceAdapter implements AttendanceCheck
 
     @Override
     public void deleteAllByUserId(Long userId) {
-        attendanceCheckJpaRepository.deleteAllByUserId(userId);
+        attendanceCheckJpaRepository.softDeleteAllByUserId(userId);
     }
 }

--- a/src/main/java/konkuk/thip/roompost/adapter/out/persistence/AttendanceCheckCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/persistence/AttendanceCheckCommandPersistenceAdapter.java
@@ -55,4 +55,9 @@ public class AttendanceCheckCommandPersistenceAdapter implements AttendanceCheck
 
         attendanceCheckJpaRepository.delete(attendanceCheckJpaEntity);
     }
+
+    @Override
+    public void deleteAllByUserId(Long userId) {
+        attendanceCheckJpaRepository.deleteAllByUserId(userId);
+    }
 }

--- a/src/main/java/konkuk/thip/roompost/adapter/out/persistence/RecordCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/persistence/RecordCommandPersistenceAdapter.java
@@ -79,8 +79,8 @@ public class RecordCommandPersistenceAdapter implements RecordCommandPort {
         commentJpaRepository.softDeleteAllByPostIds(recordIds);
         // 3. 게시글 좋아요 일괄 삭제
         postLikeJpaRepository.deleteAllByPostIds(recordIds);
-        // 4. 탈퇴한 유저가 작성한 기록 게시글 일괄 삭제
-        recordJpaRepository.deleteAllByUserId(userId);
+        // 4. 탈퇴한 유저가 작성한 기록 soft delete 일괄 처리
+        recordJpaRepository.softDeleteAllByUserId(userId);
     }
 
     @Override

--- a/src/main/java/konkuk/thip/roompost/adapter/out/persistence/RecordCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/persistence/RecordCommandPersistenceAdapter.java
@@ -1,6 +1,9 @@
 package konkuk.thip.roompost.adapter.out.persistence;
 
+import konkuk.thip.comment.adapter.out.persistence.repository.CommentJpaRepository;
+import konkuk.thip.comment.adapter.out.persistence.repository.CommentLikeJpaRepository;
 import konkuk.thip.common.exception.EntityNotFoundException;
+import konkuk.thip.post.adapter.out.persistence.PostLikeJpaRepository;
 import konkuk.thip.roompost.adapter.out.jpa.RecordJpaEntity;
 import konkuk.thip.roompost.adapter.out.mapper.RecordMapper;
 import konkuk.thip.roompost.adapter.out.persistence.repository.record.RecordJpaRepository;
@@ -13,6 +16,7 @@ import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import static konkuk.thip.common.exception.code.ErrorCode.*;
@@ -24,6 +28,11 @@ public class RecordCommandPersistenceAdapter implements RecordCommandPort {
     private final RecordJpaRepository recordJpaRepository;
     private final UserJpaRepository userJpaRepository;
     private final RoomJpaRepository roomJpaRepository;
+
+    private final CommentJpaRepository commentJpaRepository;
+    private final CommentLikeJpaRepository commentLikeJpaRepository;
+    private final PostLikeJpaRepository postLikeJpaRepository;
+
     private final RecordMapper recordMapper;
 
     @Override
@@ -55,6 +64,23 @@ public class RecordCommandPersistenceAdapter implements RecordCommandPort {
 
         recordJpaEntity.softDelete();
         recordJpaRepository.save(recordJpaEntity);
+    }
+
+    @Override
+    public void deleteAllByUserId(Long userId) {
+        // 1. 유저가 작성한 피드 게시글 ID 리스트 조회
+        List<Long> recordIds = recordJpaRepository.findRecordIdsByUserId(userId);
+        if (recordIds == null || recordIds.isEmpty()) {
+            return; // early return
+        }
+        // 2-1. 댓글 좋아요 일괄 삭제
+        commentLikeJpaRepository.deleteAllByPostIds(recordIds);
+        // 2-2. 댓글 soft delete 일괄 처리
+        commentJpaRepository.softDeleteAllByPostIds(recordIds);
+        // 3. 게시글 좋아요 일괄 삭제
+        postLikeJpaRepository.deleteAllByPostIds(recordIds);
+        // 4. 탈퇴한 유저가 작성한 기록 게시글 일괄 삭제
+        recordJpaRepository.deleteAllByUserId(userId);
     }
 
     @Override

--- a/src/main/java/konkuk/thip/roompost/adapter/out/persistence/VoteCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/persistence/VoteCommandPersistenceAdapter.java
@@ -165,12 +165,8 @@ public class VoteCommandPersistenceAdapter implements VoteCommandPort {
         }
         // 2. 투표 참여 관계 삭제
         voteParticipantJpaRepository.deleteAllByUserId(userId);
-        // 3. 해당 ID들로 JPA 엔티티 직접 조회
-        List<VoteItemJpaEntity> voteItemEntities = voteItemJpaRepository.findAllById(voteItemIds);
-        // 4. 엔티티에서 직접 투표 항목 수 감소
-        voteItemEntities.forEach(entity ->
-            entity.setCount(Math.max(0, entity.getCount() - 1)));
-        voteItemJpaRepository.saveAll(voteItemEntities);
+        // 3. 탈퇴 유저가 투표 했던 투표 항목들의 득표 수 감소
+        voteItemJpaRepository.bulkDecrementLikeCount(voteItemIds);
     }
 
     @Override
@@ -190,8 +186,8 @@ public class VoteCommandPersistenceAdapter implements VoteCommandPort {
         voteParticipantJpaRepository.deleteAllByVoteIds(voteIds);
         // 4-2. 투표 항목 일괄 삭제
         voteItemJpaRepository.deleteAllByVoteIds(voteIds);
-        // 5. 탈퇴한 유저가 작성한 투표 게시글 일괄 삭제
-        voteJpaRepository.deleteAllByUserId(userId);
+        // 5. 탈퇴한 유저가 작성한 투표 soft delete 일괄 처리
+        voteJpaRepository.softDeleteAllByUserId(userId);
     }
 
 

--- a/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/attendancecheck/AttendanceCheckJpaRepository.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/attendancecheck/AttendanceCheckJpaRepository.java
@@ -26,5 +26,5 @@ public interface AttendanceCheckJpaRepository extends JpaRepository<AttendanceCh
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE AttendanceCheckJpaEntity a SET a.status = 'INACTIVE' WHERE a.userJpaEntity.userId = :userId")
-    void deleteAllByUserId(@Param("userId") Long userId);
+    void softDeleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/attendancecheck/AttendanceCheckJpaRepository.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/attendancecheck/AttendanceCheckJpaRepository.java
@@ -2,6 +2,7 @@ package konkuk.thip.roompost.adapter.out.persistence.repository.attendancecheck;
 
 import konkuk.thip.roompost.adapter.out.jpa.AttendanceCheckJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -22,4 +23,8 @@ public interface AttendanceCheckJpaRepository extends JpaRepository<AttendanceCh
             "AND a.createdAt >= :startOfDay " +
             "AND a.createdAt < :endOfDay")
     int countByUserIdAndRoomIdAndCreatedAtBetween(@Param("userId") Long userId, @Param("roomId") Long roomId, @Param("startOfDay") LocalDateTime startOfDay, @Param("endOfDay") LocalDateTime endOfDay);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE AttendanceCheckJpaEntity a SET a.status = 'INACTIVE' WHERE a.userJpaEntity.userId = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/record/RecordJpaRepository.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/record/RecordJpaRepository.java
@@ -2,7 +2,11 @@ package konkuk.thip.roompost.adapter.out.persistence.repository.record;
 
 import konkuk.thip.roompost.adapter.out.jpa.RecordJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RecordJpaRepository extends JpaRepository<RecordJpaEntity, Long>, RecordQueryRepository {
@@ -11,4 +15,11 @@ public interface RecordJpaRepository extends JpaRepository<RecordJpaEntity, Long
      * 소프트 딜리트 적용 대상 entity 단건 조회 메서드
      */
     Optional<RecordJpaEntity> findByPostId(Long postId);
+
+    @Query("SELECT r.postId FROM RecordJpaEntity r WHERE r.userJpaEntity.userId = :userId")
+    List<Long> findRecordIdsByUserId(@Param("userId") Long userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE RecordJpaEntity r SET r.status = 'INACTIVE' WHERE r.userJpaEntity.userId = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/record/RecordJpaRepository.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/record/RecordJpaRepository.java
@@ -21,5 +21,5 @@ public interface RecordJpaRepository extends JpaRepository<RecordJpaEntity, Long
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE RecordJpaEntity r SET r.status = 'INACTIVE' WHERE r.userJpaEntity.userId = :userId")
-    void deleteAllByUserId(@Param("userId") Long userId);
+    void softDeleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/vote/VoteItemJpaRepository.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/vote/VoteItemJpaRepository.java
@@ -16,7 +16,7 @@ public interface VoteItemJpaRepository extends JpaRepository<VoteItemJpaEntity, 
     @Query("DELETE FROM VoteItemJpaEntity vi WHERE vi.voteJpaEntity.postId = :voteId")
     void deleteAllByVoteId(@Param("voteId") Long voteId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM VoteItemJpaEntity vi WHERE vi.voteJpaEntity.postId IN :voteIds")
     void deleteAllByVoteIds(@Param("voteIds") List<Long> voteIds);
 }

--- a/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/vote/VoteItemJpaRepository.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/vote/VoteItemJpaRepository.java
@@ -15,4 +15,8 @@ public interface VoteItemJpaRepository extends JpaRepository<VoteItemJpaEntity, 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM VoteItemJpaEntity vi WHERE vi.voteJpaEntity.postId = :voteId")
     void deleteAllByVoteId(@Param("voteId") Long voteId);
+
+    @Modifying
+    @Query("DELETE FROM VoteItemJpaEntity vi WHERE vi.voteJpaEntity.postId IN :voteIds")
+    void deleteAllByVoteIds(@Param("voteIds") List<Long> voteIds);
 }

--- a/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/vote/VoteItemJpaRepository.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/vote/VoteItemJpaRepository.java
@@ -19,4 +19,10 @@ public interface VoteItemJpaRepository extends JpaRepository<VoteItemJpaEntity, 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM VoteItemJpaEntity vi WHERE vi.voteJpaEntity.postId IN :voteIds")
     void deleteAllByVoteIds(@Param("voteIds") List<Long> voteIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE VoteItemJpaEntity vi " +
+            "SET vi.count = CASE WHEN vi.count > 0 THEN vi.count - 1 ELSE 0 END " +
+            "WHERE vi.voteItemId IN :voteItemIds")
+    void bulkDecrementLikeCount(@Param("voteItemIds") List<Long> voteItemIds);
 }

--- a/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/vote/VoteJpaRepository.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/vote/VoteJpaRepository.java
@@ -1,8 +1,12 @@
 package konkuk.thip.roompost.adapter.out.persistence.repository.vote;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import konkuk.thip.roompost.adapter.out.jpa.VoteJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface VoteJpaRepository extends JpaRepository<VoteJpaEntity, Long>, VoteQueryRepository {
@@ -11,4 +15,11 @@ public interface VoteJpaRepository extends JpaRepository<VoteJpaEntity, Long>, V
      * 소프트 딜리트 적용 대상 entity 단건 조회 메서드
      */
     Optional<VoteJpaEntity> findByPostId(Long postId);
+
+    @Query("SELECT v.postId FROM VoteJpaEntity v WHERE v.userJpaEntity.userId = :userId")
+    List<Long> findVoteIdsByUserId(@Param("userId") Long userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE VoteJpaEntity v SET v.status = 'INACTIVE' WHERE v.userJpaEntity.userId = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/vote/VoteJpaRepository.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/vote/VoteJpaRepository.java
@@ -21,5 +21,5 @@ public interface VoteJpaRepository extends JpaRepository<VoteJpaEntity, Long>, V
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE VoteJpaEntity v SET v.status = 'INACTIVE' WHERE v.userJpaEntity.userId = :userId")
-    void deleteAllByUserId(@Param("userId") Long userId);
+    void softDeleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/vote/VoteParticipantJpaRepository.java
+++ b/src/main/java/konkuk/thip/roompost/adapter/out/persistence/repository/vote/VoteParticipantJpaRepository.java
@@ -7,12 +7,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface VoteParticipantJpaRepository extends JpaRepository<VoteParticipantJpaEntity, Long>, VoteParticipantQueryRepository {
     @Query("SELECT vp FROM VoteParticipantJpaEntity vp WHERE vp.userJpaEntity.userId = :userId AND vp.voteItemJpaEntity.voteItemId = :voteItemId")
-    Optional<VoteParticipantJpaEntity> findVoteParticipantByUserIdAndVoteItemId(Long userId, Long voteItemId);
+    Optional<VoteParticipantJpaEntity> findVoteParticipantByUserIdAndVoteItemId(@Param("userId") Long userId,@Param("voteItemId") Long voteItemId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
@@ -25,4 +26,21 @@ public interface VoteParticipantJpaRepository extends JpaRepository<VoteParticip
        """)
     void deleteAllByVoteId(@Param("voteId") Long voteId);
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+       DELETE FROM VoteParticipantJpaEntity vp
+       WHERE vp.voteItemJpaEntity.voteItemId IN (
+            SELECT vi.voteItemId
+            FROM VoteItemJpaEntity vi
+            WHERE vi.voteJpaEntity.postId IN :voteIds
+       )
+       """)
+    void deleteAllByVoteIds(@Param("voteIds") List<Long> voteIds);
+
+    @Query("SELECT vp.voteItemJpaEntity.voteItemId FROM VoteParticipantJpaEntity vp WHERE vp.userJpaEntity.userId = :userId")
+    List<Long> findAllVoteItemIdsByUserId(@Param("userId") Long userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM VoteParticipantJpaEntity vp WHERE vp.userJpaEntity.userId = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/konkuk/thip/roompost/application/port/in/dto/vote/VoteResult.java
+++ b/src/main/java/konkuk/thip/roompost/application/port/in/dto/vote/VoteResult.java
@@ -10,11 +10,11 @@ public record VoteResult(
     public record VoteItemDto(
             Long voteItemId,
             String itemName,
-            int percentage,
+            int count,
             Boolean isVoted
     ) {
-        public static VoteItemDto of(Long voteItemId, String itemName, int percentage, Boolean isVoted) {
-            return new VoteItemDto(voteItemId, itemName, percentage, isVoted);
+        public static VoteItemDto of(Long voteItemId, String itemName, int count, Boolean isVoted) {
+            return new VoteItemDto(voteItemId, itemName, count, isVoted);
         }
     }
 

--- a/src/main/java/konkuk/thip/roompost/application/port/out/AttendanceCheckCommandPort.java
+++ b/src/main/java/konkuk/thip/roompost/application/port/out/AttendanceCheckCommandPort.java
@@ -19,4 +19,6 @@ public interface AttendanceCheckCommandPort {
     }
 
     void delete(AttendanceCheck attendanceCheck);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/konkuk/thip/roompost/application/port/out/RecordCommandPort.java
+++ b/src/main/java/konkuk/thip/roompost/application/port/out/RecordCommandPort.java
@@ -22,4 +22,6 @@ public interface RecordCommandPort {
     }
 
     void delete(Record record);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/konkuk/thip/roompost/application/port/out/VoteCommandPort.java
+++ b/src/main/java/konkuk/thip/roompost/application/port/out/VoteCommandPort.java
@@ -46,4 +46,8 @@ public interface VoteCommandPort {
     void updateVoteItem(VoteItem voteItem);
 
     void delete(Vote vote);
+
+    void deleteAllVoteParticipantByUserId(Long userId);
+
+    void deleteAllVoteByUserId(Long userId);
 }

--- a/src/main/java/konkuk/thip/roompost/application/service/RecordDeleteService.java
+++ b/src/main/java/konkuk/thip/roompost/application/service/RecordDeleteService.java
@@ -43,7 +43,6 @@ public class RecordDeleteService implements RecordDeleteUseCase {
         // 3-3. 기록 삭제
         recordCommandPort.delete(record);
 
-        //TODO// 4. 유저 방 진행도 업데이트
         return command.roomId();
     }
 }

--- a/src/main/java/konkuk/thip/roompost/application/service/RoomPostSearchService.java
+++ b/src/main/java/konkuk/thip/roompost/application/service/RoomPostSearchService.java
@@ -20,7 +20,6 @@ import konkuk.thip.room.application.port.out.RoomParticipantCommandPort;
 import konkuk.thip.room.domain.RoomParticipant;
 import konkuk.thip.roompost.application.port.out.VoteQueryPort;
 import konkuk.thip.roompost.application.port.out.dto.VoteItemQueryDto;
-import konkuk.thip.roompost.domain.VoteItem;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -144,20 +143,12 @@ public class RoomPostSearchService implements RoomPostSearchUseCase {
 
     // VoteItemQueryDto 목록을 RecordSearchResponse.PostDto.VoteItemDto 목록으로 변환하는 메서드
     private List<RoomPostSearchResponse.RoomPostSearchDto.VoteItemDto> mapToVoteItemDtos(List<VoteItemQueryDto> items, boolean isLocked) {
-        // voteCount를 모아 리스트로 변환
-        List<Integer> counts = items.stream()
-                .map(VoteItemQueryDto::voteCount)
-                .toList();
-
-        // 도메인에게 계산 위임
-        List<Integer> percentages = VoteItem.calculatePercentages(counts);
-
         // 계산 결과를 이용해 DTO 조립
         return IntStream.range(0, items.size())
                 .mapToObj(i -> RoomPostSearchResponse.RoomPostSearchDto.VoteItemDto.of(
                         items.get(i).voteItemId(),
                         isLocked ? roomPostAccessValidator.createBlurredString(items.get(i).itemName()) : items.get(i).itemName(),
-                        percentages.get(i),
+                        items.get(i).voteCount(),
                         items.get(i).isVoted()
                 ))
                 .toList();

--- a/src/main/java/konkuk/thip/roompost/application/service/VoteDeleteService.java
+++ b/src/main/java/konkuk/thip/roompost/application/service/VoteDeleteService.java
@@ -41,7 +41,6 @@ public class VoteDeleteService implements VoteDeleteUseCase {
         // 3-3. 투표 삭제
         voteCommandPort.delete(vote);
 
-        //TODO// 4. 유저 방 진행도 업데이트
         return command.roomId();
     }
 }

--- a/src/main/java/konkuk/thip/roompost/application/service/VoteService.java
+++ b/src/main/java/konkuk/thip/roompost/application/service/VoteService.java
@@ -42,17 +42,12 @@ public class VoteService implements VoteUseCase {
 
         // 2. 투표 결과 반환
         List<VoteItemQueryDto> voteItems = voteQueryPort.findVoteItemsByVoteId(command.voteId(), command.userId());
-        List<Integer> counts = voteItems.stream()
-                .map(VoteItemQueryDto::voteCount)
-                .toList();
-
-        List<Integer> percentages = VoteItem.calculatePercentages(counts);
 
         var voteItemDtos = IntStream.range(0, voteItems.size())
                 .mapToObj(i -> VoteResult.VoteItemDto.of(
                         voteItems.get(i).voteItemId(),
                         voteItems.get(i).itemName(),
-                        percentages.get(i),
+                        voteItems.get(i).voteCount(),
                         voteItems.get(i).isVoted()
                 ))
                 .toList();

--- a/src/main/java/konkuk/thip/user/adapter/in/web/UserCommandController.java
+++ b/src/main/java/konkuk/thip/user/adapter/in/web/UserCommandController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import konkuk.thip.common.dto.BaseResponse;
+import konkuk.thip.common.security.annotation.AuthToken;
 import konkuk.thip.common.security.annotation.Oauth2Id;
 import konkuk.thip.common.security.annotation.UserId;
 import konkuk.thip.common.swagger.annotation.ExceptionDescription;
@@ -13,6 +14,7 @@ import konkuk.thip.user.adapter.in.web.request.UserSignupRequest;
 import konkuk.thip.user.adapter.in.web.request.UserUpdateRequest;
 import konkuk.thip.user.adapter.in.web.response.UserFollowResponse;
 import konkuk.thip.user.adapter.in.web.response.UserSignupResponse;
+import konkuk.thip.user.application.port.in.UserDeleteUseCase;
 import konkuk.thip.user.application.port.in.UserFollowUsecase;
 import konkuk.thip.user.application.port.in.UserSignupUseCase;
 import konkuk.thip.user.application.port.in.UserUpdateUseCase;
@@ -29,6 +31,7 @@ public class UserCommandController {
     private final UserSignupUseCase userSignupUseCase;
     private final UserFollowUsecase userFollowUsecase;
     private final UserUpdateUseCase userUpdateUseCase;
+    private final UserDeleteUseCase userDeleteUseCase;
 
 
     @Operation(
@@ -72,6 +75,19 @@ public class UserCommandController {
             @Parameter(hidden = true) @UserId final Long userId,
             @RequestBody @Valid final UserUpdateRequest userUpdateRequest) {
         userUpdateUseCase.updateUser(userUpdateRequest.toCommand(userId));
+        return BaseResponse.ok(null);
+    }
+
+    @Operation(
+            summary = "회원 탈퇴",
+            description = "사용자가 회원탈퇴를 합니다. 사용자와 관련된 정보가 모두 삭제되고," +
+                    "회원탈퇴한 사용자의 토큰을 블랙리스트에 추가하여 서비스 재진입을 막습니다."
+    )
+    @ExceptionDescription(USER_DELETE)
+    @DeleteMapping("/users")
+    public BaseResponse<Void> deleteUser(@Parameter(hidden = true) @UserId final Long userId,
+                                         @Parameter(hidden = true) @AuthToken final String authToken) {
+        userDeleteUseCase.deleteUser(userId,authToken);
         return BaseResponse.ok(null);
     }
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/jpa/UserJpaEntity.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/jpa/UserJpaEntity.java
@@ -12,7 +12,7 @@ import org.hibernate.annotations.SQLDelete;
 import java.time.LocalDate;
 
 import static konkuk.thip.common.entity.StatusType.INACTIVE;
-import static konkuk.thip.common.exception.code.ErrorCode.POST_ALREADY_DELETED;
+import static konkuk.thip.common.exception.code.ErrorCode.USER_ALREADY_DELETED;
 
 @Entity
 @Table(name = "users")
@@ -70,7 +70,7 @@ public class UserJpaEntity extends BaseJpaEntity {
 
     public void softDelete(User user) {
         if(this.status.equals(INACTIVE)){
-            throw new InvalidStateException(POST_ALREADY_DELETED);
+            throw new InvalidStateException(USER_ALREADY_DELETED);
         }
         this.status = INACTIVE;
         this.oauth2Id = user.getOauth2Id();

--- a/src/main/java/konkuk/thip/user/adapter/out/jpa/UserJpaEntity.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/jpa/UserJpaEntity.java
@@ -3,12 +3,16 @@ package konkuk.thip.user.adapter.out.jpa;
 
 import jakarta.persistence.*;
 import konkuk.thip.common.entity.BaseJpaEntity;
+import konkuk.thip.common.exception.InvalidStateException;
 import konkuk.thip.user.domain.value.Alias;
 import konkuk.thip.user.domain.User;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 
 import java.time.LocalDate;
+
+import static konkuk.thip.common.entity.StatusType.INACTIVE;
+import static konkuk.thip.common.exception.code.ErrorCode.POST_ALREADY_DELETED;
 
 @Entity
 @Table(name = "users")
@@ -33,6 +37,11 @@ public class UserJpaEntity extends BaseJpaEntity {
     @Column(name = "oauth2_id", length = 50, nullable = false)
     private String oauth2Id;
 
+    /**
+     * -- SETTER --
+     *  회원 탈퇴용
+     */
+    @Setter
     @Builder.Default
     private Integer followerCount = 0; // 팔로워 수
 
@@ -58,4 +67,13 @@ public class UserJpaEntity extends BaseJpaEntity {
         this.role = UserRole.from(user.getUserRole());
         this.followerCount = user.getFollowerCount();
     }
+
+    public void softDelete(User user) {
+        if(this.status.equals(INACTIVE)){
+            throw new InvalidStateException(POST_ALREADY_DELETED);
+        }
+        this.status = INACTIVE;
+        this.oauth2Id = user.getOauth2Id();
+    }
+
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/FollowingCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/FollowingCommandPersistenceAdapter.java
@@ -56,9 +56,11 @@ public class FollowingCommandPersistenceAdapter implements FollowingCommandPort 
 
     @Override
     public void deleteAllByUserId(Long userId) {
+        // 유저가 팔로워인 팔로잉 관계 -> 유저가 팔로우 중인 유저들의 팔로워 수 감소 -> 관계 삭제
+        // 유저를 팔로우 하는 팔로잉 관계 -> 관계 삭제
 
         // 1. 탈퇴 유저가 팔로우 중인 유저들 ID 조회
-        List<Long> targetUserIds = followingJpaRepository.findAllTargetUserIdsByUserId(userId);
+        List<Long> targetUserIds = userJpaRepository.findAllTargetUserIdsByUserId(userId);
         // 2. 탈퇴한 유저의 모든 팔로잉 관계 삭제
         followingJpaRepository.deleteAllByUserIdOrFollowingUserId(userId);
         if (targetUserIds == null || targetUserIds.isEmpty()) {

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/FollowingCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/FollowingCommandPersistenceAdapter.java
@@ -64,12 +64,8 @@ public class FollowingCommandPersistenceAdapter implements FollowingCommandPort 
         if (targetUserIds == null || targetUserIds.isEmpty()) {
             return; //early return
         }
-        // 3. 해당 ID들로 JPA 엔티티 직접 조회
-        List<UserJpaEntity> userEntities = userJpaRepository.findAllById(targetUserIds);
-        // 4. 엔티티에서 직접 팔로워 수 감소
-        userEntities.forEach(entity ->
-                entity.setFollowerCount(Math.max(0, entity.getFollowerCount() - 1)));
-        userJpaRepository.saveAll(userEntities);
+        // 3. 탈퇴 유저가 팔로우 중인 유저들의 팔로워 수 감소
+        followingJpaRepository.bulkDecrementFollowerCount(targetUserIds);
     }
 
 

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/UserCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/UserCommandPersistenceAdapter.java
@@ -55,4 +55,14 @@ public class UserCommandPersistenceAdapter implements UserCommandPort {
         userJpaEntity.updateIncludeAliasFrom(user);
         userJpaRepository.save(userJpaEntity);
     }
+
+    @Override
+    public void delete(User user) {
+        UserJpaEntity userJpaEntity = userJpaRepository.findByUserId(user.getId()).orElseThrow(
+                () -> new EntityNotFoundException(USER_NOT_FOUND)
+        );
+
+        userJpaEntity.softDelete(user);
+        userJpaRepository.save(userJpaEntity);
+    }
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/UserTokenBlacklistRedisAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/UserTokenBlacklistRedisAdapter.java
@@ -1,15 +1,28 @@
 package konkuk.thip.user.adapter.out.persistence;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import konkuk.thip.common.exception.ExternalApiException;
+import konkuk.thip.common.security.oauth2.LoginUser;
 import konkuk.thip.common.security.util.JwtUtil;
 import konkuk.thip.user.application.port.UserTokenBlacklistCommandPort;
 import konkuk.thip.user.application.port.UserTokenBlacklistQueryPort;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
+import static konkuk.thip.common.exception.code.ErrorCode.JSON_PROCESSING_ERROR;
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class UserTokenBlacklistRedisAdapter implements UserTokenBlacklistQueryPort, UserTokenBlacklistCommandPort {
@@ -21,30 +34,44 @@ public class UserTokenBlacklistRedisAdapter implements UserTokenBlacklistQueryPo
 
     private final JwtUtil jwtUtil;
 
-    /**
-     * 블랙리스트에 토큰 추가 (토큰 만료시간에 맞춰 자동 소멸)
-     */
+    //블랙리스트에 토큰 추가 (토큰 만료시간에 맞춰 자동 소멸)
     @Override
     public void addTokenToBlacklist(String token) {
         Date expiration = jwtUtil.getExpirationAllowExpired(token);
+        LoginUser loginUser = jwtUtil.getLoginUser(token);
+        LocalDateTime withdrawalTime = LocalDateTime.now();
         String key = makeBlacklistKey(token);
-        redisTemplate.opsForValue().set(key, "BLACKLISTED");
+
+        Map<String, Object> valueMap = new HashMap<>();
+        valueMap.put("userId", loginUser.userId());
+        valueMap.put("withdrawalTime", withdrawalTime);
+        String valueJson = null;
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.registerModule(new JavaTimeModule());
+            mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+            valueJson = mapper.writeValueAsString(valueMap);
+        } catch (JsonProcessingException e) {
+            throw new ExternalApiException(JSON_PROCESSING_ERROR);
+        }
+        redisTemplate.opsForValue().set(key, valueJson);
+        log.info("Add token to blacklist - userId: {}, withdrawalTime: {}, expiration: {}",
+                loginUser.userId(),
+                withdrawalTime,
+                expiration
+        );
         // 토큰 만료시각으로 Redis에 expireAt 지정 (만료 이후 Redis에서 자동 삭제)
         redisTemplate.expireAt(key, expiration.toInstant());
     }
 
-    /**
-     * 토큰이 블랙리스트에 등록되어있는지 체크
-     */
+    // 토큰이 블랙리스트에 등록되어있는지 체크
     @Override
     public boolean isTokenBlacklisted(String token) {
         String key = makeBlacklistKey(token);
         return redisTemplate.hasKey(key);
     }
 
-    /**
-     * JWT 블랙리스트 Redis Key 생성 규칙
-     */
+    // JWT 블랙리스트 Redis Key 생성 규칙
     private String makeBlacklistKey(String token) {
         return blacklistPrefix + ":" + token;
     }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/UserTokenBlacklistRedisAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/UserTokenBlacklistRedisAdapter.java
@@ -55,7 +55,7 @@ public class UserTokenBlacklistRedisAdapter implements UserTokenBlacklistQueryPo
             throw new ExternalApiException(JSON_PROCESSING_ERROR);
         }
         redisTemplate.opsForValue().set(key, valueJson);
-        log.info("Add token to blacklist - userId: {}, withdrawalTime: {}, expiration: {}",
+        log.info("블랙리스트에 탈퇴한 회원 토큰 및 관련 정보 추가 - userId: {}, withdrawalTime: {}, expiration: {}",
                 loginUser.userId(),
                 withdrawalTime,
                 expiration

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/UserTokenBlacklistRedisAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/UserTokenBlacklistRedisAdapter.java
@@ -1,0 +1,52 @@
+package konkuk.thip.user.adapter.out.persistence;
+
+import konkuk.thip.common.security.util.JwtUtil;
+import konkuk.thip.user.application.port.UserTokenBlacklistCommandPort;
+import konkuk.thip.user.application.port.UserTokenBlacklistQueryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class UserTokenBlacklistRedisAdapter implements UserTokenBlacklistQueryPort, UserTokenBlacklistCommandPort {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Value("${app.redis.token-blacklist-prefix}")
+    private String blacklistPrefix;
+
+    private final JwtUtil jwtUtil;
+
+    /**
+     * 블랙리스트에 토큰 추가 (토큰 만료시간에 맞춰 자동 소멸)
+     */
+    @Override
+    public void addTokenToBlacklist(String token) {
+        Date expiration = jwtUtil.getExpirationAllowExpired(token);
+        String key = makeBlacklistKey(token);
+        redisTemplate.opsForValue().set(key, "BLACKLISTED");
+        // 토큰 만료시각으로 Redis에 expireAt 지정 (만료 이후 Redis에서 자동 삭제)
+        redisTemplate.expireAt(key, expiration.toInstant());
+    }
+
+    /**
+     * 토큰이 블랙리스트에 등록되어있는지 체크
+     */
+    @Override
+    public boolean isTokenBlacklisted(String token) {
+        String key = makeBlacklistKey(token);
+        return redisTemplate.hasKey(key);
+    }
+
+    /**
+     * JWT 블랙리스트 Redis Key 생성 규칙
+     */
+    private String makeBlacklistKey(String token) {
+        return blacklistPrefix + ":" + token;
+    }
+
+}

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/UserJpaRepository.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/UserJpaRepository.java
@@ -2,7 +2,10 @@ package konkuk.thip.user.adapter.out.persistence.repository;
 
 import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long>, UserQueryRepository {
@@ -19,4 +22,7 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long>, U
     boolean existsByNicknameAndUserIdNot(String nickname, Long userId);
 
     boolean existsByOauth2Id(String oauth2Id);
+
+    @Query("SELECT f.followingUserJpaEntity.userId FROM FollowingJpaEntity f WHERE f.userJpaEntity.userId = :userId")
+    List<Long> findAllTargetUserIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingJpaRepository.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingJpaRepository.java
@@ -1,10 +1,10 @@
 package konkuk.thip.user.adapter.out.persistence.repository.following;
 
-import io.lettuce.core.dynamic.annotation.Param;
 import konkuk.thip.user.adapter.out.jpa.FollowingJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -24,4 +24,11 @@ public interface FollowingJpaRepository extends JpaRepository<FollowingJpaEntity
 
     @Query("SELECT f.followingUserJpaEntity.userId FROM FollowingJpaEntity f WHERE f.userJpaEntity.userId = :userId")
     List<Long> findAllTargetUserIdsByUserId(@Param("userId") Long userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE UserJpaEntity u " +
+                "SET u.followerCount = CASE WHEN u.followerCount > 0 THEN u.followerCount - 1 ELSE 0 END " +
+                "WHERE u.userId IN :targetUserIds"
+    )
+    void bulkDecrementFollowerCount(@Param("targetUserIds") List<Long> targetUserIds);
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingJpaRepository.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingJpaRepository.java
@@ -22,9 +22,6 @@ public interface FollowingJpaRepository extends JpaRepository<FollowingJpaEntity
     @Query("DELETE FROM FollowingJpaEntity f WHERE f.userJpaEntity.userId = :userId OR f.followingUserJpaEntity.userId = :userId")
     void deleteAllByUserIdOrFollowingUserId(@Param("userId") Long userId);
 
-    @Query("SELECT f.followingUserJpaEntity.userId FROM FollowingJpaEntity f WHERE f.userJpaEntity.userId = :userId")
-    List<Long> findAllTargetUserIdsByUserId(@Param("userId") Long userId);
-
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE UserJpaEntity u " +
                 "SET u.followerCount = CASE WHEN u.followerCount > 0 THEN u.followerCount - 1 ELSE 0 END " +

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingJpaRepository.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/following/FollowingJpaRepository.java
@@ -1,16 +1,27 @@
 package konkuk.thip.user.adapter.out.persistence.repository.following;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import konkuk.thip.user.adapter.out.jpa.FollowingJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface FollowingJpaRepository extends JpaRepository<FollowingJpaEntity, Long>, FollowingQueryRepository {
 
     @Query("SELECT COUNT(f) > 0 FROM FollowingJpaEntity f WHERE f.userJpaEntity.userId = :userId AND f.followingUserJpaEntity.userId = :followingUserId")
-    boolean existsByUserIdAndFollowingUserId(Long userId, Long followingUserId);
+    boolean existsByUserIdAndFollowingUserId(@Param("userId") Long userId, @Param("followingUserId") Long followingUserId);
 
     @Query("SELECT COUNT(f) FROM FollowingJpaEntity f WHERE f.userJpaEntity.userId = :userId")
-    int countFollowingByUserId(Long userId);
+    int countFollowingByUserId(@Param("userId") Long userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM FollowingJpaEntity f WHERE f.userJpaEntity.userId = :userId OR f.followingUserJpaEntity.userId = :userId")
+    void deleteAllByUserIdOrFollowingUserId(@Param("userId") Long userId);
+
+    @Query("SELECT f.followingUserJpaEntity.userId FROM FollowingJpaEntity f WHERE f.userJpaEntity.userId = :userId")
+    List<Long> findAllTargetUserIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/konkuk/thip/user/application/port/UserTokenBlacklistCommandPort.java
+++ b/src/main/java/konkuk/thip/user/application/port/UserTokenBlacklistCommandPort.java
@@ -1,0 +1,5 @@
+package konkuk.thip.user.application.port;
+
+public interface UserTokenBlacklistCommandPort {
+    void addTokenToBlacklist(String token);
+}

--- a/src/main/java/konkuk/thip/user/application/port/UserTokenBlacklistQueryPort.java
+++ b/src/main/java/konkuk/thip/user/application/port/UserTokenBlacklistQueryPort.java
@@ -1,0 +1,5 @@
+package konkuk.thip.user.application.port;
+
+public interface UserTokenBlacklistQueryPort {
+    boolean isTokenBlacklisted(String token);
+}

--- a/src/main/java/konkuk/thip/user/application/port/in/UserDeleteUseCase.java
+++ b/src/main/java/konkuk/thip/user/application/port/in/UserDeleteUseCase.java
@@ -1,0 +1,5 @@
+package konkuk.thip.user.application.port.in;
+
+public interface UserDeleteUseCase {
+    void deleteUser(Long userId, String authToken);
+}

--- a/src/main/java/konkuk/thip/user/application/port/out/FollowingCommandPort.java
+++ b/src/main/java/konkuk/thip/user/application/port/out/FollowingCommandPort.java
@@ -19,4 +19,7 @@ public interface FollowingCommandPort {
     void save(Following following, User targetUser);
 
     void deleteFollowing(Following following, User targetUser);
+
+    void deleteAllByUserId(Long userId);
+
 }

--- a/src/main/java/konkuk/thip/user/application/port/out/UserCommandPort.java
+++ b/src/main/java/konkuk/thip/user/application/port/out/UserCommandPort.java
@@ -11,4 +11,5 @@ public interface UserCommandPort {
     User findById(Long userId);
     Map<Long, User> findByIds(List<Long> userIds);
     void update(User user);
+    void delete(User user);
 }

--- a/src/main/java/konkuk/thip/user/application/service/UserDeleteService.java
+++ b/src/main/java/konkuk/thip/user/application/service/UserDeleteService.java
@@ -57,13 +57,11 @@ public class UserDeleteService implements UserDeleteUseCase {
 
         // 3. 유저가 남긴 관련 정보들 삭제
         // 팔로잉 관계 삭제
-        // 유저가 팔로워인 팔로잉 관계 -> 유저가 팔로우 중인 유저들의 팔로워 수 감소 -> 관계 삭제
-        // 유저를 팔로우 하는 팔로잉 관계 -> 관계 삭제
         followingCommandPort.deleteAllByUserId(userId);
         // 최근검색어 삭제
         recentSearchCommandPort.deleteAllByUserId(userId);
         // 알림 삭제 // TODO 알림구현 적용되면 수정
-        // notificationCommandPort.deleteAllByUserId(userId);
+        // notificationCommandPort.softDeleteAllByUserId(userId);
         // 책/피드 저장 관계 삭제
         feedCommandPort.deleteAllSavedFeedByUserId(userId);
         bookCommandPort.deleteAllSavedBookByUserId(userId);
@@ -79,24 +77,14 @@ public class UserDeleteService implements UserDeleteUseCase {
         postLikeCommandPort.deleteAllByUserId(userId);
 
         // 피드 삭제
-        // 댓글 삭제 -> 댓글의 좋아요 삭제
-        // 좋아요 삭제
-        // 피드 저장관계 삭제
         feedCommandPort.deleteAllFeedByUserId(userId);
         // 기록 삭제
-        // 댓글 삭제 -> 댓글의 좋아요 삭제
-        // 좋아요 삭제
         recordCommandPort.deleteAllByUserId(userId);
         // 투표 삭제
-        // 댓글 삭제 -> 댓글의 좋아요 삭제
-        // 좋아요 삭제
-        // 투표 참여 관계 일괄 삭제 -> 투표 항목 일괄 삭제
         voteCommandPort.deleteAllVoteByUserId(userId);
 
-        // 방 참여 관계 삭제 (member는 진행/모집/만료, host는 만료)
-        // 방 멤버수 감소, 방 진행도 업데이트
+        // 방 참여 관계 삭제
         roomParticipantCommandPort.deleteAllByUserId(userId);
-
         // 유저 삭제
         userCommandPort.delete(user);
         // 토큰 블랙리스트 추가

--- a/src/main/java/konkuk/thip/user/application/service/UserDeleteService.java
+++ b/src/main/java/konkuk/thip/user/application/service/UserDeleteService.java
@@ -1,0 +1,106 @@
+package konkuk.thip.user.application.service;
+
+import konkuk.thip.book.application.port.out.BookCommandPort;
+import konkuk.thip.comment.application.port.out.CommentCommandPort;
+import konkuk.thip.comment.application.port.out.CommentLikeCommandPort;
+import konkuk.thip.common.exception.BusinessException;
+import konkuk.thip.feed.application.port.out.FeedCommandPort;
+import konkuk.thip.post.application.port.out.PostLikeCommandPort;
+import konkuk.thip.recentSearch.application.port.out.RecentSearchCommandPort;
+import konkuk.thip.room.application.port.out.RoomParticipantCommandPort;
+import konkuk.thip.roompost.application.port.out.AttendanceCheckCommandPort;
+import konkuk.thip.roompost.application.port.out.RecordCommandPort;
+import konkuk.thip.roompost.application.port.out.VoteCommandPort;
+import konkuk.thip.user.application.port.UserTokenBlacklistCommandPort;
+import konkuk.thip.user.application.port.in.UserDeleteUseCase;
+import konkuk.thip.user.application.port.out.FollowingCommandPort;
+import konkuk.thip.user.application.port.out.UserCommandPort;
+import konkuk.thip.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static konkuk.thip.common.exception.code.ErrorCode.USER_CANNOT_DELETE_ROOM_HOST;
+
+@Service
+@RequiredArgsConstructor
+public class UserDeleteService implements UserDeleteUseCase {
+
+    private final UserCommandPort userCommandPort;
+    private final FollowingCommandPort followingCommandPort;
+    private final FeedCommandPort feedCommandPort;
+    private final BookCommandPort bookCommandPort;
+    private final VoteCommandPort voteCommandPort;
+    private final CommentCommandPort commentCommandPort;
+    private final PostLikeCommandPort postLikeCommandPort;
+    private final RecordCommandPort recordCommandPort;
+    private final CommentLikeCommandPort commentLikeCommandPort;
+    private final RecentSearchCommandPort recentSearchCommandPort;
+    private final AttendanceCheckCommandPort attendanceCheckCommandPort;
+    private final RoomParticipantCommandPort roomParticipantCommandPort;
+
+    private final UserTokenBlacklistCommandPort userTokenBlacklistCommandPort;
+
+    @Override
+    @Transactional
+    public void deleteUser(Long userId, String authToken)  {
+
+        // 1. 진행/모집 중인 방의 호스트일경우 회원탈퇴 불가
+        boolean isHostInActiveRoom = roomParticipantCommandPort.existsHostUserInActiveRoom(userId);
+        if (isHostInActiveRoom) {
+            throw new BusinessException(USER_CANNOT_DELETE_ROOM_HOST);
+        }
+
+        // 2. 유저 조회 및 검증
+        User user = userCommandPort.findById(userId);
+        user.markAsDeleted();
+
+        // 3. 유저가 남긴 관련 정보들 삭제
+        // 팔로잉 관계 삭제
+        // 유저가 팔로워인 팔로잉 관계 -> 유저가 팔로우 중인 유저들의 팔로워 수 감소 -> 관계 삭제
+        // 유저를 팔로우 하는 팔로잉 관계 -> 관계 삭제
+        followingCommandPort.deleteAllByUserId(userId);
+        // 최근검색어 삭제
+        recentSearchCommandPort.deleteAllByUserId(userId);
+        // 알림 삭제 // TODO 알림구현 적용되면 수정
+        // notificationCommandPort.deleteAllByUserId(userId);
+        // 책/피드 저장 관계 삭제
+        feedCommandPort.deleteAllSavedFeedByUserId(userId);
+        bookCommandPort.deleteAllSavedBookByUserId(userId);
+        // 오늘의 한마디 관계 삭제
+        attendanceCheckCommandPort.deleteAllByUserId(userId);
+        // 투표 참여 관계 삭제 -> 투표한 항목의 득표 수 감소
+        voteCommandPort.deleteAllVoteParticipantByUserId(userId);
+        // 댓글 좋아요 삭제 -> 댓글의 좋아요 수 감소
+        commentLikeCommandPort.deleteAllByUserId(userId);
+        // 댓글 삭제 -> 게시글의 댓글 수 감소, 댓글의 좋아요 삭제
+        commentCommandPort.deleteAllByUserId(userId);
+        // 게시글 좋아요 삭제 -> 게시글의 좋아요 수 감소
+        postLikeCommandPort.deleteAllByUserId(userId);
+
+        // 피드 삭제
+        // 댓글 삭제 -> 댓글의 좋아요 삭제
+        // 좋아요 삭제
+        // 피드 저장관계 삭제
+        feedCommandPort.deleteAllFeedByUserId(userId);
+        // 기록 삭제
+        // 댓글 삭제 -> 댓글의 좋아요 삭제
+        // 좋아요 삭제
+        recordCommandPort.deleteAllByUserId(userId);
+        // 투표 삭제
+        // 댓글 삭제 -> 댓글의 좋아요 삭제
+        // 좋아요 삭제
+        // 투표 참여 관계 일괄 삭제 -> 투표 항목 일괄 삭제
+        voteCommandPort.deleteAllVoteByUserId(userId);
+
+        // 방 참여 관계 삭제 (member는 진행/모집/만료, host는 만료)
+        // 방 멤버수 감소, 방 진행도 업데이트
+        roomParticipantCommandPort.deleteAllByUserId(userId);
+
+        // 유저 삭제
+        userCommandPort.delete(user);
+        // 토큰 블랙리스트 추가
+        userTokenBlacklistCommandPort.addTokenToBlacklist(authToken);
+    }
+
+}

--- a/src/main/java/konkuk/thip/user/domain/User.java
+++ b/src/main/java/konkuk/thip/user/domain/User.java
@@ -75,4 +75,10 @@ public class User extends BaseDomainEntity {
         }
     }
 
+    public void markAsDeleted() {
+        if (this.oauth2Id != null && !this.oauth2Id.startsWith("deleted:")) {
+            this.oauth2Id = "deleted:" + this.oauth2Id;
+        }
+    }
+
 }

--- a/src/main/java/konkuk/thip/user/domain/User.java
+++ b/src/main/java/konkuk/thip/user/domain/User.java
@@ -9,6 +9,9 @@ import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDate;
 
+import static konkuk.thip.common.exception.code.ErrorCode.USER_ALREADY_DELETED;
+import static konkuk.thip.common.exception.code.ErrorCode.USER_OAUTH2ID_CANNOT_BE_NULL;
+
 @Getter
 @SuperBuilder
 public class User extends BaseDomainEntity {
@@ -76,9 +79,13 @@ public class User extends BaseDomainEntity {
     }
 
     public void markAsDeleted() {
-        if (this.oauth2Id != null && !this.oauth2Id.startsWith("deleted:")) {
-            this.oauth2Id = "deleted:" + this.oauth2Id;
+        if (this.oauth2Id == null) {
+            throw new InvalidStateException(USER_OAUTH2ID_CANNOT_BE_NULL);
         }
+        if (this.oauth2Id.startsWith("deleted:")) {
+            throw new InvalidStateException(USER_ALREADY_DELETED);
+        }
+        this.oauth2Id = "deleted:" + this.oauth2Id;
     }
 
 }

--- a/src/test/java/konkuk/thip/comment/adapter/out/persistence/CommentCommandPersistenceAdapterTest.java
+++ b/src/test/java/konkuk/thip/comment/adapter/out/persistence/CommentCommandPersistenceAdapterTest.java
@@ -1,0 +1,94 @@
+package konkuk.thip.comment.adapter.out.persistence;
+
+import jakarta.persistence.EntityManager;
+import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.adapter.out.persistence.repository.BookJpaRepository;
+import konkuk.thip.comment.adapter.out.jpa.CommentJpaEntity;
+import konkuk.thip.comment.adapter.out.mapper.CommentMapper;
+import konkuk.thip.comment.adapter.out.persistence.repository.CommentJpaRepository;
+import konkuk.thip.comment.adapter.out.persistence.repository.CommentLikeJpaRepository;
+import konkuk.thip.common.entity.StatusType;
+import konkuk.thip.common.util.TestEntityFactory;
+import konkuk.thip.config.TestQuerydslConfig;
+import konkuk.thip.feed.adapter.out.jpa.FeedJpaEntity;
+import konkuk.thip.feed.adapter.out.persistence.repository.FeedJpaRepository;
+import konkuk.thip.post.domain.PostType;
+import konkuk.thip.roompost.adapter.out.persistence.repository.record.RecordJpaRepository;
+import konkuk.thip.roompost.adapter.out.persistence.repository.vote.VoteJpaRepository;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.domain.value.Alias;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({TestQuerydslConfig.class, CommentCommandPersistenceAdapter.class})
+class CommentCommandPersistenceAdapterTest {
+
+    @Autowired CommentCommandPersistenceAdapter adapter;    // repository 인터페이스가 아니므로 자동 스캔 X -> import 해줘야함
+    @Autowired CommentJpaRepository commentJpaRepository;
+    @Autowired CommentLikeJpaRepository commentLikeJpaRepository;
+    @Autowired BookJpaRepository bookJpaRepository;
+    @Autowired FeedJpaRepository feedJpaRepository;
+    @Autowired UserJpaRepository userJpaRepository;
+    @Autowired RecordJpaRepository recordJpaRepository;
+    @Autowired VoteJpaRepository voteJpaRepository;
+
+    @MockitoBean CommentMapper commentMapper;   // Mock bean 으로 설정
+
+    @Autowired EntityManager em;
+
+    @Test
+    @DisplayName("deleteAllByUserId: Post.commentCount는 targetUser의 댓글 수만큼 감소하고, 해당 댓글들은 INACTIVE 처리된다.")
+    void deleteAllByUserId_updatesPostCount_andSoftDeletesComments() {
+        // given
+        UserJpaEntity targetUser = userJpaRepository.save(TestEntityFactory.createUser(Alias.WRITER));
+        UserJpaEntity otherUser  = userJpaRepository.save(TestEntityFactory.createUser(Alias.WRITER));
+
+        BookJpaEntity bookJpaEntity = bookJpaRepository.save(TestEntityFactory.createBook());
+        FeedJpaEntity feedJpaEntity = feedJpaRepository.save(TestEntityFactory.createFeed(otherUser, bookJpaEntity, true));
+
+        CommentJpaEntity c1 = commentJpaRepository.save(TestEntityFactory.createComment(feedJpaEntity, targetUser, PostType.FEED));
+        CommentJpaEntity c2 = commentJpaRepository.save(TestEntityFactory.createComment(feedJpaEntity, targetUser, PostType.FEED));
+        CommentJpaEntity c3 = commentJpaRepository.save(TestEntityFactory.createComment(feedJpaEntity, otherUser, PostType.FEED));
+
+        // 피드의 commentCount update
+        feedJpaEntity.setCommentCount(3);
+
+        // when
+        adapter.deleteAllByUserId(targetUser.getUserId());
+
+        // then
+        em.flush();  // 더티체킹 → DB 반영
+        em.clear();
+
+        // 1) 게시글의 commentCount가 3 -> 1 로 감소했는지 확인 (targetUser 댓글 2개 삭제)
+        FeedJpaEntity updated = feedJpaRepository.findByPostId(feedJpaEntity.getPostId()).orElseThrow();
+        assertThat(updated.getCommentCount()).isEqualTo(1);
+
+        // 2) targetUser의 댓글은 INACTIVE, otherUser의 댓글은 ACTIVE
+        List<CommentJpaEntity> all = commentJpaRepository.findAll(); // 상태 필터링 AOP 없다면 전부 보임
+        long targetInactive = all.stream()
+                .filter(c -> c.getUserJpaEntity().getUserId().equals(targetUser.getUserId()))
+                .filter(c -> StatusType.INACTIVE.name().equals(c.getStatus().name())) // BaseJpaEntity.status 타입에 맞게 비교
+                .count();
+
+        long otherActive = all.stream()
+                .filter(c -> c.getUserJpaEntity().getUserId().equals(otherUser.getUserId()))
+                .filter(c -> StatusType.ACTIVE.name().equals(c.getStatus().name()))
+                .count();
+
+        assertThat(targetInactive).isEqualTo(2); // targetUser가 단 댓글 2개 모두 INACTIVE
+        assertThat(otherActive).isEqualTo(1);    // otherUser가 단 댓글 1개는 그대로 ACTIVE
+    }
+}

--- a/src/test/java/konkuk/thip/common/util/TestEntityFactory.java
+++ b/src/test/java/konkuk/thip/common/util/TestEntityFactory.java
@@ -12,6 +12,8 @@ import konkuk.thip.feed.domain.value.ContentList;
 import konkuk.thip.post.adapter.out.jpa.PostJpaEntity;
 import konkuk.thip.post.adapter.out.jpa.PostLikeJpaEntity;
 import konkuk.thip.post.domain.PostType;
+import konkuk.thip.recentSearch.adapter.out.jpa.RecentSearchJpaEntity;
+import konkuk.thip.recentSearch.adapter.out.jpa.RecentSearchType;
 import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
 import konkuk.thip.room.adapter.out.jpa.RoomParticipantJpaEntity;
 import konkuk.thip.room.adapter.out.jpa.RoomParticipantRole;
@@ -279,49 +281,14 @@ public class TestEntityFactory {
      * 공개/비공개 여부만을 설정하는 기본 피드 생성을 위한 팩토리 메서드
      */
     public static FeedJpaEntity createFeed(UserJpaEntity user, BookJpaEntity book, boolean isPublic) {
-
-//        return FeedJpaEntity.builder()
-//                .content("기본 피드 본문입니다.")
-//                .isPublic(isPublic)
-//                .likeCount(0)
-//                .commentCount(0)
-//                .reportCount(0)
-//                .userJpaEntity(user)
-//                .bookJpaEntity(book)
-//                .contentList(ContentList.empty())
-//                .build();
         return createFeed(user, book, isPublic, 0, 0, Collections.emptyList(), Collections.emptyList());
     }
 
     public static FeedJpaEntity createFeed(UserJpaEntity user, BookJpaEntity book, boolean isPublic, int likeCount, int commentCount, List<String> imageUrls) {
-
-//        FeedJpaEntity feed = FeedJpaEntity.builder()
-//                .content("이미지 포함 피드")
-//                .isPublic(isPublic)
-//                .likeCount(0)
-//                .commentCount(0)
-//                .reportCount(0)
-//                .userJpaEntity(user)
-//                .bookJpaEntity(book)
-//                .contentList(ContentList.of(imageUrls))
-//                .build();
-//
         return createFeed(user, book, isPublic, likeCount, commentCount, imageUrls, Collections.emptyList());
     }
 
     public static FeedJpaEntity createFeed(UserJpaEntity user, BookJpaEntity book, List<String> imageUrls, boolean isPublic) {
-
-//        FeedJpaEntity feed = FeedJpaEntity.builder()
-//                .content("이미지 포함 피드")
-//                .isPublic(isPublic)
-//                .likeCount(0)
-//                .commentCount(0)
-//                .reportCount(0)
-//                .userJpaEntity(user)
-//                .bookJpaEntity(book)
-//                .contentList(ContentList.of(imageUrls))
-//                .build();
-//
         return createFeed(user, book, isPublic, 0, 0, imageUrls, Collections.emptyList());
     }
 
@@ -391,4 +358,13 @@ public class TestEntityFactory {
                 .userJpaEntity(userJpaEntity)
                 .build();
     }
+
+    public static RecentSearchJpaEntity createRecentSearch(UserJpaEntity userJpaEntity) {
+        return RecentSearchJpaEntity.builder()
+                .searchTerm("테스트검색어")
+                .type(RecentSearchType.BOOK_SEARCH)
+                .userJpaEntity(userJpaEntity)
+                .build();
+    }
+
 }

--- a/src/test/java/konkuk/thip/roompost/adapter/in/web/RoomPostSearchApiTest.java
+++ b/src/test/java/konkuk/thip/roompost/adapter/in/web/RoomPostSearchApiTest.java
@@ -129,7 +129,7 @@ class RoomPostSearchApiTest {
                 for (JsonNode voteItem : voteItems) {
                     assertThat(voteItem.path("voteItemId")).isNotNull();
                     assertThat(voteItem.path("itemName")).isNotNull();
-                    assertThat(voteItem.path("percentage")).isNotNull();
+                    assertThat(voteItem.path("count")).isNotNull();
                     assertThat(voteItem.path("isVoted")).isNotNull();
                 }
             }

--- a/src/test/java/konkuk/thip/user/adapter/in/web/UserDeleteApiTest.java
+++ b/src/test/java/konkuk/thip/user/adapter/in/web/UserDeleteApiTest.java
@@ -1,0 +1,468 @@
+package konkuk.thip.user.adapter.in.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.adapter.out.persistence.repository.BookJpaRepository;
+import konkuk.thip.book.adapter.out.persistence.repository.SavedBookJpaRepository;
+import konkuk.thip.comment.adapter.out.jpa.CommentJpaEntity;
+import konkuk.thip.comment.adapter.out.jpa.CommentLikeJpaEntity;
+import konkuk.thip.comment.adapter.out.persistence.repository.CommentJpaRepository;
+import konkuk.thip.comment.adapter.out.persistence.repository.CommentLikeJpaRepository;
+import konkuk.thip.common.security.util.JwtUtil;
+import konkuk.thip.common.util.TestEntityFactory;
+import konkuk.thip.feed.adapter.out.jpa.FeedJpaEntity;
+import konkuk.thip.feed.adapter.out.persistence.repository.FeedJpaRepository;
+import konkuk.thip.feed.adapter.out.persistence.repository.SavedFeedJpaRepository;
+import konkuk.thip.post.adapter.out.jpa.PostLikeJpaEntity;
+import konkuk.thip.post.adapter.out.persistence.PostLikeJpaRepository;
+import konkuk.thip.recentSearch.adapter.out.persistence.repository.RecentSearchJpaRepository;
+import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
+import konkuk.thip.room.adapter.out.jpa.RoomParticipantJpaEntity;
+import konkuk.thip.room.adapter.out.jpa.RoomStatus;
+import konkuk.thip.room.adapter.out.persistence.repository.RoomJpaRepository;
+import konkuk.thip.room.adapter.out.persistence.repository.roomparticipant.RoomParticipantJpaRepository;
+import konkuk.thip.room.domain.value.Category;
+import konkuk.thip.roompost.adapter.out.jpa.*;
+import konkuk.thip.roompost.adapter.out.persistence.repository.attendancecheck.AttendanceCheckJpaRepository;
+import konkuk.thip.roompost.adapter.out.persistence.repository.record.RecordJpaRepository;
+import konkuk.thip.roompost.adapter.out.persistence.repository.vote.VoteItemJpaRepository;
+import konkuk.thip.roompost.adapter.out.persistence.repository.vote.VoteJpaRepository;
+import konkuk.thip.roompost.adapter.out.persistence.repository.vote.VoteParticipantJpaRepository;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.adapter.out.persistence.repository.following.FollowingJpaRepository;
+import konkuk.thip.user.application.port.UserTokenBlacklistQueryPort;
+import konkuk.thip.user.domain.value.Alias;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+
+import static konkuk.thip.common.entity.StatusType.INACTIVE;
+import static konkuk.thip.common.exception.code.ErrorCode.USER_CANNOT_DELETE_ROOM_HOST;
+import static konkuk.thip.post.domain.PostType.*;
+import static konkuk.thip.room.adapter.out.jpa.RoomParticipantRole.HOST;
+import static konkuk.thip.room.adapter.out.jpa.RoomParticipantRole.MEMBER;
+import static konkuk.thip.room.adapter.out.jpa.RoomStatus.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@DisplayName("[통합] 회원탈퇴 api 테스트")
+public class UserDeleteApiTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private UserJpaRepository userJpaRepository;
+    @Autowired private BookJpaRepository bookJpaRepository;
+    @Autowired private FeedJpaRepository feedJpaRepository;
+    @Autowired private CommentJpaRepository commentJpaRepository;
+    @Autowired private CommentLikeJpaRepository commentLikeJpaRepository;
+    @Autowired private PostLikeJpaRepository postLikeJpaRepository;
+    @Autowired private SavedFeedJpaRepository savedFeedJpaRepository;
+    @Autowired private RoomJpaRepository roomJpaRepository;
+    @Autowired private RoomParticipantJpaRepository roomParticipantJpaRepository;
+    @Autowired private VoteJpaRepository voteJpaRepository;
+    @Autowired private VoteItemJpaRepository voteItemJpaRepository;
+    @Autowired private FollowingJpaRepository followingJpaRepository;
+    @Autowired private RecentSearchJpaRepository recentSearchJpaRepository;
+    @Autowired private SavedBookJpaRepository savedBookJpaRepository;
+    @Autowired private AttendanceCheckJpaRepository attendanceCheckJpaRepository;
+    @Autowired private VoteParticipantJpaRepository voteParticipantJpaRepository;
+    @Autowired private RecordJpaRepository recordJpaRepository;
+    @Autowired private UserTokenBlacklistQueryPort userTokenBlacklistQueryPort;
+
+    @Autowired private JwtUtil jwtUtil;
+    @Autowired private EntityManager entityManager;
+    @Autowired private ObjectMapper objectMapper;
+
+    @AfterEach
+    void tearDown() {
+        followingJpaRepository.deleteAllInBatch();
+        recentSearchJpaRepository.deleteAllInBatch();
+        savedFeedJpaRepository.deleteAllInBatch();
+        savedBookJpaRepository.deleteAllInBatch();
+        attendanceCheckJpaRepository.deleteAllInBatch();
+        voteParticipantJpaRepository.deleteAllInBatch();
+        commentLikeJpaRepository.deleteAllInBatch();
+        commentJpaRepository.deleteAllInBatch();
+        postLikeJpaRepository.deleteAllInBatch();
+        feedJpaRepository.deleteAllInBatch();
+        recordJpaRepository.deleteAllInBatch();
+        voteItemJpaRepository.deleteAllInBatch();
+        voteJpaRepository.deleteAllInBatch();
+        roomParticipantJpaRepository.deleteAllInBatch();
+        roomJpaRepository.deleteAll();
+        bookJpaRepository.deleteAll();
+        userJpaRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 성공시 모든 연관 엔티티가 각 엔티티 삭제 전략에 맞게 삭제되고 탈퇴한 회원의 토큰이 블랙리스트에 등록된다.")
+    void deleteUser_success() throws Exception {
+
+        // given
+        // 유저 설정 1:테스트하고자하는 유저 2:방의 호스트 유저 3:방의 멤버유저
+        UserJpaEntity testUser1 = userJpaRepository.save(TestEntityFactory.createUser(Alias.ARTIST));
+        UserJpaEntity otherHostUser2 = userJpaRepository.save(TestEntityFactory.createUser(Alias.ARTIST));
+        UserJpaEntity otherMemberUser3 = userJpaRepository.save(TestEntityFactory.createUser(Alias.ARTIST));
+
+        // 팔로잉 관계 설정
+        followingJpaRepository.save(TestEntityFactory.createFollowing(testUser1, otherHostUser2)); // 유저 1이 유저 2 팔로우
+        followingJpaRepository.save(TestEntityFactory.createFollowing(otherMemberUser3, testUser1)); // 유저 3이 유저 1팔로우
+        followingJpaRepository.save(TestEntityFactory.createFollowing(otherMemberUser3, otherHostUser2)); // 유저 3이 유저 2팔로우
+        otherHostUser2.setFollowerCount(2); userJpaRepository.save(otherHostUser2); //유저 2 팔로워수 2
+        testUser1.setFollowerCount(1); userJpaRepository.save(testUser1); //유저 1 팔로워수 1
+
+        // 최근검색어 저장
+        recentSearchJpaRepository.save(TestEntityFactory.createRecentSearch(testUser1));
+
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBook());
+        Category category = TestEntityFactory.createLiteratureCategory();
+        // 방 참여 관계 설정: 모든 유저가 방에 참여해있음
+        RoomJpaEntity roomExpired1 = createRoom(book,category, EXPIRED);
+        RoomJpaEntity roomInProgress2 = createRoom(book,category, IN_PROGRESS);
+        RoomJpaEntity roomRecruiting3 = createRoom(book,category, RECRUITING);
+
+        // 방1-> 만료된 방 : 유저1이 HOST
+        RoomParticipantJpaEntity r1_rp1 = roomParticipantJpaRepository.save(TestEntityFactory.createRoomParticipant(roomExpired1,testUser1,HOST,50.0));
+        RoomParticipantJpaEntity r1_rp2 = roomParticipantJpaRepository.save(TestEntityFactory.createRoomParticipant(roomExpired1,otherHostUser2, MEMBER,30.0));
+        RoomParticipantJpaEntity r1_rp3 = roomParticipantJpaRepository.save(TestEntityFactory.createRoomParticipant(roomExpired1,otherMemberUser3,MEMBER,60.0));
+        updateRoomPercentage(r1_rp1,r1_rp2,r1_rp3,roomExpired1);
+        // 방2-> 진행중인 방 : 유저2가 HOST
+        RoomParticipantJpaEntity r2_rp1 = roomParticipantJpaRepository.save(TestEntityFactory.createRoomParticipant(roomInProgress2,testUser1,MEMBER,50.0));
+        RoomParticipantJpaEntity r2_rp2 = roomParticipantJpaRepository.save(TestEntityFactory.createRoomParticipant(roomInProgress2,otherHostUser2,HOST,30.0));
+        RoomParticipantJpaEntity r2_rp3 = roomParticipantJpaRepository.save(TestEntityFactory.createRoomParticipant(roomInProgress2,otherMemberUser3,MEMBER,60.0));
+        updateRoomPercentage(r2_rp1,r2_rp2,r2_rp3,roomInProgress2);
+        // 방3 -> 모집중인 방 : 유저2가 HOST
+        RoomParticipantJpaEntity r3_rp1 = roomParticipantJpaRepository.save(TestEntityFactory.createRoomParticipant(roomRecruiting3,testUser1,MEMBER,50.0));
+        RoomParticipantJpaEntity r3_rp2 = roomParticipantJpaRepository.save(TestEntityFactory.createRoomParticipant(roomRecruiting3,otherHostUser2,HOST,30.0));
+        RoomParticipantJpaEntity r3_rp3 = roomParticipantJpaRepository.save(TestEntityFactory.createRoomParticipant(roomRecruiting3,otherMemberUser3,MEMBER,60.0));
+        updateRoomPercentage(r3_rp1,r3_rp2,r3_rp3,roomRecruiting3);
+
+        // 피드/책 저장관계 설정
+        FeedJpaEntity u2_f1 = feedJpaRepository.save(TestEntityFactory.createFeed(otherHostUser2,book,true)); //유저 2가 피드1 작성
+        savedFeedJpaRepository.save(TestEntityFactory.createSavedFeed(testUser1,u2_f1)); //유저 1이 유저2가 작성한 피드1를 저장
+
+        BookJpaEntity sb = bookJpaRepository.save(TestEntityFactory.createBook());
+        savedBookJpaRepository.save(TestEntityFactory.createSavedBook(testUser1,sb));
+
+        // 오늘의 한마디 관계 설정
+        AttendanceCheckJpaEntity a = attendanceCheckJpaRepository.save(TestEntityFactory.createAttendanceCheck
+                ("유저1이 방2에 남긴 오늘의한마디1",roomInProgress2,testUser1));
+
+        //유저 2가 방2에 투표1 생성
+        VoteJpaEntity u2_v1 = voteJpaRepository.save(
+                VoteJpaEntity.builder().content("유저2가 방2에 생성한 투표1").userJpaEntity(otherHostUser2).page(33).isOverview(true)
+                        .commentCount(2).likeCount(1).roomJpaEntity(roomInProgress2).build());
+        VoteItemJpaEntity v1_vi1 = voteItemJpaRepository.save(
+                VoteItemJpaEntity.builder().itemName("유저2가 방2에 생성한 투표1의 항목1").count(1).voteJpaEntity(u2_v1).build());
+        VoteItemJpaEntity v1_vi2 = voteItemJpaRepository.save(
+                VoteItemJpaEntity.builder().itemName("유저2가 방2에 생성한 투표1의 항목2").count(0).voteJpaEntity(u2_v1).build());
+        VoteParticipantJpaEntity u1_vp1 = voteParticipantJpaRepository.save(TestEntityFactory.createVoteParticipant(testUser1, v1_vi1)); //유저1이 투표1의 투표항목1에 투표
+        CommentJpaEntity u2_v1_c1 = commentJpaRepository.save(
+                CommentJpaEntity.builder().content("유저2가 투표1에 남긴 댓글1").postJpaEntity(u2_v1).userJpaEntity(otherHostUser2)
+                        .likeCount(1).reportCount(0).postType(VOTE).build()); //유저2가 투표1에 댓글
+        // 유저1의 댓글 좋아요 관계 설정
+        CommentLikeJpaEntity u1_c1_cl1 = commentLikeJpaRepository.save(TestEntityFactory.createCommentLike(u2_v1_c1, testUser1)); //유저1이 댓글1에 댓글좋아요
+
+        //유저2가 방2에 기록1 생성
+        RecordJpaEntity u2_r1 = recordJpaRepository.save(
+                RecordJpaEntity.builder().content("유저2가 방2에 생성한 기록1").userJpaEntity(otherHostUser2).page(22).isOverview(false)
+                        .commentCount(1).likeCount(1).roomJpaEntity(roomInProgress2).build());
+
+        // 유저1의 게시글 좋아요 관계 설정
+        PostLikeJpaEntity u1_v1_pl1 = postLikeJpaRepository.save(TestEntityFactory.createPostLike(testUser1,u2_v1)); //유저1이 투표1에 좋아요
+        PostLikeJpaEntity u1_f1_pl2 = postLikeJpaRepository.save(TestEntityFactory.createPostLike(testUser1,u2_f1)); //유저1이 피드1에 좋아요
+        PostLikeJpaEntity u1_r1_pl3 = postLikeJpaRepository.save(TestEntityFactory.createPostLike(testUser1,u2_r1)); //유저1이 기록1에 좋아요
+
+        // 유저1의 댓글 저장
+        CommentJpaEntity u1_v1_c2 = commentJpaRepository.save(
+                CommentJpaEntity.builder().content("유저1이 투표1에 남긴 댓글2").postJpaEntity(u2_v1).userJpaEntity(testUser1)
+                        .likeCount(1).reportCount(0).postType(VOTE).build()); //유저1이 투표1에 댓글
+        CommentJpaEntity u1_f1_c3 = commentJpaRepository.save(
+                CommentJpaEntity.builder().content("유저1이 피드1에 남긴 댓글3").postJpaEntity(u2_f1).userJpaEntity(testUser1)
+                        .likeCount(1).reportCount(0).postType(FEED).build()); //유저1이 피드1에 댓글
+        CommentJpaEntity u1_r1_c4 = commentJpaRepository.save(
+                CommentJpaEntity.builder().content("유저1이 기록1에 남긴 댓글4").postJpaEntity(u2_r1).userJpaEntity(testUser1)
+                        .likeCount(1).reportCount(0).postType(RECORD).build()); //유저1이 기록1에 댓글
+
+        u2_f1.setLikeCount(1); //피드 1 좋아요/댓글 씽크 맞추기
+        u2_f1.setCommentCount(1);
+        feedJpaRepository.save(u2_f1);
+
+        // 유저1이 남긴 댓글에 대해 댓글 좋아요 관계 설정 : 유저2가 유저1이 남긴 댓글에 대해 좋아요
+        CommentLikeJpaEntity u2_c2_cl = commentLikeJpaRepository.save(
+                TestEntityFactory.createCommentLike(u1_v1_c2, otherHostUser2));
+        CommentLikeJpaEntity u2_c3_cl = commentLikeJpaRepository.save(
+                TestEntityFactory.createCommentLike(u1_f1_c3, otherHostUser2));
+        CommentLikeJpaEntity u2_c4_cl = commentLikeJpaRepository.save(
+                TestEntityFactory.createCommentLike(u1_r1_c4, otherHostUser2));
+
+        // 유저1이 작성한 게시물 관계 설정
+        // 유저 1이 피드2 작성
+        FeedJpaEntity u1_f2 = feedJpaRepository.save(TestEntityFactory.createFeed(testUser1,book,true));
+        CommentJpaEntity u2_f3_c4 = commentJpaRepository.save(
+                CommentJpaEntity.builder().content("유저2이 피드2에 남긴 댓글4").postJpaEntity(u1_f2).userJpaEntity(otherHostUser2)
+                        .likeCount(1).reportCount(0).postType(FEED).build()); //유저2이 피드2에 댓글
+        //유저3이 댓글4에 댓글좋아요
+        CommentLikeJpaEntity u3_c4_cl2 = commentLikeJpaRepository.save(TestEntityFactory.createCommentLike(u2_f3_c4, otherMemberUser3));
+        PostLikeJpaEntity u2_f2_pl4 = postLikeJpaRepository.save(TestEntityFactory.createPostLike(otherHostUser2, u1_f2)); //유저2가 피드2에 좋아요
+        savedFeedJpaRepository.save(TestEntityFactory.createSavedFeed(otherHostUser2,u1_f2)); //유저2가 피드2를 저장
+        u1_f2.setLikeCount(1); //피드 2 좋아요/댓글 씽크 맞추기
+        u1_f2.setCommentCount(1);
+        feedJpaRepository.save(u1_f2);
+
+        // 유저 1이 투표2 작성
+        VoteJpaEntity u1_v2 = voteJpaRepository.save(
+                VoteJpaEntity.builder().content("유저1가 방2에 생성한 투표2").userJpaEntity(testUser1).page(33).isOverview(true)
+                        .commentCount(1).likeCount(1).roomJpaEntity(roomInProgress2).build());
+        VoteItemJpaEntity v2_vi1 = voteItemJpaRepository.save(
+                VoteItemJpaEntity.builder().itemName("유저1이 방2에 생성한 투표2의 항목1").count(1).voteJpaEntity(u1_v2).build());
+        VoteItemJpaEntity v2_vi2 = voteItemJpaRepository.save(
+                VoteItemJpaEntity.builder().itemName("유저1이 방2에 생성한 투표2의 항목2").count(1).voteJpaEntity(u1_v2).build());
+        VoteParticipantJpaEntity u2_vp2 = voteParticipantJpaRepository.save(TestEntityFactory.createVoteParticipant(otherHostUser2, v2_vi1)); //유저2이 투표2의 투표항목1에 투표
+        VoteParticipantJpaEntity u3_vp3 = voteParticipantJpaRepository.save(TestEntityFactory.createVoteParticipant(otherMemberUser3, v2_vi2)); //유저3이 투표2의 투표항목2에 투표
+        CommentJpaEntity u3_v2_c5 = commentJpaRepository.save(
+                CommentJpaEntity.builder().content("유저3이 투표2에 남긴 댓글5").postJpaEntity(u1_v2).userJpaEntity(otherMemberUser3)
+                        .likeCount(1).reportCount(0).postType(VOTE).build()); //유저3이 투표2에 댓글
+        //유저2이 댓글5에 댓글좋아요
+        CommentLikeJpaEntity u2_c5_cl3 = commentLikeJpaRepository.save(TestEntityFactory.createCommentLike(u3_v2_c5, otherHostUser2));
+        PostLikeJpaEntity u3_v2_pl5 = postLikeJpaRepository.save(TestEntityFactory.createPostLike(otherMemberUser3, u1_v2)); //유저3이 투표2에 좋아요
+
+        // 유저 1이 기록2 작성
+        RecordJpaEntity u1_r2 = recordJpaRepository.save(
+                RecordJpaEntity.builder().content("유저1이 방2에 생성한 기록2").userJpaEntity(testUser1).page(22).isOverview(false)
+                        .commentCount(1).likeCount(1).roomJpaEntity(roomInProgress2).build());
+        CommentJpaEntity u2_r2_c6 = commentJpaRepository.save(
+                CommentJpaEntity.builder().content("유저2가 기록2에 남긴 댓글6").postJpaEntity(u1_r2).userJpaEntity(otherHostUser2)
+                        .likeCount(1).reportCount(0).postType(RECORD).build()); //유저2가 기록2에 댓글
+        //유저3이 댓글6에 댓글좋아요
+        CommentLikeJpaEntity u3_c6_cl4 = commentLikeJpaRepository.save(TestEntityFactory.createCommentLike(u2_r2_c6, otherMemberUser3));
+        PostLikeJpaEntity u2_r2_pl6 = postLikeJpaRepository.save(TestEntityFactory.createPostLike(otherHostUser2, u1_r2)); //유저2가 기록2에 좋아요
+
+        //when
+        String accessToken = jwtUtil.createAccessToken(testUser1.getUserId());
+        mockMvc.perform(delete("/users")
+                .header("Authorization", "Bearer " + accessToken)  //헤더 추가
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        // then: 1) 유저 팔로잉/팔로워 관계 삭제
+        // 탈퇴한 유저1의 팔로잉/팔로워 관계는 모두 삭제되어야하고, 관련 없는 유저3->유저2 팔로우관계만 남아있어야함
+        // 유저2의 팔로워 수가 1이어야함
+        assertEquals(followingJpaRepository.findAll().get(0).getUserJpaEntity().getUserId(), otherMemberUser3.getUserId());
+        assertEquals(2, (int) otherHostUser2.getFollowerCount());
+
+        // 2) 최근검색어 삭제
+        assertTrue(recentSearchJpaRepository.findAll().isEmpty());
+
+        // 3) 저장한 책/파드 삭제
+        assertTrue(savedFeedJpaRepository.findAllByUserId(testUser1.getUserId()).isEmpty());
+        assertTrue(savedBookJpaRepository.findAll().isEmpty());
+
+        // 4) 오늘의 한마디 관계 soft delete (status=INACTIVE)
+        AttendanceCheckJpaEntity deletedAc = attendanceCheckJpaRepository.findById(a.getAttendanceCheckId()).orElse(null);
+        assertThat(deletedAc.getStatus()).isEqualTo(INACTIVE);
+
+        // 5) 유저 투표 참여 관계 삭제
+        // 탈퇴한 유저가 참여한 투표관계 모두 삭제
+        // 탈퇴한 유저가 참여했던 투표의 득표수 감소
+        assertTrue(voteParticipantJpaRepository.findById(u1_vp1.getVoteParticipantId()).isEmpty());
+        assertEquals(1, v1_vi1.getCount());
+
+        // 6) 유저 댓글 좋아요 삭제
+        // 탈퇴한 유저의 모든 댓글 좋아요 관계 삭제
+        // 탈퇴한 유저가 좋아요한 댓글의 좋아요 수 감소
+        assertTrue(voteParticipantJpaRepository.findById(u1_c1_cl1.getLikeId()).isEmpty());
+        CommentJpaEntity updatedCm1 = commentJpaRepository.findById(u2_v1_c1.getCommentId()).orElse(null);
+        assertEquals(0, updatedCm1.getLikeCount());
+
+        // 7) 유저 댓글 soft delete (status=INACTIVE)
+        // 탈퇴한 유저의 모든 댓글 soft delete
+        // 탈퇴한 유저가 남긴 게시글의 댓글 수 감소
+        // 탈퇴한 유저의 모든 댓글의 좋아요 관계 삭제
+        CommentJpaEntity deletedCm1 = commentJpaRepository.findById(u1_v1_c2.getCommentId()).orElse(null);
+        CommentJpaEntity deletedCm2 = commentJpaRepository.findById(u1_f1_c3.getCommentId()).orElse(null);
+        CommentJpaEntity deletedCm3 = commentJpaRepository.findById(u1_r1_c4.getCommentId()).orElse(null);
+        assertThat(deletedCm1.getStatus()).isEqualTo(INACTIVE);
+        assertThat(deletedCm2.getStatus()).isEqualTo(INACTIVE);
+        assertThat(deletedCm3.getStatus()).isEqualTo(INACTIVE);
+
+        VoteJpaEntity updateV1 = voteJpaRepository.findByPostId(u2_v1.getPostId()).orElse(null);
+        FeedJpaEntity updateF1 = feedJpaRepository.findByPostId(u2_f1.getPostId()).orElse(null);
+        RecordJpaEntity updateR1 = recordJpaRepository.findByPostId(u2_r1.getPostId()).orElse(null);
+        assertEquals(1, updateV1.getCommentCount()); // 유저2가 남긴 댓글은 남아있음
+        assertEquals(0, updateF1.getCommentCount());
+        assertEquals(0, updateR1.getCommentCount());
+
+        assertTrue(commentLikeJpaRepository.findById(u2_c2_cl.getLikeId()).isEmpty());
+        assertTrue(commentLikeJpaRepository.findById(u2_c3_cl.getLikeId()).isEmpty());
+        assertTrue(commentLikeJpaRepository.findById(u2_c4_cl.getLikeId()).isEmpty());
+
+        // 8) 유저 게시글 좋아요 삭제
+        // 탈퇴한 유저가 남긴 모든 게시글 좋아요 삭제
+        // 탈퇴한 유저가 남긴 게시글의 좋아요 수 감소
+        assertTrue(postLikeJpaRepository.findById(u1_v1_pl1.getLikeId()).isEmpty());
+        assertTrue(postLikeJpaRepository.findById(u1_f1_pl2.getLikeId()).isEmpty());
+        assertTrue(postLikeJpaRepository.findById(u1_r1_pl3.getLikeId()).isEmpty());
+        assertEquals(0, updateV1.getLikeCount());
+        assertEquals(0, updateF1.getLikeCount());
+        assertEquals(0, updateR1.getLikeCount());
+
+        // 9) 유저가 작성한 피드 soft delete (status=INACTIVE)
+        // 탈퇴한 유저가 작성한 모든 피드 soft delete
+        // 탈퇴한 유저가 작성한 모든 피드의 댓글 좋아요 삭제
+        // 탈퇴한 유저가 작성한 모든 피드의 댓글 soft delete
+        // 탈퇴한 유저가 작성한 모든 피드 좋아요 삭제
+        // 탈퇴한 유저가 작성한 피드를 저장하는 모든 관계 삭제
+        FeedJpaEntity deletedF1 = feedJpaRepository.findById(u1_f2.getPostId()).orElse(null);
+        assertThat(deletedF1.getStatus()).isEqualTo(INACTIVE);
+        assertTrue(commentLikeJpaRepository.findById(u3_c4_cl2.getLikeId()).isEmpty());
+        CommentJpaEntity deletedCm4 = commentJpaRepository.findById(u2_f3_c4.getCommentId()).orElse(null);
+        assertThat(deletedCm4.getStatus()).isEqualTo(INACTIVE);
+        assertTrue(postLikeJpaRepository.findById(u2_f2_pl4.getLikeId()).isEmpty());
+        assertTrue(savedFeedJpaRepository.findAllByUserId(otherHostUser2.getUserId()).isEmpty());
+
+        // 9) 유저가 작성한 투표 soft delete (status=INACTIVE)
+        // 탈퇴한 유저가 작성한 모든 투표 soft delete
+        // 탈퇴한 유저가 작성한 모든 투표의 댓글 좋아요 삭제
+        // 탈퇴한 유저가 작성한 모든 투표의 댓글 soft delete
+        // 탈퇴한 유저가 작성한 모든 투표 좋아요 삭제
+        // 탈퇴한 유저가 작성한 투표에 참여하는 모든 관계를 삭제
+        // 탈퇴한 유저가 작성한 모든 투표의 투표 항목 삭제
+        VoteJpaEntity deletedV1 = voteJpaRepository.findById(u1_v2.getPostId()).orElse(null);
+        assertThat(deletedV1.getStatus()).isEqualTo(INACTIVE);
+        assertTrue(commentLikeJpaRepository.findById(u2_c5_cl3.getLikeId()).isEmpty());
+        CommentJpaEntity deletedCm5 = commentJpaRepository.findById(u3_v2_c5.getCommentId()).orElse(null);
+        assertThat(deletedCm5.getStatus()).isEqualTo(INACTIVE);
+        assertTrue(postLikeJpaRepository.findById(u3_v2_pl5.getLikeId()).isEmpty());
+        assertTrue(voteParticipantJpaRepository.findById(u2_vp2.getVoteParticipantId()).isEmpty());
+        assertTrue(voteParticipantJpaRepository.findById(u3_vp3.getVoteParticipantId()).isEmpty());
+        assertTrue(voteItemJpaRepository.findById(v2_vi1.getVoteItemId()).isEmpty());
+        assertTrue(voteItemJpaRepository.findById(v2_vi2.getVoteItemId()).isEmpty());
+
+        // 10) 유저가 작성한 기록 soft delete (status=INACTIVE)
+        // 탈퇴한 유저가 작성한 모든 기록 soft delete
+        // 탈퇴한 유저가 작성한 모든 기록의 댓글 좋아요 삭제
+        // 탈퇴한 유저가 작성한 모든 기록의 댓글 soft delete
+        // 탈퇴한 유저가 작성한 모든 기록 좋아요 삭제
+        RecordJpaEntity deletedR1 = recordJpaRepository.findById(u1_r2.getPostId()).orElse(null);
+        assertThat(deletedR1.getStatus()).isEqualTo(INACTIVE);
+        assertTrue(commentLikeJpaRepository.findById(u3_c6_cl4.getLikeId()).isEmpty());
+        CommentJpaEntity deletedCm6 = commentJpaRepository.findById(u2_r2_c6.getCommentId()).orElse(null);
+        assertThat(deletedCm6.getStatus()).isEqualTo(INACTIVE);
+        assertTrue(postLikeJpaRepository.findById(u2_r2_pl6.getLikeId()).isEmpty());
+
+        // 11) 유저가 참여한 방 관계 soft delete (status=INACTIVE)
+        // 탈퇴한 유저가 참여한 모든 방 관계 soft delete
+        // 탈퇴한 유저가 참여한 모든 방의 멤버수 감소
+        // 탈퇴한 유저가 참여한 모든 방의 진행도 업데이트
+        RoomParticipantJpaEntity deletedRp1 = roomParticipantJpaRepository.
+                findById(r1_rp1.getRoomParticipantId()).orElse(null); //만료된 방에서는 host가 나가도 상관없음
+        RoomParticipantJpaEntity deletedRp2 = roomParticipantJpaRepository.
+                findById(r2_rp1.getRoomParticipantId()).orElse(null);
+        RoomParticipantJpaEntity deletedRp3 = roomParticipantJpaRepository.
+                findById(r3_rp1.getRoomParticipantId()).orElse(null);
+        assertThat(deletedRp1.getStatus()).isEqualTo(INACTIVE);
+        assertThat(deletedRp2.getStatus()).isEqualTo(INACTIVE);
+        assertThat(deletedRp3.getStatus()).isEqualTo(INACTIVE);
+        assertEquals(2, roomJpaRepository.findByRoomId(roomExpired1.getRoomId()).get().getMemberCount());
+        assertEquals(45.0, roomJpaRepository.findByRoomId(roomExpired1.getRoomId()).get().getRoomPercentage());
+        assertEquals(2, roomJpaRepository.findByRoomId(roomInProgress2.getRoomId()).get().getMemberCount());
+        assertEquals(45.0, roomJpaRepository.findByRoomId(roomInProgress2.getRoomId()).get().getRoomPercentage());
+        assertEquals(2, roomJpaRepository.findByRoomId(roomRecruiting3.getRoomId()).get().getMemberCount());
+        assertEquals(45.0, roomJpaRepository.findByRoomId(roomRecruiting3.getRoomId()).get().getRoomPercentage());
+
+        // 12) 유저 soft delete (status=INACTIVE)
+        // 탈퇴한 유저의 oauth2Id는 deleted:로 시작해야함
+        entityManager.clear();
+        UserJpaEntity deletedUser = userJpaRepository.findById(testUser1.getUserId()).orElse(null);
+        assertThat(deletedUser.getStatus()).isEqualTo(INACTIVE);
+        assertThat(deletedUser.getOauth2Id()).startsWith("deleted:");
+
+        // 13) 탈퇴한 유저의 토큰을 블랙리스트 등록 검증
+        assertTrue(userTokenBlacklistQueryPort.isTokenBlacklisted(accessToken));
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 시 진행/모집 중인 방의 호스트라면 [400 에러 발생]")
+    void deleteUser_whenHostInActiveRoom_thenThrowBusinessException() throws Exception {
+
+        // given
+        UserJpaEntity hostUser1 = userJpaRepository.save(TestEntityFactory.createUser(Alias.ARTIST));
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBook());
+        Category category = TestEntityFactory.createLiteratureCategory();
+        RoomJpaEntity roomInProgress = createRoom(book, category, IN_PROGRESS);
+        roomParticipantJpaRepository.save(TestEntityFactory.createRoomParticipant(roomInProgress, hostUser1, HOST, 100.0));
+
+        // when
+        String accessToken1 = jwtUtil.createAccessToken(hostUser1.getUserId());
+        // then
+        mockMvc.perform(delete("/users")
+                        .header("Authorization", "Bearer " + accessToken1)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(USER_CANNOT_DELETE_ROOM_HOST.getCode()));
+
+        // given
+        UserJpaEntity hostUser2 = userJpaRepository.save(TestEntityFactory.createUser(Alias.ARTIST));
+        RoomJpaEntity roomInRecruiting = createRoom(book, category, RECRUITING);
+        roomParticipantJpaRepository.save(TestEntityFactory.createRoomParticipant(roomInRecruiting, hostUser2, HOST, 100.0));
+
+        // when
+        String accessToken2 = jwtUtil.createAccessToken(hostUser2.getUserId());
+
+        // then
+        mockMvc.perform(delete("/users")
+                        .header("Authorization", "Bearer " + accessToken2)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(USER_CANNOT_DELETE_ROOM_HOST.getCode()));
+
+    }
+
+
+    private RoomJpaEntity createRoom(BookJpaEntity book, Category category, RoomStatus roomStatus) {
+        return roomJpaRepository.save(RoomJpaEntity.builder()
+                .title("방이름")
+                .description("설명")
+                .isPublic(true)
+                .startDate(LocalDate.now().minusDays(1))
+                .endDate(LocalDate.now().plusDays(30))
+                .recruitCount(3)
+                .bookJpaEntity(book)
+                .category(category)
+                .memberCount(3) // 방장과 참여자 포함
+                .roomStatus(roomStatus)
+                .build());
+    }
+
+    private void updateRoomPercentage(RoomParticipantJpaEntity roomParticipant1, RoomParticipantJpaEntity roomParticipant2,
+                                      RoomParticipantJpaEntity roomParticipant3,RoomJpaEntity room) {
+        roomParticipant1.updateCurrentPage(50); // 탈퇴하는 유저의 진행도 50
+        roomParticipantJpaRepository.save(roomParticipant1);
+
+        roomParticipant2.updateCurrentPage(30); // 2번째 유저의 진행도 30;
+        roomParticipantJpaRepository.save(roomParticipant2);
+
+        roomParticipant3.updateCurrentPage(60); // 3번째 유저의 진행도 60
+        roomParticipantJpaRepository.save(roomParticipant3);
+
+        room.updateRoomPercentage(46.6); // 방참여자들의 진행도 평균 46.6 --> 유저1이 탈퇴하면 진행도 평균은 45
+        roomJpaRepository.save(room);
+    }
+}

--- a/src/test/java/konkuk/thip/user/adapter/in/web/UserDeleteApiTest.java
+++ b/src/test/java/konkuk/thip/user/adapter/in/web/UserDeleteApiTest.java
@@ -1,6 +1,5 @@
 package konkuk.thip.user.adapter.in.web;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
 import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
 import konkuk.thip.book.adapter.out.persistence.repository.BookJpaRepository;
@@ -44,7 +43,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #176 

## 📝 작업 내용
- 회원 탈퇴 api를 구현했습니다.
- 회원탈퇴에대한 흐름은 서비스 메서드 및 테스트 코드에 상세히 작성했으니 확인해주시면 감사하겠습니다.
- 회원탈퇴 api 요청 -> 회원탈퇴 할수있는 유저인지 검증 -> 유저의 oauthId prefix 추가 -> 연관된 엔티티 삭제 -> 토큰 블랙리스트 등록
- 워낙 연관관계가 많은 엔티티들을 한번에 삭제하려다보니 서비스코드에 삭제되는 엔티티를 나열하다보니 주석때문에 서비스가 길어지는 감이있는데 리뷰받고 머지되기전에 가독성을 향상시키도록 서비스에 있는 주석들을 최소화 해두겠습니다.
- 회의 내용에따라 투표 조회시 투표 퍼센트가아닌 득표수를 보여주도록 수정했습니다.
- 회원 탈퇴시 탈퇴한 회원의 토큰을 토큰의 만료시점까지 레디스에 저장하기때문에 따로 삭제하는 메서드는 작성하지않았습니다. 이때 레디스에 블랙리스트 토큰을 저장하는 시점에 이미 만료된 토큰의 유효기간을 추출할수있도록 try catch문을 사용했습니다. 이미 만료된 토큰을 레디스에 넣어도 만료되는 시점이 지났기때문에 해당 토큰은 무시되고 정상적으로 회원탈퇴 로직이 진행됩니다.
--> 회원탈퇴를 하는 도중에 토큰이 만료되어 다시 그 유저를 로그인으로 리다이렉트 시키는것보다 위와 같이 구현하는게 더 낫다고 판단했습니다.
- 회원 탈퇴시 유저 soft delete 시 delete가아닌 softDelete메서드를 사용한 이유는 user의 oauth2Id를 업데이트 -> save -> delete 메서드를 사용하니 db에 제대로 저장되지않는 문제가있어서 해당 방식으로 구현했습니다.

## 📸 스크린샷
<img width="567" height="396" alt="image" src="https://github.com/user-attachments/assets/aad5c0c1-23f2-46f8-8630-d77e1e86adbf" />

## 💬 리뷰 요구사항

- 구현 하면서 아래의 고민사항들이 있는데 제가 구현한 방식보다 더 좋은, 최선의 방식이있다면 리뷰부탁드립니다!!
1.최대한 join을 사용하지 않으려고 엔티티에 직접 수를 가지고있는 관련 엔티티들을 삭제할때(팔로워 수/투표 수 etc...) 해당 엔티티 id들을 1차적으로 조회 -> 얼리 리턴 -> id들가지고 해당 엔티티들 재조회 와 같이 해당 방식으로 구현했습니다.
2. 탈퇴한유저가 작성한 댓글, 게시글 좋아요 삭제 시에 작성한 댓글의 게시글의 댓글 수, 게시글 좋아요 수 감소를 하기 위해 각각 JOIN FETCH, JOIN을 사용하여 연관된 postJpaEntity를 조회하여 각 게시글 타입에 맞게 저장하도록 구현했습니다. 
3. 위와같이 댓글/게시글에서 게시글에 따른 분기문처리때문에 중복코드가 꽤 많이 생기는데 헬퍼서비스를 도입하는 건 어떨까요?.. 영속성 어댑터 계층에 서비스가 역의존성을 가지는건 좋지않다고생각하지만 둘다 정말 같은 역할을하는 느낌이 들어서..
4. 블랙리스트 토큰을 저장하는 어댑터의 이름을 현재 `UserTokenBlacklistRedisAdapter`로 작성하고 패키지도 user아래 위치해있는데 이건 auth역할이 더 강하다고 생각하긴하는데 auth에 어댑터라는 패키지가 없다보니.. 이름이랑 패키지 구조 추천받습니다 허헣

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 회원 탈퇴 API(DELETE /users) 추가 — 탈퇴 시 팔로우·저장(피드/도서)·검색기록·출석·투표(참여/작성)·댓글/좋아요·포스트(피드/레코드/투표) 등이 일괄 정리(삭제/소프트삭제)됩니다.
  * 활성 상태의 방(모집/진행) 호스트는 탈퇴 불가(명확한 오류 반환).
  * 투표 결과 표시가 퍼센트에서 개수(count) 기준으로 변경.

* **Security**
  * 탈퇴 시 JWT 토큰을 블랙리스트에 등록하여 재사용 차단.
  * 요청 처리 중 인증 토큰 주입 지원(@AuthToken) 추가.

* **Documentation**
  * Swagger에 회원 탈퇴 응답/에러(USER_DELETE) 사례 추가.

* **Tests**
  * 회원 탈퇴 통합 테스트 추가 (다수 관계의 일괄 정리 검증).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->