### PR TITLE
[feat] 안읽은 알림 여부 조회 api 구현

### DIFF
--- a/src/main/java/konkuk/thip/notification/adapter/in/web/NotificationQueryController.java
+++ b/src/main/java/konkuk/thip/notification/adapter/in/web/NotificationQueryController.java
@@ -8,6 +8,8 @@ import konkuk.thip.common.security.annotation.UserId;
 import konkuk.thip.common.swagger.annotation.ExceptionDescription;
 import konkuk.thip.notification.adapter.in.web.response.NotificationShowEnableStateResponse;
 import konkuk.thip.notification.adapter.in.web.response.NotificationShowResponse;
+import konkuk.thip.notification.adapter.in.web.response.NotificationUncheckedExistsResponse;
+import konkuk.thip.notification.application.port.in.NotificationExistsUncheckedUseCase;
 import konkuk.thip.notification.application.port.in.NotificationShowEnableStateUseCase;
 import konkuk.thip.notification.application.port.in.NotificationShowUseCase;
 import konkuk.thip.notification.application.port.in.dto.NotificationType;
@@ -26,6 +28,7 @@ public class NotificationQueryController {
 
     private final NotificationShowEnableStateUseCase notificationShowEnableStateUseCase;
     private final NotificationShowUseCase notificationShowUseCase;
+    private final NotificationExistsUncheckedUseCase notificationExistsUncheckedUseCase;
 
     @Operation(
             summary = "사용자 푸시알림 수신여부 조회 (마이페이지 -> 알림설정)",
@@ -55,5 +58,15 @@ public class NotificationQueryController {
             @RequestParam(value = "type", required = false, defaultValue = "feedAndRoom") final String type
     ) {
         return BaseResponse.ok(notificationShowUseCase.showNotifications(userId, cursor, NotificationType.from(type)));
+    }
+
+    @Operation(
+            summary = "유저의 안읽은 알림 존재 여부 확인",
+            description = "유저가 읽지 않은 알림이 존재하는지 여부를 확인합니다."
+    )
+    @GetMapping("/notifications/exists-unchecked")
+    public BaseResponse<NotificationUncheckedExistsResponse> existsUnchecked(@Parameter(hidden = true) @UserId final Long userId) {
+        return BaseResponse.ok(NotificationUncheckedExistsResponse.of(
+                        notificationExistsUncheckedUseCase.existsUnchecked(userId)));
     }
 }

--- a/src/main/java/konkuk/thip/notification/adapter/in/web/response/NotificationUncheckedExistsResponse.java
+++ b/src/main/java/konkuk/thip/notification/adapter/in/web/response/NotificationUncheckedExistsResponse.java
@@ -1,0 +1,9 @@
+package konkuk.thip.notification.adapter.in.web.response;
+
+public record NotificationUncheckedExistsResponse(
+        boolean exists
+) {
+    public static NotificationUncheckedExistsResponse of(boolean exists) {
+        return new NotificationUncheckedExistsResponse(exists);
+    }
+}

--- a/src/main/java/konkuk/thip/notification/adapter/out/persistence/NotificationQueryPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/notification/adapter/out/persistence/NotificationQueryPersistenceAdapter.java
@@ -40,6 +40,11 @@ public class NotificationQueryPersistenceAdapter implements NotificationQueryPor
         ));
     }
 
+    @Override
+    public boolean existsUnchecked(Long userId) {
+        return notificationJpaRepository.existsByUserIdAndIsCheckedFalse(userId);
+    }
+
     private CursorBasedList<NotificationQueryDto> findNotificationsByPrimaryKeyCursor(Cursor cursor, PrimaryKeyNotificationQueryFunction queryFunction) {
         Long lastNotificationId = cursor.isFirstRequest() ? null : cursor.getLong(0);
         int pageSize = cursor.getPageSize();

--- a/src/main/java/konkuk/thip/notification/adapter/out/persistence/repository/NotificationQueryRepository.java
+++ b/src/main/java/konkuk/thip/notification/adapter/out/persistence/repository/NotificationQueryRepository.java
@@ -11,4 +11,6 @@ public interface NotificationQueryRepository {
     List<NotificationQueryDto> findRoomNotificationsOrderByCreatedAtDesc(Long userId, Long lastNotificationId, int pageSize);
 
     List<NotificationQueryDto> findFeedAndRoomNotificationsOrderByCreatedAtDesc(Long userId, Long lastNotificationId, int pageSize);
+
+    boolean existsByUserIdAndIsCheckedFalse(Long userId);
 }

--- a/src/main/java/konkuk/thip/notification/adapter/out/persistence/repository/NotificationQueryRepositoryImpl.java
+++ b/src/main/java/konkuk/thip/notification/adapter/out/persistence/repository/NotificationQueryRepositoryImpl.java
@@ -47,6 +47,17 @@ public class NotificationQueryRepositoryImpl implements NotificationQueryReposit
         return getNotificationQueryDtos(pageSize, notification, where);
     }
 
+    @Override
+    public boolean existsByUserIdAndIsCheckedFalse(Long userId) {
+        Integer result = queryFactory.selectOne()
+                .from(notification)
+                .where(notification.userJpaEntity.userId.eq(userId)
+                        .and(notification.isChecked.eq(false)))
+                .fetchFirst();
+
+        return result != null;
+    }
+
     private static BooleanExpression applyCursor(Long lastNotificationId, BooleanExpression where, QNotificationJpaEntity notification) {
         if (lastNotificationId != null) {
             where = where.and(notification.notificationId.lt(lastNotificationId));

--- a/src/main/java/konkuk/thip/notification/application/port/in/NotificationExistsUncheckedUseCase.java
+++ b/src/main/java/konkuk/thip/notification/application/port/in/NotificationExistsUncheckedUseCase.java
@@ -1,0 +1,6 @@
+package konkuk.thip.notification.application.port.in;
+
+public interface NotificationExistsUncheckedUseCase {
+
+    boolean existsUnchecked(Long userId);
+}

--- a/src/main/java/konkuk/thip/notification/application/port/out/NotificationQueryPort.java
+++ b/src/main/java/konkuk/thip/notification/application/port/out/NotificationQueryPort.java
@@ -11,4 +11,6 @@ public interface NotificationQueryPort {
     CursorBasedList<NotificationQueryDto> findRoomNotificationsByUserId(Long userId, Cursor cursor);
 
     CursorBasedList<NotificationQueryDto> findFeedAndRoomNotificationsByUserId(Long userId, Cursor cursor);
+
+    boolean existsUnchecked(Long userId);
 }

--- a/src/main/java/konkuk/thip/notification/application/service/NotificationExistsUncheckedService.java
+++ b/src/main/java/konkuk/thip/notification/application/service/NotificationExistsUncheckedService.java
@@ -1,0 +1,20 @@
+package konkuk.thip.notification.application.service;
+
+import konkuk.thip.notification.application.port.in.NotificationExistsUncheckedUseCase;
+import konkuk.thip.notification.application.port.out.NotificationQueryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationExistsUncheckedService implements NotificationExistsUncheckedUseCase {
+
+    private final NotificationQueryPort notificationQueryPort;
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean existsUnchecked(Long userId) {
+        return notificationQueryPort.existsUnchecked(userId);
+    }
+}

--- a/src/test/java/konkuk/thip/notification/adapter/in/web/NotificationExistsUncheckedApiTest.java
+++ b/src/test/java/konkuk/thip/notification/adapter/in/web/NotificationExistsUncheckedApiTest.java
@@ -1,0 +1,72 @@
+package konkuk.thip.notification.adapter.in.web;
+
+import konkuk.thip.common.util.TestEntityFactory;
+import konkuk.thip.notification.adapter.out.jpa.NotificationJpaEntity;
+import konkuk.thip.notification.adapter.out.persistence.repository.NotificationJpaRepository;
+import konkuk.thip.notification.domain.value.NotificationCategory;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.domain.value.Alias;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("[통합] 안읽은 알림 존재 여부 확인 api 통합 테스트")
+class NotificationExistsUncheckedApiTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private UserJpaRepository userJpaRepository;
+    @Autowired private NotificationJpaRepository notificationJpaRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    @Test
+    @DisplayName("유저가 읽지 않은 알림이 있을 경우, true 를 반환한다.")
+    void notification_exists_unchecked_true() throws Exception {
+        //given
+        UserJpaEntity user = userJpaRepository.save(TestEntityFactory.createUser(Alias.WRITER));
+        NotificationJpaEntity n1 = notificationJpaRepository.save(TestEntityFactory.createNotification(user, "알림1", NotificationCategory.FEED));
+
+        //when
+        ResultActions result = mockMvc.perform(get("/notifications/exists-unchecked")
+                .requestAttr("userId", user.getUserId()));
+
+        //then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.exists").value(true));
+    }
+
+    @Test
+    @DisplayName("유저가 읽지 않은 알림이 없을 경우, false 를 반환한다.")
+    void notification_exists_unchecked_false() throws Exception {
+        //given
+        UserJpaEntity user = userJpaRepository.save(TestEntityFactory.createUser(Alias.WRITER));
+        NotificationJpaEntity n1 = notificationJpaRepository.save(TestEntityFactory.createNotification(user, "알림1", NotificationCategory.FEED));
+        jdbcTemplate.update(
+                "UPDATE notifications SET is_checked = TRUE WHERE notification_id = ?",
+                n1.getNotificationId()
+        );
+
+        //when
+        ResultActions result = mockMvc.perform(get("/notifications/exists-unchecked")
+                .requestAttr("userId", user.getUserId()));
+
+        //then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.exists").value(false));
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #317 

## 📝 작업 내용

- 유저가 안읽은 알림이 있는지 존재 여부를 확인하는 api 를 개발했습니다.
- notifications 테이블 전체를 스캔하며 'is_checked = false' 인 알림을 찾는것을 방지하기 위해, queryDsl의 selectOne(), fetchFirst() 기능을 활용하였습니다
- 통합 테스트 코드를 통해 api 동작을 검증했습니다

## 📸 스크린샷

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 읽지 않은 알림 존재 여부를 확인하는 API 추가: GET /notifications/exists-unchecked
  - 현재 사용자 기준으로 읽지 않은 알림이 하나라도 있으면 exists=true, 없으면 false를 반환
  - 응답 예: { "data": { "exists": true|false } }

- 테스트
  - 통합 테스트 추가: 읽지 않은 알림이 있는/없는 경우 각각 200 응답 및 exists 값 검증

<!-- end of auto-generated comment: release notes by coderabbit.ai -->