### PR TITLE
[Feat] 어플리케이션 단위 500 에러 디스코드로 알림 전송기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,9 @@ dependencies {
 
     // Webflux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // LogStash
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 }
 
 def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile

--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,9 @@ dependencies {
 
 	// Firebase
 	implementation 'com.google.firebase:firebase-admin:9.3.0'
+
+    // Webflux
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile

--- a/src/main/java/konkuk/thip/book/adapter/out/api/aladin/AladinApiUtil.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/api/aladin/AladinApiUtil.java
@@ -2,7 +2,7 @@ package konkuk.thip.book.adapter.out.api.aladin;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import konkuk.thip.common.exception.BusinessException;
+import konkuk.thip.common.exception.ExternalApiException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -54,14 +54,15 @@ public class AladinApiUtil {
                 // TODO : 알라딘으로부터 page 정보가 없으면 ??
                 // 보상 시나리오 : 유저에게 "page 정보를 찾을 수 없는 책입니다. 직접 page 정보를 입력하세요" 라고 안내
                 // 일단 지금은 exception throw 만 진행
-                throw new BusinessException(BOOK_ALADIN_API_ISBN_NOT_FOUND);
+                throw new ExternalApiException(BOOK_ALADIN_API_ISBN_NOT_FOUND);
             }
 
             JsonNode subInfo = items.get(0).path(SUB_INFO_PARSING_KEY.getValue());
 
             return subInfo.path(PAGE_COUNT_PARSING_KEY.getValue()).asInt();
         } catch (IOException e) {
-            throw new BusinessException(BOOK_ALADIN_API_PARSING_ERROR);
+            throw new ExternalApiException(BOOK_ALADIN_API_PARSING_ERROR);
         }
     }
 }
+

--- a/src/main/java/konkuk/thip/book/adapter/out/api/naver/NaverApiUtil.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/api/naver/NaverApiUtil.java
@@ -1,6 +1,7 @@
 package konkuk.thip.book.adapter.out.api.naver;
 
-import konkuk.thip.common.exception.BusinessException;
+import konkuk.thip.common.exception.ExternalApiException;
+import konkuk.thip.common.exception.InternalServerException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -63,7 +64,7 @@ public class NaverApiUtil {
         try {
             text = URLEncoder.encode(keyword, "UTF-8");
         } catch (UnsupportedEncodingException e) {
-            throw new BusinessException(BOOK_KEYWORD_ENCODING_FAILED);
+            throw new InternalServerException(BOOK_KEYWORD_ENCODING_FAILED);
         }
         return text;
     }
@@ -84,7 +85,7 @@ public class NaverApiUtil {
                 return readBody(con.getErrorStream());
             }
         } catch (IOException e) {
-            throw new BusinessException(BOOK_NAVER_API_REQUEST_ERROR);
+            throw new ExternalApiException(BOOK_NAVER_API_REQUEST_ERROR);
         } finally {
             con.disconnect();
         }
@@ -96,9 +97,9 @@ public class NaverApiUtil {
             URL url = new URL(apiUrl);
             return (HttpURLConnection)url.openConnection();
         } catch (MalformedURLException e) {
-            throw new BusinessException(BOOK_NAVER_API_URL_ERROR);
+            throw new InternalServerException(BOOK_NAVER_API_URL_ERROR);
         } catch (IOException e) {
-            throw new BusinessException(BOOK_NAVER_API_URL_HTTP_CONNECT_FAILED);
+            throw new InternalServerException(BOOK_NAVER_API_URL_HTTP_CONNECT_FAILED);
         }
     }
 
@@ -116,7 +117,7 @@ public class NaverApiUtil {
 
             return responseBody.toString();
         } catch (IOException e) {
-            throw new BusinessException(BOOK_NAVER_API_RESPONSE_ERROR);
+            throw new ExternalApiException(BOOK_NAVER_API_RESPONSE_ERROR);
         }
     }
 

--- a/src/main/java/konkuk/thip/book/adapter/out/persistence/BookRedisAdapter.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/persistence/BookRedisAdapter.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import konkuk.thip.book.application.port.in.dto.BookMostSearchResult;
 import konkuk.thip.book.application.port.out.BookRedisCommandPort;
 import konkuk.thip.book.application.port.out.BookRedisQueryPort;
-import konkuk.thip.common.exception.ExternalApiException;
+import konkuk.thip.common.exception.InternalServerException;
 import konkuk.thip.common.exception.code.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -80,7 +80,7 @@ public class BookRedisAdapter implements BookRedisQueryPort, BookRedisCommandPor
                     new TypeReference<List<BookMostSearchResult.BookRankInfo>>() {}
             );
         } catch (JsonProcessingException e) {
-            throw new ExternalApiException(ErrorCode.JSON_PROCESSING_ERROR);
+            throw new InternalServerException(ErrorCode.JSON_PROCESSING_ERROR);
         }
     }
 
@@ -106,7 +106,7 @@ public class BookRedisAdapter implements BookRedisQueryPort, BookRedisCommandPor
         try {
             detailJson = objectMapper.writeValueAsString(bookRankDetails);
         } catch (JsonProcessingException e) {
-            throw new ExternalApiException(JSON_PROCESSING_ERROR);
+            throw new InternalServerException(JSON_PROCESSING_ERROR);
         }
         redisTemplate.opsForValue().set(redisKey, detailJson);
     }

--- a/src/main/java/konkuk/thip/common/Discord/DiscordClient.java
+++ b/src/main/java/konkuk/thip/common/Discord/DiscordClient.java
@@ -14,14 +14,14 @@ import java.util.Map;
 @Component
 public class DiscordClient {
 
-    @Value("$(discord.env")
+    @Value("${discord.env}")
     private String env;
 
     @Value("${discord.webhook-url}")
     private String webhookUrl;
 
     public void sendErrorMessage(String message, String stackTrace, String requestId, String userId) {
-        if(env.equals("test")) return;
+        if("test".equals(env)) return;
 
         WebClient webClient = WebClient.create();
 

--- a/src/main/java/konkuk/thip/common/Discord/DiscordClient.java
+++ b/src/main/java/konkuk/thip/common/Discord/DiscordClient.java
@@ -1,0 +1,64 @@
+package konkuk.thip.common.Discord;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class DiscordClient {
+
+    @Value("$(discord.env")
+    private String env;
+
+    @Value("${discord.webhook-url}")
+    private String webhookUrl;
+
+    public void sendErrorMessage(String message, String stackTrace, String requestId, String userId) {
+        if(env.equals("test")) return;
+
+        WebClient webClient = WebClient.create();
+
+        Map<String, Object> embedData = new HashMap<>();
+        embedData.put("title", "THIP 서버 500 에러 발생");
+
+        Map<String, String> field1 = new HashMap<>();
+        field1.put("name", "발생시각");
+        field1.put("value", LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+
+        Map<String, String> field2 = new HashMap<>();
+        field2.put("name", "에러 명");
+        field2.put("value", message);
+
+        Map<String, String> field3 = new HashMap<>();
+        field3.put("name", "스택 트레이스");
+        field3.put("value", stackTrace);
+
+        Map<String, String> field4 = new HashMap<>();
+        field4.put("name", "Request ID");
+        field4.put("value", requestId != null ? requestId : "N/A");
+
+        Map<String, String> field5 = new HashMap<>();
+        field5.put("name", "User ID");
+        field5.put("value", userId != null ? userId : "N/A");
+
+        embedData.put("fields", List.of(field1, field2, field3, field4, field5));
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("embeds", new Object[]{embedData});
+
+        webClient.post()
+                .uri(webhookUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(payload)
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block();
+    }
+}

--- a/src/main/java/konkuk/thip/common/aop/StatusFilterAspect.java
+++ b/src/main/java/konkuk/thip/common/aop/StatusFilterAspect.java
@@ -2,7 +2,7 @@ package konkuk.thip.common.aop;
 
 import jakarta.persistence.EntityManager;
 import konkuk.thip.common.entity.StatusType;
-import konkuk.thip.common.exception.InvalidStateException;
+import konkuk.thip.common.exception.InternalServerException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -30,7 +30,7 @@ public class StatusFilterAspect {
      */
     private Session currentTxSession() {
         if (!TransactionSynchronizationManager.isActualTransactionActive()) {
-            throw new InvalidStateException(PERSISTENCE_TRANSACTION_REQUIRED);
+            throw new InternalServerException(PERSISTENCE_TRANSACTION_REQUIRED);
         }
         return session();
     }

--- a/src/main/java/konkuk/thip/common/discord/DiscordClient.java
+++ b/src/main/java/konkuk/thip/common/discord/DiscordClient.java
@@ -1,4 +1,4 @@
-package konkuk.thip.common.Discord;
+package konkuk.thip.common.discord;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;

--- a/src/main/java/konkuk/thip/common/dto/BaseResponse.java
+++ b/src/main/java/konkuk/thip/common/dto/BaseResponse.java
@@ -3,9 +3,14 @@ package konkuk.thip.common.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 
+import static konkuk.thip.common.logging.LoggingConstant.REQUEST_ID;
+
+@Slf4j
 @Getter
-@JsonPropertyOrder({"success", "code", "message", "data"})
+@JsonPropertyOrder({"success", "code", "message", "requestId", "data"})
 public class BaseResponse<T> {
 
     @JsonProperty("isSuccess")
@@ -15,17 +20,20 @@ public class BaseResponse<T> {
 
     private final String message;
 
+    private final String requestId;
+
     private final T data;
 
-    private BaseResponse(boolean success, int code, String message, T data) {
+    private BaseResponse(boolean success, int code, String message, String requestId, T data) {
         this.success = success;
         this.code = code;
         this.message = message;
+        this.requestId = requestId;
         this.data = data;
     }
 
     private BaseResponse(ResponseCode response, T data) {
-        this(response.isSuccess(), response.getCode(), response.getMessage(), data);
+        this(response.isSuccess(), response.getCode(), response.getMessage(), MDC.get(REQUEST_ID.getValue()), data);
     }
 
     public static <T> BaseResponse<T> ok(T data) {

--- a/src/main/java/konkuk/thip/common/dto/ErrorResponse.java
+++ b/src/main/java/konkuk/thip/common/dto/ErrorResponse.java
@@ -3,9 +3,12 @@ package konkuk.thip.common.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
+import org.slf4j.MDC;
+
+import static konkuk.thip.common.logging.LoggingConstant.REQUEST_ID;
 
 @Getter
-@JsonPropertyOrder({"success", "code", "message"})
+@JsonPropertyOrder({"success", "code", "message", "requestId"})
 public class ErrorResponse {
 
     @JsonProperty("isSuccess")
@@ -15,14 +18,17 @@ public class ErrorResponse {
 
     private final String message;
 
-    private ErrorResponse(boolean success, int code, String message) {
+    private final String requestId;
+
+    private ErrorResponse(boolean success, int code, String message, String requestId) {
         this.success = success;
         this.code = code;
         this.message = message;
+        this.requestId = requestId;
     }
 
     private ErrorResponse(ResponseCode response) {
-        this(response.isSuccess(), response.getCode(), response.getMessage());
+        this(response.isSuccess(), response.getCode(), response.getMessage(), MDC.get(REQUEST_ID.getValue()));
     }
 
     public static ErrorResponse of(ResponseCode response) {
@@ -32,6 +38,6 @@ public class ErrorResponse {
     public static ErrorResponse of(ResponseCode response, String message) {
         StringBuilder sb =  new StringBuilder();
         sb.append(response.getMessage()).append(" ").append(message);
-        return new ErrorResponse(response.isSuccess(), response.getCode(), sb.toString());
+        return new ErrorResponse(response.isSuccess(), response.getCode(), sb.toString(), MDC.get(REQUEST_ID.getValue()));
     }
 }

--- a/src/main/java/konkuk/thip/common/exception/FirebaseException.java
+++ b/src/main/java/konkuk/thip/common/exception/FirebaseException.java
@@ -2,20 +2,16 @@ package konkuk.thip.common.exception;
 
 import konkuk.thip.common.exception.code.ErrorCode;
 
-public class FirebaseException extends BusinessException {
+public class FirebaseException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
     public FirebaseException(ErrorCode errorCode) {
-        super(errorCode);
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
     }
-
     public FirebaseException(ErrorCode errorCode, Exception e) {
-        super(errorCode, e);
-    }
-
-    public FirebaseException(Exception e) {
-        super(ErrorCode.FIREBASE_SEND_ERROR, e);
-    }
-
-    public FirebaseException() {
-        super(ErrorCode.FIREBASE_SEND_ERROR);
+        super(errorCode.getMessage(), e);
+        this.errorCode = errorCode;
     }
 }

--- a/src/main/java/konkuk/thip/common/exception/InternalServerException.java
+++ b/src/main/java/konkuk/thip/common/exception/InternalServerException.java
@@ -1,0 +1,17 @@
+package konkuk.thip.common.exception;
+
+import konkuk.thip.common.exception.code.ErrorCode;
+
+public class InternalServerException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public InternalServerException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+    public InternalServerException(ErrorCode errorCode, Exception e) {
+        super(errorCode.getMessage(), e);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
@@ -78,11 +78,10 @@ public enum ErrorCode implements ResponseCode {
     BOOK_NAVER_API_ISBN_NOT_FOUND(HttpStatus.BAD_REQUEST, 80009, "네이버 API 에서 ISBN으로 검색한 결과가 존재하지 않습니다."),
     BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, 80010, "존재하지 않는 BOOK 입니다."),
     BOOK_ALREADY_SAVED(HttpStatus.BAD_REQUEST, 80011, "사용자가 이미 저장한 책입니다."),
-    DUPLICATED_BOOKS_IN_COLLECTION(HttpStatus.INTERNAL_SERVER_ERROR, 80012, "중복된 책이 존재합니다."),
     BOOK_NOT_SAVED_CANNOT_DELETE(HttpStatus.BAD_REQUEST, 80013, "사용자가 저장하지 않은 책은 저장삭제 할 수 없습니다."),
     BOOK_NOT_SAVED_DB_CANNOT_DELETE(HttpStatus.BAD_REQUEST, 80014, "DB에 존재하지 않은 책은 저장삭제 할 수 없습니다."),
     BOOK_ALADIN_API_PARSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 80015, "알라딘 API 응답 파싱에 실패하였습니다."),
-    BOOK_ALADIN_API_ISBN_NOT_FOUND(HttpStatus.BAD_REQUEST, 80016, "알라딘 API 에서 ISBN으로 검색한 결과가 존재하지 않습니다."),
+    BOOK_ALADIN_API_ISBN_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, 80016, "알라딘 API 에서 ISBN으로 검색한 결과가 존재하지 않습니다."),
 
     /**
      * 90000 : recentSearch error
@@ -225,6 +224,7 @@ public enum ErrorCode implements ResponseCode {
     FCM_TOKEN_ENABLED_STATE_ALREADY(HttpStatus.BAD_REQUEST, 200001, "요청한 상태로 이미 푸쉬 알림 여부가 설정되어 있습니다."),
     FCM_TOKEN_ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN, 200002, "토큰을 소유하고 있는 계정이 아닙니다."),
     FIREBASE_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 200003, "FCM 푸쉬 알림 전송에 실패했습니다."),
+    FCM_TOKEN_DEVICE_ARRAY_MISMATCH(HttpStatus.INTERNAL_SERVER_ERROR, 200004, "메시지, FCM 토큰, 디바이스 ID 리스트의 크기는 같아야 합니다."),
 
 
     /**

--- a/src/main/java/konkuk/thip/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/konkuk/thip/common/exception/handler/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import konkuk.thip.common.dto.ErrorResponse;
 import konkuk.thip.common.exception.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -19,6 +20,8 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 import java.util.Optional;
 
 import static konkuk.thip.common.exception.code.ErrorCode.*;
+import static konkuk.thip.common.logging.LoggingConstant.REQUEST_ID;
+import static konkuk.thip.common.logging.LoggingConstant.USER_ID;
 
 @Slf4j
 @RestControllerAdvice
@@ -123,13 +126,9 @@ public class GlobalExceptionHandler {
             stackSummary = lines[1] + "\n" + lines[2] + "\n" + lines[lines.length - 1];
         }
 
-//        // MDC에서 requestId, userId 추출
-//        String requestId = MDC.get("requestId");
-//        String userId = MDC.get("userId");
-
         // MDC에서 requestId, userId 추출
-        String requestId = "dummyRequestId";
-        String userId = "dummyUserId";
+        String requestId = MDC.get(REQUEST_ID.getValue());
+        String userId = MDC.get(USER_ID.getValue());
 
         // Discord 웹훅 전송
         discordClient.sendErrorMessage(combinedMessage, stackSummary, requestId, userId);

--- a/src/main/java/konkuk/thip/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/konkuk/thip/common/exception/handler/GlobalExceptionHandler.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import static konkuk.thip.common.exception.code.ErrorCode.*;
 import static konkuk.thip.common.logging.LoggingConstant.REQUEST_ID;
 import static konkuk.thip.common.logging.LoggingConstant.USER_ID;
+import static org.apache.commons.lang3.exception.ExceptionUtils.getStackTrace;
 
 @Slf4j
 @RestControllerAdvice
@@ -115,7 +116,7 @@ public class GlobalExceptionHandler {
 
         String exceptionClassName = e.getClass().getSimpleName(); // 예외 클래스명
         String combinedMessage = "[" + exceptionClassName + "] " + e.getMessage(); // 메시지에 예외 클래스명 포함
-        String stackTrace = org.apache.commons.lang3.exception.ExceptionUtils.getStackTrace(e);
+        String stackTrace = getStackTrace(e);
 
         // 스택트레이스 요약: 두,세번째 줄 + 마지막줄
         String[] lines = stackTrace.split("\n");

--- a/src/main/java/konkuk/thip/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/konkuk/thip/common/exception/handler/GlobalExceptionHandler.java
@@ -2,9 +2,9 @@ package konkuk.thip.common.exception.handler;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
+import konkuk.thip.common.Discord.DiscordClient;
 import konkuk.thip.common.dto.ErrorResponse;
-import konkuk.thip.common.exception.AuthException;
-import konkuk.thip.common.exception.BusinessException;
+import konkuk.thip.common.exception.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +24,8 @@ import static konkuk.thip.common.exception.code.ErrorCode.*;
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
+
+    private final DiscordClient discordClient;
 
     // 요청한 API가 없는 경우
     @ExceptionHandler(NoHandlerFoundException.class)
@@ -102,19 +104,36 @@ public class GlobalExceptionHandler {
                 .body(ErrorResponse.of(e.getErrorCode(), detail));
     }
 
-    // 서버 내부 오류 예외 처리
-    @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<ErrorResponse> runtimeExceptionHandler(RuntimeException e) {
-        log.error("[RuntimeExceptionHandler] {}", e.getMessage(), e); // 메시지와 스택트레이스 출력
-        return ResponseEntity
-                .status(API_SERVER_ERROR.getHttpStatus())
-                .body(ErrorResponse.of(API_SERVER_ERROR));
-    }
+    // 서버 내부 오류 예외 (500) 처리
+    @ExceptionHandler({RuntimeException.class, IllegalStateException.class,
+            FirebaseException.class, InternalServerException.class, ExternalApiException.class})
+    public ResponseEntity<ErrorResponse> handleServerErrors(Exception e) {
+        log.error("[ServerErrorHandler] {}", e.getMessage(), e);
 
-    // IllegalStateException 예외 처리
-    @ExceptionHandler(IllegalStateException.class)
-    public ResponseEntity<ErrorResponse> illegalStateExceptionHandler(IllegalStateException e) {
-        log.error("[IllegalStateExceptionHandler] {}", e.getMessage());
+        String exceptionClassName = e.getClass().getSimpleName(); // 예외 클래스명
+        String combinedMessage = "[" + exceptionClassName + "] " + e.getMessage(); // 메시지에 예외 클래스명 포함
+        String stackTrace = org.apache.commons.lang3.exception.ExceptionUtils.getStackTrace(e);
+
+        // 스택트레이스 요약: 두,세번째 줄 + 마지막줄
+        String[] lines = stackTrace.split("\n");
+        String stackSummary;
+        if (lines.length <= 3) {
+            stackSummary = stackTrace; // 짧으면 다 보여줌
+        } else {
+            stackSummary = lines[1] + "\n" + lines[2] + "\n" + lines[lines.length - 1];
+        }
+
+//        // MDC에서 requestId, userId 추출
+//        String requestId = MDC.get("requestId");
+//        String userId = MDC.get("userId");
+
+        // MDC에서 requestId, userId 추출
+        String requestId = "dummyRequestId";
+        String userId = "dummyUserId";
+
+        // Discord 웹훅 전송
+        discordClient.sendErrorMessage(combinedMessage, stackSummary, requestId, userId);
+
         return ResponseEntity
                 .status(API_SERVER_ERROR.getHttpStatus())
                 .body(ErrorResponse.of(API_SERVER_ERROR));

--- a/src/main/java/konkuk/thip/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/konkuk/thip/common/exception/handler/GlobalExceptionHandler.java
@@ -132,7 +132,11 @@ public class GlobalExceptionHandler {
         String userId = "dummyUserId";
 
         // Discord 웹훅 전송
-        discordClient.sendErrorMessage(combinedMessage, stackSummary, requestId, userId);
+        try {
+            discordClient.sendErrorMessage(combinedMessage, stackSummary, requestId, userId);
+        } catch (Exception sendException) {
+            log.error("[ServerErrorHandler] -> [Discord] 전송 실패", sendException);
+        }
 
         return ResponseEntity
                 .status(API_SERVER_ERROR.getHttpStatus())

--- a/src/main/java/konkuk/thip/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/konkuk/thip/common/exception/handler/GlobalExceptionHandler.java
@@ -2,7 +2,7 @@ package konkuk.thip.common.exception.handler;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
-import konkuk.thip.common.Discord.DiscordClient;
+import konkuk.thip.common.discord.DiscordClient;
 import konkuk.thip.common.dto.ErrorResponse;
 import konkuk.thip.common.exception.*;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/konkuk/thip/common/logging/LoggingConstant.java
+++ b/src/main/java/konkuk/thip/common/logging/LoggingConstant.java
@@ -1,0 +1,16 @@
+package konkuk.thip.common.logging;
+
+public enum LoggingConstant {
+    REQUEST_ID("request_id"),
+    USER_ID("user_id");
+
+    private final String value;
+
+    LoggingConstant(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/konkuk/thip/common/logging/MdcLoggingFilter.java
+++ b/src/main/java/konkuk/thip/common/logging/MdcLoggingFilter.java
@@ -1,0 +1,34 @@
+package konkuk.thip.common.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static konkuk.thip.common.logging.LoggingConstant.REQUEST_ID;
+
+@Component
+public class MdcLoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    jakarta.servlet.http.HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String rawRequestId = request.getHeader("X-Request-ID");
+            String requestId = (rawRequestId == null || rawRequestId.trim().isEmpty())
+                    ? UUID.randomUUID().toString()
+                    : rawRequestId;
+
+            MDC.put(REQUEST_ID.getValue(), requestId);
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.clear();
+        }
+    }
+}

--- a/src/main/java/konkuk/thip/common/logging/MdcLoggingFilter.java
+++ b/src/main/java/konkuk/thip/common/logging/MdcLoggingFilter.java
@@ -3,6 +3,7 @@ package konkuk.thip.common.logging;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -17,7 +18,7 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
-                                    jakarta.servlet.http.HttpServletResponse response,
+                                    HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
         try {
             String rawRequestId = request.getHeader("X-Request-ID");

--- a/src/main/java/konkuk/thip/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/konkuk/thip/common/security/filter/JwtAuthenticationFilter.java
@@ -104,12 +104,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             throw new AuthException(AUTH_BLACKLIST_TOKEN);
         }
 
-        if (!jwtUtil.validateToken(token)) {
-            throw new AuthException(AUTH_INVALID_TOKEN);
-        }
-
         if (jwtUtil.isExpired(token)) {
             throw new AuthException(AUTH_EXPIRED_TOKEN);
+        }
+
+        if (!jwtUtil.validateToken(token)) {
+            throw new AuthException(AUTH_INVALID_TOKEN);
         }
     }
 

--- a/src/main/java/konkuk/thip/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/konkuk/thip/common/security/filter/JwtAuthenticationFilter.java
@@ -13,6 +13,7 @@ import konkuk.thip.common.security.util.JwtUtil;
 import konkuk.thip.user.application.port.UserTokenBlacklistQueryPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.http.server.PathContainer;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -26,6 +27,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static konkuk.thip.common.exception.code.ErrorCode.*;
+import static konkuk.thip.common.logging.LoggingConstant.USER_ID;
 import static konkuk.thip.common.security.constant.AuthParameters.*;
 
 @Slf4j
@@ -67,24 +69,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain) throws ServletException, IOException {
         try {
             String token = extractToken(request);
-            if (token == null) {
-                throw new AuthException(AUTH_TOKEN_NOT_FOUND);
-            }
 
-            if (userTokenBlacklistQueryPort.isTokenBlacklisted(token)) {
-                throw new AuthException(AUTH_BLACKLIST_TOKEN);
-            }
-
-            if (!jwtUtil.validateToken(token)) {
-                throw new AuthException(AUTH_INVALID_TOKEN);
-            }
-
-            if (jwtUtil.isExpired(token)) {
-                throw new AuthException(AUTH_EXPIRED_TOKEN);
-            }
+            validateToken(token);
 
             request.setAttribute(JWT_TOKEN_ATTRIBUTE.getValue(), token);
             LoginUser loginUser = jwtUtil.getLoginUser(token);
+            MDC.put(USER_ID.getValue(), String.valueOf(loginUser.userId()));
 
             if (loginUser.userId() != null) {
                 request.setAttribute(JWT_ACCESS_TOKEN_KEY.getValue(), loginUser.userId());
@@ -102,6 +92,24 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             request.setAttribute("exception", e);
         } finally {
             filterChain.doFilter(request, response);
+        }
+    }
+
+    private void validateToken(String token) {
+        if (token == null) {
+            throw new AuthException(AUTH_TOKEN_NOT_FOUND);
+        }
+
+        if (userTokenBlacklistQueryPort.isTokenBlacklisted(token)) {
+            throw new AuthException(AUTH_BLACKLIST_TOKEN);
+        }
+
+        if (!jwtUtil.validateToken(token)) {
+            throw new AuthException(AUTH_INVALID_TOKEN);
+        }
+
+        if (jwtUtil.isExpired(token)) {
+            throw new AuthException(AUTH_EXPIRED_TOKEN);
         }
     }
 

--- a/src/main/java/konkuk/thip/common/security/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/konkuk/thip/common/security/oauth2/CustomSuccessHandler.java
@@ -3,7 +3,7 @@ package konkuk.thip.common.security.oauth2;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import konkuk.thip.common.exception.AuthException;
+import konkuk.thip.common.exception.InternalServerException;
 import konkuk.thip.common.exception.code.ErrorCode;
 import konkuk.thip.common.security.oauth2.tokenstorage.LoginTokenStorage;
 import konkuk.thip.common.security.util.JwtUtil;
@@ -51,7 +51,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         if (!webDomainProperties.isAllowed(Objects.toString(webRedirectDomain, ""))) {
             List<String> origins = webDomainProperties.getWebDomainUrls();
             if (origins == null || origins.isEmpty()) {
-                throw new AuthException(ErrorCode.WEB_DOMAIN_ORIGIN_EMPTY);
+                throw new InternalServerException(ErrorCode.WEB_DOMAIN_ORIGIN_EMPTY);
             }
             webRedirectDomain = origins.get(0);
         }

--- a/src/main/java/konkuk/thip/common/security/oauth2/tokenstorage/RedisLoginTokenStorage.java
+++ b/src/main/java/konkuk/thip/common/security/oauth2/tokenstorage/RedisLoginTokenStorage.java
@@ -1,6 +1,6 @@
 package konkuk.thip.common.security.oauth2.tokenstorage;
 
-import konkuk.thip.common.exception.AuthException;
+import konkuk.thip.common.exception.InternalServerException;
 import konkuk.thip.common.exception.code.ErrorCode;
 import konkuk.thip.common.security.oauth2.TokenType;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +39,7 @@ public class RedisLoginTokenStorage implements LoginTokenStorage {
             return entry;
         }
 
-        throw new AuthException(ErrorCode.JSON_PROCESSING_ERROR);
+        throw new InternalServerException(ErrorCode.JSON_PROCESSING_ERROR);
     }
 
     private String toRedisKey(String key) {

--- a/src/main/java/konkuk/thip/config/AwsS3ImageUrlInitializer.java
+++ b/src/main/java/konkuk/thip/config/AwsS3ImageUrlInitializer.java
@@ -1,7 +1,7 @@
 package konkuk.thip.config;
 
 import jakarta.annotation.PostConstruct;
-import konkuk.thip.common.exception.BusinessException;
+import konkuk.thip.common.exception.InternalServerException;
 import konkuk.thip.config.properties.AwsS3Properties;
 import konkuk.thip.room.domain.value.Category;
 import konkuk.thip.user.domain.value.Alias;
@@ -20,7 +20,7 @@ public class AwsS3ImageUrlInitializer {
     void bindCloudFrontBaseUrl() {
         String baseUrl = awsS3Properties.cloudFrontBaseUrl();
         if (baseUrl == null || baseUrl.isEmpty()) {
-            throw new BusinessException(AWS_BUCKET_BASE_URL_NOT_CONFIGURED);
+            throw new InternalServerException(AWS_BUCKET_BASE_URL_NOT_CONFIGURED);
         }
 
         Alias.registerBaseUrlSupplier(awsS3Properties::cloudFrontBaseUrl);

--- a/src/main/java/konkuk/thip/config/SecurityConfig.java
+++ b/src/main/java/konkuk/thip/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package konkuk.thip.config;
 
+import konkuk.thip.common.logging.MdcLoggingFilter;
 import konkuk.thip.common.security.constant.SecurityWhitelist;
 import konkuk.thip.common.security.filter.JwtAuthenticationEntryPoint;
 import konkuk.thip.common.security.filter.JwtAuthenticationFilter;
@@ -46,6 +47,7 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomSuccessHandler customSuccessHandler;
+    private final MdcLoggingFilter mdcLoggingFilter;
 
     private final ClientRegistrationRepository clientRegistrationRepository;
     private final WebDomainProperties webDomainProperties;
@@ -69,6 +71,7 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(mdcLoggingFilter, JwtAuthenticationFilter.class)
                 .oauth2Login((oauth2) -> oauth2
                         .authorizationEndpoint(authorizationEndpointConfig -> authorizationEndpointConfig
                                 .authorizationRequestResolver(resolver)

--- a/src/main/java/konkuk/thip/message/adapter/out/firebase/FirebaseAdapter.java
+++ b/src/main/java/konkuk/thip/message/adapter/out/firebase/FirebaseAdapter.java
@@ -11,6 +11,9 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+import static konkuk.thip.common.exception.code.ErrorCode.FCM_TOKEN_DEVICE_ARRAY_MISMATCH;
+import static konkuk.thip.common.exception.code.ErrorCode.FIREBASE_SEND_ERROR;
+
 @Slf4j
 @Component
 @Profile("!test & !local")
@@ -29,14 +32,14 @@ public class FirebaseAdapter implements FirebaseMessagingPort {
             log.debug("[FCM:SEND] ok id={} token={} device={}", messageId, maskDependingProfile(fcmToken), maskDependingProfile(deviceId));
         } catch (FirebaseMessagingException e) {
             log.warn("[FCM:SEND] fail token={} device={} code={} msg={}", maskDependingProfile(fcmToken), maskDependingProfile(deviceId), e.getMessagingErrorCode(), e.getMessage());
-            throw new FirebaseException(e);
+            throw new FirebaseException(FIREBASE_SEND_ERROR);
         }
     }
 
     @Override
     public void sendBatch(List<Message> messages, List<String> fcmTokens, List<String> deviceIds) {
         if (messages.size() != fcmTokens.size() || messages.size() != deviceIds.size()) {
-            throw new FirebaseException(new IllegalArgumentException("메시지, FCM 토큰, 디바이스 ID 리스트의 크기는 같아야 합니다."));
+            throw new FirebaseException(FCM_TOKEN_DEVICE_ARRAY_MISMATCH);
         }
 
         try {
@@ -62,11 +65,11 @@ public class FirebaseAdapter implements FirebaseMessagingPort {
 
             if (batchResponse.getFailureCount() > 0) {
                 log.warn("[FCM:BATCH] 일부 메시지 전송 실패: {}/{}", batchResponse.getFailureCount(), messages.size());
-                throw new FirebaseException();
+                throw new FirebaseException(FIREBASE_SEND_ERROR);
             }
         } catch (FirebaseMessagingException e) {
             log.warn("[FCM:BATCH] 메시지 전송 실패: code={} msg={}", e.getMessagingErrorCode(), e.getMessage());
-            throw new FirebaseException(e);
+            throw new FirebaseException(FIREBASE_SEND_ERROR);
         }
     }
 

--- a/src/main/java/konkuk/thip/notification/domain/value/NotificationRedirectSpecConverter.java
+++ b/src/main/java/konkuk/thip/notification/domain/value/NotificationRedirectSpecConverter.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
-import konkuk.thip.common.exception.InvalidStateException;
+import konkuk.thip.common.exception.InternalServerException;
 
 import java.io.IOException;
 
@@ -22,7 +22,7 @@ public class NotificationRedirectSpecConverter implements AttributeConverter<Not
         try {
             return objectMapper.writeValueAsString(attribute);
         } catch (JsonProcessingException e) {
-            throw new InvalidStateException(NOTIFICATION_REDIRECT_DATA_SERIALIZE_FAILED);
+            throw new InternalServerException(NOTIFICATION_REDIRECT_DATA_SERIALIZE_FAILED);
         }
     }
 
@@ -32,7 +32,7 @@ public class NotificationRedirectSpecConverter implements AttributeConverter<Not
         try {
             return objectMapper.readValue(dbData, NotificationRedirectSpec.class);
         } catch (IOException e) {
-            throw new InvalidStateException(NOTIFICATION_REDIRECT_DATA_DESERIALIZE_FAILED);
+            throw new InternalServerException(NOTIFICATION_REDIRECT_DATA_DESERIALIZE_FAILED);
         }
     }
 }

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/UserTokenBlacklistRedisAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/UserTokenBlacklistRedisAdapter.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import konkuk.thip.common.exception.ExternalApiException;
+import konkuk.thip.common.exception.InternalServerException;
 import konkuk.thip.common.security.oauth2.LoginUser;
 import konkuk.thip.common.security.util.JwtUtil;
 import konkuk.thip.user.application.port.UserTokenBlacklistCommandPort;
@@ -52,7 +52,7 @@ public class UserTokenBlacklistRedisAdapter implements UserTokenBlacklistQueryPo
             mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
             valueJson = mapper.writeValueAsString(valueMap);
         } catch (JsonProcessingException e) {
-            throw new ExternalApiException(JSON_PROCESSING_ERROR);
+            throw new InternalServerException(JSON_PROCESSING_ERROR);
         }
         redisTemplate.opsForValue().set(key, valueJson);
         log.info("블랙리스트에 탈퇴한 회원 토큰 및 관련 정보 추가 - userId: {}, withdrawalTime: {}, expiration: {}",

--- a/src/main/java/konkuk/thip/user/domain/User.java
+++ b/src/main/java/konkuk/thip/user/domain/User.java
@@ -1,6 +1,7 @@
 package konkuk.thip.user.domain;
 
 import konkuk.thip.common.entity.BaseDomainEntity;
+import konkuk.thip.common.exception.InternalServerException;
 import konkuk.thip.common.exception.InvalidStateException;
 import konkuk.thip.common.exception.code.ErrorCode;
 import konkuk.thip.user.domain.value.Alias;
@@ -80,7 +81,7 @@ public class User extends BaseDomainEntity {
 
     public void markAsDeleted() {
         if (this.oauth2Id == null) {
-            throw new InvalidStateException(USER_OAUTH2ID_CANNOT_BE_NULL);
+            throw new InternalServerException(USER_OAUTH2ID_CANNOT_BE_NULL);
         }
         if (this.oauth2Id.startsWith("deleted:")) {
             throw new InvalidStateException(USER_ALREADY_DELETED);

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- 색상 변환기 등록(콘솔용) -->
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="wEx" class="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter" />
+
+    <property name="LOG_PATH" value="logs"/>
+
+    <!-- 콘솔 로그 패턴(컬러) -->
+    <property name="console.format"
+              value="[%clr(%d{yyyy-MM-dd HH:mm:ss}){green}:%clr(%-3relative){faint}] [%clr(%thread){magenta}] %highlight(%-5level) %clr(%logger{35}){cyan} - %clr(%msg){yellow}%n"/>
+
+    <!-- 파일 로그 패턴 (텍스트, key=value 형태) -->
+    <property name="file.format"
+              value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%level] [%thread] [%logger] [request_id:%X{request_id}] [user_id:%X{user_id}] %msg%n%wEx"/>
+
+    <!-- 콘솔 로그 Appender(컬러) -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${console.format}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- INFO 로그 파일 (텍스트) -->
+    <appender name="INFO_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/info/info.log</file>
+        <encoder>
+            <pattern>${file.format}</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/info/info.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>10</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <!-- WARN 로그 파일 (텍스트) -->
+    <appender name="WARN_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/warn/warn.log</file>
+        <encoder>
+            <pattern>${file.format}</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/warn/warn.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>10</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <!-- ERROR 로그 파일 (텍스트) -->
+    <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/error/error.log</file>
+        <encoder>
+            <pattern>${file.format}</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/error/error.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>10</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="INFO_FILE" />
+        <appender-ref ref="WARN_FILE" />
+        <appender-ref ref="ERROR_FILE" />
+    </root>
+</configuration>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #319

## 📝 작업 내용

- 서버에서 500에러 발생시 디스코드 웹훅을 이용해 알림을 전송하도록했습니다.
- 기존에 500에러가 핸들러에서 분산되어있어서 500에러 핸들러를 하나로 합쳤습니다.
- 500 에러를 위한 `InternalServerException`를 추가했습니다.
- 네이버,알라딘 api 이용중에 외부 api에대한 예외처리를 `ExternalApiException`로 통합했습니다.

## 📸 스크린샷

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 모든 성공/에러 응답에 requestId 포함 및 X-Request-ID 수집(미제공 시 생성)
  - 요청 단위 MDC 기록(요청ID·사용자ID) 및 인증 성공 시 사용자ID 기록
  - 서버 오류 발생 시 디스코드 알림 전송 기능 추가(동기 전송)
  - 콘솔/레벨별 롤링 파일 로그 구성 추가

- Bug Fixes
  - 서버 예외 처리 경로 통합 및 예외 타입 정비로 오류 분류·보고 일관성 개선
  - Firebase 전송/배치 실패 처리 및 관련 에러 코드 개선

- Chores
  - Spring WebFlux 및 Logstash Logback Encoder 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->