### PR TITLE
[hotfix] 책 저장시 3000자 넘을경우 ... 처리 추가해서 db 저장하도록 수정

### DIFF
--- a/src/main/java/konkuk/thip/book/adapter/out/api/naver/NaverBookXmlParser.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/api/naver/NaverBookXmlParser.java
@@ -16,6 +16,7 @@ import static konkuk.thip.common.exception.code.ErrorCode.BOOK_NAVER_API_ISBN_NO
 import static konkuk.thip.common.exception.code.ErrorCode.BOOK_NAVER_API_PARSING_ERROR;
 
 public class NaverBookXmlParser {
+    private static final int MAX_DESCRIPTION_LENGTH = 3000;
 
     public static NaverBookParseResult parseBookList(String xml) {
         List<NaverBookParseResult.NaverBook> naverBooks = new ArrayList<>();
@@ -71,8 +72,8 @@ public class NaverBookXmlParser {
                     String rawDescription =  StringEscapeUtils.unescapeHtml4(getTagValue(item, "description"));
                     String description;
                     String suffix = "...";
-                    if (rawDescription.length() > 3000) {
-                        description = rawDescription.substring(0, 3000 - suffix.length()) + suffix;
+                    if (rawDescription.length() > MAX_DESCRIPTION_LENGTH) {
+                        description = rawDescription.substring(0, MAX_DESCRIPTION_LENGTH - suffix.length()) + suffix;
                     } else {
                         description = rawDescription;
                     }

--- a/src/main/java/konkuk/thip/book/adapter/out/api/naver/NaverBookXmlParser.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/api/naver/NaverBookXmlParser.java
@@ -17,6 +17,7 @@ import static konkuk.thip.common.exception.code.ErrorCode.BOOK_NAVER_API_PARSING
 
 public class NaverBookXmlParser {
     private static final int MAX_DESCRIPTION_LENGTH = 3000;
+    private static final String DESCRIPTION_SUFFIX = "...";
 
     public static NaverBookParseResult parseBookList(String xml) {
         List<NaverBookParseResult.NaverBook> naverBooks = new ArrayList<>();
@@ -71,9 +72,8 @@ public class NaverBookXmlParser {
                     String isbn = getTagValue(item, "isbn");
                     String rawDescription =  StringEscapeUtils.unescapeHtml4(getTagValue(item, "description"));
                     String description;
-                    String suffix = "...";
                     if (rawDescription.length() > MAX_DESCRIPTION_LENGTH) {
-                        description = rawDescription.substring(0, MAX_DESCRIPTION_LENGTH - suffix.length()) + suffix;
+                        description = rawDescription.substring(0, MAX_DESCRIPTION_LENGTH - DESCRIPTION_SUFFIX.length()) + DESCRIPTION_SUFFIX;
                     } else {
                         description = rawDescription;
                     }

--- a/src/main/java/konkuk/thip/book/adapter/out/api/naver/NaverBookXmlParser.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/api/naver/NaverBookXmlParser.java
@@ -68,7 +68,14 @@ public class NaverBookXmlParser {
                     String author = getTagValue(item, "author");
                     String publisher = getTagValue(item, "publisher");
                     String isbn = getTagValue(item, "isbn");
-                    String description =  StringEscapeUtils.unescapeHtml4(getTagValue(item, "description"));
+                    String rawDescription =  StringEscapeUtils.unescapeHtml4(getTagValue(item, "description"));
+                    String description;
+                    String suffix = "...";
+                    if (rawDescription.length() > 3000) {
+                        description = rawDescription.substring(0, 3000 - suffix.length()) + suffix;
+                    } else {
+                        description = rawDescription;
+                    }
 
                     return NaverDetailBookParseResult.builder()
                             .title(title)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #327

## 📝 작업 내용

- 책 저장시 description 칼럼에 3000자 제약보다 넘는 책 설명이 들어올경우 2997자까지만 저장후 자른뒤 ... 를 추가하여 db에 저장하도록 수정했습니다.


## 📸 스크린샷
<img width="445" height="40" alt="image" src="https://github.com/user-attachments/assets/be506c38-e66e-4df6-b29b-ab6c8dbe8e07" />

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 도서 설명 처리 로직을 개선했습니다. HTML 이스케이프를 해제한 후 설명이 3,000자 초과 시 자동으로 잘라내고 끝에 "..."을 붙여 표시하여, 과도하게 긴 설명으로 인한 표시 문제를 방지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->