### PR TITLE
[refactor] 알림 리다이렉트를 위한 데이터 구조 수정

### DIFF
--- a/src/main/java/konkuk/thip/comment/application/service/CommentCreateService.java
+++ b/src/main/java/konkuk/thip/comment/application/service/CommentCreateService.java
@@ -93,24 +93,34 @@ public class CommentCreateService implements CommentCreateUseCase {
     private void sendNotificationsToPostWriter(PostQueryDto postQueryDto, User actorUser) {
         if (postQueryDto.creatorId().equals(actorUser.getId())) return; // 자신이 작성한 게시글 제외
 
-        if (postQueryDto.postType().equals(FEED.getType())) {
-            // 피드 댓글 알림 이벤트 발행
-            feedNotificationOrchestrator.notifyFeedCommented(postQueryDto.creatorId(), actorUser.getId(), actorUser.getNickname(), postQueryDto.postId());
-        } else if (postQueryDto.postType().equals(RECORD.getType()) || postQueryDto.postType().equals(VOTE.getType())) {
-            // 모임방 게시글 댓글 알림 이벤트 발행
-            roomNotificationOrchestrator.notifyRoomPostCommented(postQueryDto.creatorId(), actorUser.getId(), actorUser.getNickname(), postQueryDto.roomId(), postQueryDto.page(), postQueryDto.postId(), postQueryDto.postType());
+        PostType postType = PostType.from(postQueryDto.postType());
+        switch (postType) {
+            case FEED ->    // 피드 댓글 알림 이벤트 발행
+                    feedNotificationOrchestrator.notifyFeedCommented(
+                            postQueryDto.creatorId(), actorUser.getId(), actorUser.getNickname(), postQueryDto.postId()
+                    );
+            case RECORD, VOTE ->    // 모임방 게시글 댓글 알림 이벤트 발행
+                    roomNotificationOrchestrator.notifyRoomPostCommented(
+                            postQueryDto.creatorId(), actorUser.getId(), actorUser.getNickname(),
+                            postQueryDto.roomId(), postQueryDto.page(), postQueryDto.postId(), postType
+                    );
         }
     }
 
     private void sendNotificationsToParentCommentWriter(PostQueryDto postQueryDto, CommentQueryDto parentCommentDto, User actorUser) {
         if (parentCommentDto.creatorId().equals(actorUser.getId())) return; // 자신이 작성한 댓글 제외
 
-        if (postQueryDto.postType().equals(FEED.getType())) {
-            // 피드 답글 알림 이벤트 발행
-            feedNotificationOrchestrator.notifyFeedReplied(parentCommentDto.creatorId(), actorUser.getId(), actorUser.getNickname(), postQueryDto.postId());
-        } else if (postQueryDto.postType().equals(RECORD.getType()) || postQueryDto.postType().equals(VOTE.getType())) {
-            // 모임방 게시글 답글 알림 이벤트 발행
-            roomNotificationOrchestrator.notifyRoomPostCommentReplied(parentCommentDto.creatorId(), actorUser.getId(), actorUser.getNickname(), postQueryDto.roomId(), postQueryDto.page(), postQueryDto.postId(), postQueryDto.postType());
+        PostType postType = PostType.from(postQueryDto.postType());
+        switch (postType) {
+            case FEED ->    // 피드 답글 알림 이벤트 발행
+                    feedNotificationOrchestrator.notifyFeedReplied(
+                            parentCommentDto.creatorId(), actorUser.getId(), actorUser.getNickname(), postQueryDto.postId()
+                    );
+            case RECORD, VOTE ->    // 모임방 게시글 답글 알림 이벤트 발행
+                    roomNotificationOrchestrator.notifyRoomPostCommentReplied(
+                            parentCommentDto.creatorId(), actorUser.getId(), actorUser.getNickname(),
+                            postQueryDto.roomId(), postQueryDto.page(), postQueryDto.postId(), postType
+                    );
         }
     }
 

--- a/src/main/java/konkuk/thip/comment/application/service/CommentLikeService.java
+++ b/src/main/java/konkuk/thip/comment/application/service/CommentLikeService.java
@@ -71,13 +71,19 @@ public class CommentLikeService implements CommentLikeUseCase {
         if (command.userId().equals(comment.getCreatorId())) return; // 자신의 댓글에 좋아요 누르는 경우 제외
 
         User actorUser = userCommandPort.findById(command.userId());
-        // 좋아요 푸쉬알림 전송
-        if (comment.getPostType() == PostType.FEED) {
-            feedNotificationOrchestrator.notifyFeedCommentLiked(comment.getCreatorId(), actorUser.getId(), actorUser.getNickname(), comment.getTargetPostId());
-        }
-        if (comment.getPostType() == PostType.RECORD || comment.getPostType() == PostType.VOTE) {
-            PostQueryDto postQueryDto = postHandler.getPostQueryDto(comment.getPostType(), comment.getTargetPostId());
-            roomNotificationOrchestrator.notifyRoomCommentLiked(comment.getCreatorId(), actorUser.getId(), actorUser.getNickname(), postQueryDto.roomId(), postQueryDto.page(), postQueryDto.postId(), postQueryDto.postType());
+        PostType postType = comment.getPostType();
+
+        switch (postType) {
+            case FEED ->
+                    feedNotificationOrchestrator.notifyFeedCommentLiked(
+                            comment.getCreatorId(), actorUser.getId(), actorUser.getNickname(),comment.getTargetPostId()
+                    );
+            case RECORD, VOTE -> {
+                    PostQueryDto postQueryDto = postHandler.getPostQueryDto(comment.getPostType(), comment.getTargetPostId());
+                    roomNotificationOrchestrator.notifyRoomCommentLiked(
+                            comment.getCreatorId(), actorUser.getId(), actorUser.getNickname(), postQueryDto.roomId(), postQueryDto.page(), postQueryDto.postId(), postType
+                    );
+            }
         }
     }
 }

--- a/src/main/java/konkuk/thip/notification/application/port/in/RoomNotificationOrchestrator.java
+++ b/src/main/java/konkuk/thip/notification/application/port/in/RoomNotificationOrchestrator.java
@@ -1,5 +1,7 @@
 package konkuk.thip.notification.application.port.in;
 
+import konkuk.thip.post.domain.PostType;
+
 public interface RoomNotificationOrchestrator {
 
     /**
@@ -9,7 +11,7 @@ public interface RoomNotificationOrchestrator {
 
     // ===== Room 영역 =====
     void notifyRoomPostCommented(Long targetUserId, Long actorUserId, String actorUsername,
-                                 Long roomId, Integer page, Long postId, String postType);
+                                 Long roomId, Integer page, Long postId, PostType postType);
 
     void notifyRoomVoteStarted(Long targetUserId, Long roomId, String roomTitle, Integer page, Long postId);
 
@@ -24,11 +26,11 @@ public interface RoomNotificationOrchestrator {
                               Long actorUserId, String actorUsername);
 
     void notifyRoomCommentLiked(Long targetUserId, Long actorUserId, String actorUsername,
-                                Long roomId, Integer page, Long postId, String postType);
+                                Long roomId, Integer page, Long postId, PostType postType);
 
     void notifyRoomPostLiked(Long targetUserId, Long actorUserId, String actorUsername,
-                             Long roomId, Integer page, Long postId, String postType);
+                             Long roomId, Integer page, Long postId, PostType postType);
 
     void notifyRoomPostCommentReplied(Long targetUserId, Long actorUserId, String actorUsername,
-                                      Long roomId, Integer page, Long postId, String postType);
+                                      Long roomId, Integer page, Long postId, PostType postType);
 }

--- a/src/main/java/konkuk/thip/notification/domain/value/MessageRoute.java
+++ b/src/main/java/konkuk/thip/notification/domain/value/MessageRoute.java
@@ -16,7 +16,5 @@ public enum MessageRoute {
     // ROOM
     ROOM_MAIN,              // 특정 모임방 메인 화면으로 이동
     ROOM_DETAIL,            // 특정 모임 상세정보 화면으로 이동
-    ROOM_POST_DETAIL,       // 특정 모임 게시글 상세 화면으로 이동 -> PostType으로 투표인지 기록인지 판단
-    ROOM_RECORD_DETAIL,     // 특정 모임 기록 상세 화면으로 이동 (기록장 조회 - 페이지 필터 걸린채로)
-    ROOM_VOTE_DETAIL;       // 특정 모임 투표 상세 화면으로 이동 (투표 조회 - 페이지 필터 걸린채로)
+    ROOM_POST_DETAIL,       // 특정 모임 게시글 상세 화면으로 이동 -> PostType으로 투표(VOTE)인지 기록(RECORD)인지 판단
 }

--- a/src/main/java/konkuk/thip/post/adapter/out/persistence/PostLikeCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/post/adapter/out/persistence/PostLikeCommandPersistenceAdapter.java
@@ -2,14 +2,11 @@ package konkuk.thip.post.adapter.out.persistence;
 
 import konkuk.thip.common.exception.EntityNotFoundException;
 import konkuk.thip.post.adapter.out.persistence.repository.PostLikeJpaRepository;
-import konkuk.thip.feed.adapter.out.jpa.FeedJpaEntity;
 import konkuk.thip.post.domain.PostType;
 import konkuk.thip.feed.adapter.out.persistence.repository.FeedJpaRepository;
 import konkuk.thip.post.adapter.out.jpa.PostJpaEntity;
 import konkuk.thip.post.adapter.out.mapper.PostLikeMapper;
 import konkuk.thip.post.application.port.out.PostLikeCommandPort;
-import konkuk.thip.roompost.adapter.out.jpa.RecordJpaEntity;
-import konkuk.thip.roompost.adapter.out.jpa.VoteJpaEntity;
 import konkuk.thip.roompost.adapter.out.persistence.repository.record.RecordJpaRepository;
 import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
@@ -17,11 +14,7 @@ import konkuk.thip.roompost.adapter.out.persistence.repository.vote.VoteJpaRepos
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import static konkuk.thip.common.exception.code.ErrorCode.*;
 import static konkuk.thip.common.exception.code.ErrorCode.RECORD_NOT_FOUND;

--- a/src/main/java/konkuk/thip/roompost/application/service/RoomPostSearchService.java
+++ b/src/main/java/konkuk/thip/roompost/application/service/RoomPostSearchService.java
@@ -48,7 +48,7 @@ public class RoomPostSearchService implements RoomPostSearchUseCase {
     private final RoomPostAccessValidator roomPostAccessValidator;
     private final RoomPostQueryMapper roomPostQueryMapper;
 
-    private static final int DEFAULT_PAGE_SIZE = 10;
+    private static final int DEFAULT_PAGE_SIZE = 20;
 
     @Override
     @Transactional(readOnly = true)

--- a/src/test/java/konkuk/thip/notification/application/service/RoomNotificationOrchestratorSyncImplTest.java
+++ b/src/test/java/konkuk/thip/notification/application/service/RoomNotificationOrchestratorSyncImplTest.java
@@ -6,6 +6,7 @@ import konkuk.thip.message.application.port.in.RoomNotificationDispatchUseCase;
 import konkuk.thip.notification.adapter.out.jpa.NotificationJpaEntity;
 import konkuk.thip.notification.adapter.out.persistence.repository.NotificationJpaRepository;
 import konkuk.thip.notification.application.port.in.RoomNotificationOrchestrator;
+import konkuk.thip.post.domain.PostType;
 import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
 import konkuk.thip.user.domain.value.Alias;
@@ -63,7 +64,7 @@ class RoomNotificationOrchestratorSyncImplTest {
         Long roomId = 11L;
         Integer page = 1;
         Long postId = 22L;
-        String postType = "RECORD";
+        PostType postType = PostType.RECORD;
 
         // when & then
         assertThatThrownBy(() ->
@@ -83,7 +84,7 @@ class RoomNotificationOrchestratorSyncImplTest {
         Long roomId = 12L;
         Integer page = 3;
         Long postId = 33L;
-        String postType = "RECORD";
+        PostType postType = PostType.RECORD;
 
         // when
         orchestrator.notifyRoomPostCommented(
@@ -110,7 +111,7 @@ class RoomNotificationOrchestratorSyncImplTest {
         Long roomId = 1001L;
         Integer page = 7;
         Long postId = 5001L;
-        String postType = "RECORD";
+        PostType postType = PostType.RECORD;
 
         // when (트랜잭션 안)
         orchestrator.notifyRoomPostCommented(
@@ -146,7 +147,7 @@ class RoomNotificationOrchestratorSyncImplTest {
         Long roomId = 1002L;
         Integer page = 2;
         Long postId = 5002L;
-        String postType = "RECORD";
+        PostType postType = PostType.RECORD;
 
         // when
         orchestrator.notifyRoomPostCommented(

--- a/src/test/java/konkuk/thip/notification/application/service/RoomNotificationOrchestratorSyncImplUnitTest.java
+++ b/src/test/java/konkuk/thip/notification/application/service/RoomNotificationOrchestratorSyncImplUnitTest.java
@@ -1,6 +1,7 @@
 package konkuk.thip.notification.application.service;
 
 import konkuk.thip.message.application.port.out.RoomEventCommandPort;
+import konkuk.thip.post.domain.PostType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,7 +30,7 @@ class RoomNotificationOrchestratorSyncImplUnitTest {
         Long targetUserId = 10L;
         Long actorUserId = 20L;
         String actorUsername = "alice";
-        Long roomId = 1L; int page = 2; Long postId = 3L; String postType = "RECORD";
+        Long roomId = 1L; int page = 2; Long postId = 3L; PostType postType = PostType.RECORD;
 
         // when
         sut.notifyRoomPostCommented(targetUserId, actorUserId, actorUsername, roomId, page, postId, postType);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #314 

## 📝 작업 내용

FE 분들의 요청을 받아 '알림 읽음 처리 api' 의 응답으로 반환하는 데이터들의 구조를 수정했습니다.

1. 모임방 기록 route 경로를 ROOM_POST_DETAIL 1개로 통일
  - 기존에 있던 ROOM_RECORD_DETAIL, ROOM_VOTE_DETAIL 을 삭제하고 모두 ROOM_POST_DETAIL 로 통일시켰습니다

2. ROOM_POST_DETAIL route 시에 param에 "openComments" 키 추가
  - 알림 클릭 시 댓글 모달창이 열린 채로 화면 전환이 이루어져야 하는 경우를 위해 "openComments" key 를 추가했습니다.
  - value 를 boolean type 으로 구성해서, FE 분들은 이 값으로 댓글 모달창을 열지 말지를 판단할 수 있습니다

## 📸 스크린샷
<img width="1112" height="87" alt="image" src="https://github.com/user-attachments/assets/8014a830-a316-4bab-8e3b-dbe95f78ca64" />

<img width="613" height="823" alt="image" src="https://github.com/user-attachments/assets/9cb92bee-cc30-4e6f-b2a4-3d4c219230ad" />

-> 댓글 모달창이 열려야하는 경우에 대해 response.params.openComments 값이 true 인 것 확인했습니다

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 알림에서 댓글/답글 알림을 탭하면 해당 게시글이 열리고 댓글 영역이 즉시 표시됩니다.
- 변경사항
  - 룸 게시글 검색의 기본 페이지 크기를 10에서 20으로 확대해 한 화면에서 더 많은 게시글을 볼 수 있습니다.
- 리팩터
  - 알림 처리 로직을 일원화해 게시글 유형에 따른 알림 동작의 일관성과 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->