### PR TITLE
[hotfix] 알림 읽음 처리 api 수정

### DIFF
--- a/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/thip/common/swagger/SwaggerResponseDescription.java
@@ -379,8 +379,7 @@ public enum SwaggerResponseDescription {
     ))),
     NOTIFICATION_MARK_TO_CHECKED(new LinkedHashSet<>(Set.of(
             NOTIFICATION_NOT_FOUND,
-            NOTIFICATION_ACCESS_FORBIDDEN,
-            NOTIFICATION_ALREADY_CHECKED
+            NOTIFICATION_ACCESS_FORBIDDEN
     ))),
 
   ;

--- a/src/main/java/konkuk/thip/notification/adapter/in/web/NotificationCommandController.java
+++ b/src/main/java/konkuk/thip/notification/adapter/in/web/NotificationCommandController.java
@@ -67,7 +67,8 @@ public class NotificationCommandController {
 
     @Operation(
             summary = "유저의 특정 알림 읽음 처리",
-            description = "유저가 특정 알림을 읽음 처리합니다 (푸시알림, 알림센터의 알림 모두 포함). 읽음 처리 후, 해당 알림의 페이지로 리다이렉트를 위한 데이터를 응답합니다."
+            description = "유저가 특정 알림을 읽음 처리합니다 (푸시알림, 알림센터의 알림 모두 포함). 읽음 처리 후, 해당 알림의 페이지로 리다이렉트를 위한 데이터를 응답합니다. " +
+                    "이미 읽음처리가 된 알림에 대해서는 리다이렉트를 위한 데이터만 응답합니다."
     )
     @ExceptionDescription(NOTIFICATION_MARK_TO_CHECKED)
     @PostMapping("/notifications/check")

--- a/src/main/java/konkuk/thip/notification/application/service/NotificationMarkService.java
+++ b/src/main/java/konkuk/thip/notification/application/service/NotificationMarkService.java
@@ -1,5 +1,6 @@
 package konkuk.thip.notification.application.service;
 
+import konkuk.thip.common.exception.InvalidStateException;
 import konkuk.thip.notification.adapter.in.web.response.NotificationMarkToCheckedResponse;
 import konkuk.thip.notification.application.port.in.NotificationMarkUseCase;
 import konkuk.thip.notification.application.port.out.NotificationCommandPort;
@@ -22,9 +23,13 @@ public class NotificationMarkService implements NotificationMarkUseCase {
         notification.validateOwner(userId);
 
         // 2. 알림 읽음 처리
-        notification.markToChecked();
-        notificationCommandPort.update(notification);
-
+        try {
+            notification.markToChecked();
+            notificationCommandPort.update(notification);
+        } catch (InvalidStateException e) {
+            // 이미 알림 읽음 처리된 경우 -> 무시
+        }
+        
         // 3. 읽음 처리된 알림의 redirectSpec 반환 (for FE 알림 리다이렉트 동작)
         return new NotificationMarkToCheckedResponse(
                 notification.getRedirectSpec().route(),


### PR DESCRIPTION

## #️⃣ 연관된 이슈

> closes #312 

## 📝 작업 내용

이슈 참고해 주시면 됩니다.

개발서버에서 제대로 동작하는것 확인했습니다

## 📸 스크린샷

## 💬 리뷰 요구사항


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 이미 읽은 알림을 다시 읽음 처리할 때, 성공(200)과 함께 리다이렉트 정보(route/params)를 반환합니다.
- 버그 수정
  - 알림 읽음 처리 시 응답 구조를 일관되게 정리했습니다. 권한이 없는 경우 403은 그대로 유지됩니다.
- 문서
  - API 설명을 보강하고, 불필요한 오류 사례를 정리해 문서 정확도를 높였습니다.
- 테스트
  - 재읽기 시나리오를 성공 응답 검증으로 업데이트하고, 리다이렉트 데이터 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->