### PR TITLE
[test] 모임방 참여 api 부하 테스트 진행

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,11 @@ clean.doLast {
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+	useJUnitPlatform {
+        if (System.getenv('CI') == 'true') {
+            excludeTags 'concurrency'
+        }
+    }
 }
 
 apply from: "$rootDir/jacoco.gradle"

--- a/loadtest/room_join_load_test.js
+++ b/loadtest/room_join_load_test.js
@@ -1,0 +1,148 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend, Counter } from 'k6/metrics';
+
+const BASE_URL      = 'http://localhost:8080';
+const ROOM_ID       = 12345;
+const USERS_START   = 10000;   // 토큰 발급 시작 userId
+const USERS_COUNT   = 500;     // 총 사용자 = VU 수
+const TOKEN_BATCH   = 200;     // 토큰 발급 배치 크기
+const BATCH_PAUSE_S = 0.2;     // 배치 간 대기 (for 토큰 발급 API 병목 방지)
+const START_DELAY_S = 5;       // 테스트 시작 전 대기 (for 방 참여 요청 동시 시작)
+
+// ===== 커스텀 메트릭 =====
+const joinLatency = new Trend('rooms_join_latency'); // 참여 API 지연(ms)
+const http5xx     = new Counter('rooms_join_5xx');   // 5xx 개수
+const http2xx     = new Counter('rooms_join_2xx');   // 2xx 개수
+const http4xx     = new Counter('rooms_join_4xx');   // 4xx 개수
+
+// 실패 원인 분포 파악용(응답 JSON의 code 필드 기준)
+const token_issue_failed                = new Counter('token_issue_failed');
+const fail_ROOM_MEMBER_COUNT_EXCEEDED   = new Counter('fail_ROOM_MEMBER_COUNT_EXCEEDED');
+const fail_USER_ALREADY_PARTICIPATE     = new Counter('fail_USER_ALREADY_PARTICIPATE');
+const fail_OTHER_4XX                    = new Counter('fail_OTHER_4XX');
+
+const ERR = {   // THIP error code
+  ROOM_MEMBER_COUNT_EXCEEDED: 100006,
+  USER_ALREADY_PARTICIPATE: 140005,
+};
+
+function parseError(res) {
+  try {
+    const j = JSON.parse(res.body || '{}'); // BaseResponse 구조
+    // BaseResponse: { isSuccess:boolean, code:number, message:string, requestId:string, data:any }
+    return {
+      code: Number(j.code),              // 정수 코드
+      message: j.message || '',
+      requestId: j.requestId || '',
+      isSuccess: !!j.isSuccess
+    };
+  } catch (e) {
+    return { code: NaN, message: '', requestId: '', isSuccess: false };
+  }
+}
+
+// ------------ 시나리오 ------------
+// [인기 작가가 만든 모임방에 THIP의 수많은 유저들이 '모임방 참여' 요청을 보내는 상황 가정]
+export const options = {
+  scenarios: {
+    // 각 VU가 "정확히 1회" 실행 → 1 VU = 1명 유저
+    join_once_burst: {
+      executor: 'per-vu-iterations',
+      vus: USERS_COUNT,
+      iterations: 1,
+      startTime: '0s',         // 모든 VU가 거의 동시에 스케줄링
+      gracefulStop: '5s',
+    },
+  },
+  thresholds: {
+    rooms_join_5xx:     ['count==0'],     // 서버 오류는 0건이어야 함
+    rooms_join_latency: ['p(95)<1000'],   // p95 < 1s
+  },
+};
+
+// setup: 토큰 배치 발급
+// roomId 12345 방 & userId 10000 ~ 유저들은 사전에 만들어져 있어야 함
+export function setup() {
+  const userIds = Array.from({ length: USERS_COUNT }, (_, i) => USERS_START + i);
+  const tokens = [];
+
+  for (let i = 0; i < userIds.length; i += TOKEN_BATCH) {
+    const slice = userIds.slice(i, i + TOKEN_BATCH);
+    const reqs = slice.map((uid) => [
+      'GET',
+      `${BASE_URL}/api/test/token/access?userId=${uid}`,
+      null,
+      { tags: { phase: 'setup_token_issue', room: `${ROOM_ID}` } },
+    ]);
+
+    const responses = http.batch(reqs);
+    for (const r of responses) {
+      if (r.status === 200 && r.body) {
+        tokens.push(r.body.trim());
+      }
+      else {
+        tokens.push(''); // 실패한 자리도 인덱스 유지
+        token_issue_failed.add(1);
+      }
+    }
+    sleep(BATCH_PAUSE_S);
+  }
+  if (tokens.length > USERS_COUNT) tokens.length = USERS_COUNT;
+
+  const startAt = Date.now() + START_DELAY_S * 1000;    // 동시 시작 시간
+
+  return { tokens, startAt };
+}
+
+// VU : 각자 자기 토큰으로 참여 호출 & 각자 1회만 실행
+export default function (data) {
+  const idx = __VU - 1;                 // VU <-> user 매핑(1:1)
+  const token = data.tokens[idx];
+
+  // 동기 시작: startAt까지 대기 → 모든 VU가 거의 같은 타이밍에 시작
+    const now = Date.now();
+    if (now < data.startAt) {
+      sleep((data.startAt - now) / 1000);
+    }
+
+  if (!token) {     // 토큰 발급 실패 -> 스킵
+    return;
+  }
+
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+
+  const body = JSON.stringify({ type: 'join' });
+  const url = `${BASE_URL}/rooms/${ROOM_ID}/join`;
+
+  const res = http.post(url, body, { headers, tags: { phase: 'join', room: `${ROOM_ID}` } });
+
+  // === 커스텀 메트릭 기록 ===
+  joinLatency.add(res.timings.duration);
+  if (res.status >= 200 && res.status < 300) http2xx.add(1);
+  else if (res.status >= 400 && res.status < 500) {
+    http4xx.add(1);
+    const err = parseError(res);
+    switch (err.code) {
+      case ERR.ROOM_MEMBER_COUNT_EXCEEDED:
+        fail_ROOM_MEMBER_COUNT_EXCEEDED.add(1);
+        break;
+      case ERR.USER_ALREADY_PARTICIPATE:
+        fail_USER_ALREADY_PARTICIPATE.add(1);
+        break;
+      default:
+        fail_OTHER_4XX.add(1);
+    }
+  } else if (res.status >= 500) {
+    http5xx.add(1);
+  }
+
+  // === 검증 ===
+  check(res, {
+    'join responded': (r) => r.status !== 0,
+    'join 200 or expected 4xx': (r) => r.status === 200 || (r.status >= 400 && r.status < 500),
+  });
+}

--- a/src/test/java/konkuk/thip/common/persistence/JpaRepositoryMethodTest.java
+++ b/src/test/java/konkuk/thip/common/persistence/JpaRepositoryMethodTest.java
@@ -116,4 +116,38 @@ public class JpaRepositoryMethodTest {
         //when //then
         assertThat(testUserRepository.findById(id)).isEmpty();
     }
+
+    @Test
+    @DisplayName("flush 시점에 dirty 엔티티에 대하여 어떤 SQL이 실행되는지 확인")
+    void check_dirty_entity_sql_query_when_flush() throws Exception {
+        //given
+        TestUser u1 = new TestUser("노성준");
+        em.persist(u1);     // u1 엔티티 영속화
+        Long id = u1.getUserId();
+        em.flush();     // insert 쿼리 즉시 반영
+
+        //when
+        TestUser loaded = testUserRepository.findByUserId(id).orElseThrow();
+        loaded.setNickname("김희용");      // dirty 상태
+
+        //then
+        em.flush();
+        /**
+         * flush 시점에 영속성 컨텍스트 상에 dirty 상태인 엔티티에 대하여 UPDATE 쿼리가 발생하는 것 확인
+         */
+    }
+
+    @Test
+    @DisplayName("flush 시점에 신규 엔티티에 대하여 어떤 SQL이 실행되는지 확인")
+    void check_new_entity_sql_query_when_flush() throws Exception {
+        //given
+        TestUser u2 = new TestUser("노성준");
+        em.persist(u2);     // u2 엔티티 영속화
+
+        //when //then
+        em.flush();
+        /**
+         * flush 시점에 영속성 컨텍스트 상에 새로 추가된 엔티티에 대하여 INSERT 쿼리가 발생하는 것 확인
+         */
+    }
 }

--- a/src/test/java/konkuk/thip/common/util/TestEntityFactory.java
+++ b/src/test/java/konkuk/thip/common/util/TestEntityFactory.java
@@ -147,6 +147,20 @@ public class TestEntityFactory {
                 .build();
     }
 
+    public static RoomJpaEntity createCustomRoom(BookJpaEntity book, Category category, int recruitCount) {
+        return RoomJpaEntity.builder()
+                .title("방이름")
+                .description("설명")
+                .isPublic(true)
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusDays(5))
+                .recruitCount(recruitCount)
+                .bookJpaEntity(book)
+                .category(category)
+                .roomStatus(RoomStatus.RECRUITING)
+                .build();
+    }
+
     public static RoomJpaEntity createCustomRoom(BookJpaEntity book, Category category, LocalDate startDate, LocalDate endDate, RoomStatus roomStatus) {
         return RoomJpaEntity.builder()
                 .title("방이름")

--- a/src/test/java/konkuk/thip/room/concurrency/RoomJoinConcurrencyTest.java
+++ b/src/test/java/konkuk/thip/room/concurrency/RoomJoinConcurrencyTest.java
@@ -1,0 +1,150 @@
+package konkuk.thip.room.concurrency;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
+import konkuk.thip.book.adapter.out.persistence.repository.BookJpaRepository;
+import konkuk.thip.common.util.TestEntityFactory;
+import konkuk.thip.room.adapter.in.web.request.RoomJoinRequest;
+import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
+import konkuk.thip.room.adapter.out.persistence.repository.RoomJpaRepository;
+import konkuk.thip.room.adapter.out.persistence.repository.roomparticipant.RoomParticipantJpaRepository;
+import konkuk.thip.room.domain.value.Category;
+import konkuk.thip.room.domain.value.RoomParticipantRole;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.domain.value.Alias;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("[동시성] 방 참여 동시 요청 테스트")
+@Tag("concurrency")
+public class RoomJoinConcurrencyTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private RoomJpaRepository roomJpaRepository;
+    @Autowired private RoomParticipantJpaRepository roomParticipantJpaRepository;
+    @Autowired private BookJpaRepository bookJpaRepository;
+    @Autowired private UserJpaRepository userJpaRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    @Test
+    @DisplayName("[동시성] 방 참여 동시 요청 테스트")
+    void room_join_test_in_multi_thread() throws Exception {
+        //given
+        int requestUserCount = 500;
+
+        BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBook());
+        // 모집인원 10명 방 생성
+        RoomJpaEntity room = roomJpaRepository.save(TestEntityFactory.createCustomRoom(book, Category.LITERATURE, 10));
+        List<Long> savedUserIds = createUsersRange(requestUserCount + 1);
+
+        UserJpaEntity hostUser = userJpaRepository.save(TestEntityFactory.createUser(Alias.WRITER));
+        roomParticipantJpaRepository.save(TestEntityFactory.createRoomParticipant(room, hostUser, RoomParticipantRole.HOST, 0.0));
+
+        List<Long> requestUserIds = savedUserIds.subList(1, savedUserIds.size());
+
+        //when : 동시에 방 참여 요청
+        ExecutorService pool = Executors.newFixedThreadPool(Math.min(requestUserCount, 100));
+        CountDownLatch ready = new CountDownLatch(requestUserCount);
+        CountDownLatch start = new  CountDownLatch(1);
+        CountDownLatch finish = new  CountDownLatch(requestUserCount);
+
+        RoomJoinRequest body = new RoomJoinRequest("join");
+        String json = objectMapper.writeValueAsString(body);
+
+        List<Future<Integer>> results = new ArrayList<>(requestUserCount);
+        for (int i = 0; i < requestUserCount; i++) {
+            final long userId = requestUserIds.get(i);
+            results.add(pool.submit(() -> {
+                ready.countDown();
+                start.await();
+                try {
+                    mockMvc.perform(post("/rooms/{roomId}/join", room.getRoomId())
+                                    .contentType("application/json")
+                                    .content(json)
+                                    .requestAttr("userId", userId))
+                            .andExpect(status().isOk());
+                    return 200;
+                } catch (AssertionError e) {
+                    return 400;
+                } finally {
+                    finish.countDown();
+                }
+            }));
+        }
+
+        // 동시에 시작
+        ready.await(10, TimeUnit.SECONDS);
+        start.countDown();
+        finish.await(60, TimeUnit.SECONDS);
+        pool.shutdown();
+
+        long okCount = results.stream().filter(f -> {
+            try {
+                return f.get() == 200;
+            } catch (Exception e) {
+                return false;
+            }
+        }).count();
+
+        //then : DB 실측값 검증
+        RoomJpaEntity reloadedRoom = roomJpaRepository.findByRoomId(room.getRoomId()).orElseThrow();
+
+        long participantRows = jdbcTemplate.query(
+                "SELECT COUNT(*) FROM room_participants WHERE room_id = ?",
+                ps -> ps.setLong(1, room.getRoomId()),
+                rs -> {rs.next(); return rs.getLong(1); }
+        );
+
+        int memberCountInRoom = reloadedRoom.getMemberCount();
+        int recruit = reloadedRoom.getRecruitCount();
+
+        System.out.println("=== RESULT ===");
+        System.out.println("OK responses(= 방 참여 OK 응답을 받은 thread 수) : " + okCount);
+        System.out.println("participants rows(= host 1명 포함된 결과)      : " + participantRows);
+        System.out.println("room.memberCount                            : " + memberCountInRoom);
+        System.out.println("recruitCount                                : " + recruit);
+
+        /**
+         * 현재 방 참여 로직
+         * 1. 방 참여자에 해당하는 RoomParticipant 엔티티 저장
+         * 2. Room 엔티티의 memberCount 증가 (Room의 도메인 규칙으로 memberCount가 recruitCount를 초과하지 않도록 제한됨)
+         * -> 동시성 경쟁이 발생하는 트래픽 규모에서는 participants 테이블의 행 수와 Room.memberCount 동기화 보장 X
+         */
+
+        // 1) participants가 recruitCount 보다 커질 수 있음
+        assertThat(participantRows).isGreaterThan(recruit);
+
+        // 2) memberCount가 실제 participants 수보다 작을 수 있음
+        // memberCount 값은 Room 도메인 규칙에 의해 recruitCount를 초과하여 증가하지 않음
+        assertThat(memberCountInRoom).isLessThan((int) participantRows);
+    }
+
+    private List<Long> createUsersRange(long count) {
+        List<Long> userIds = new ArrayList<>();
+        for (long i = 0; i < count; i++) {
+            UserJpaEntity saved = userJpaRepository.save(TestEntityFactory.createUser(Alias.WRITER));
+            userIds.add(saved.getUserId());
+        }
+        return userIds;
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #325 

## 📝 작업 내용
- '인기 작가 모임방에 여러 유저들이 동시에 모임방 참여 요청을 보낼 경우' 에 대한 시나리오를 설정하고, 이를 테스트 코드와 부하 테스트 스크립트로 재현하여 테스트 하였습니다.

1. 테스트 코드
- 동시에 여러 유저들이 모임방 참여 요청을 보내는 상황을 재현하기 위해, java.util.concurrent.ExecutorService 를 활용하여 여러 스레드가 동시에 모임방 참여 api 요청을 보내도록 구현
- 모임방 제한인원보다 많은 수의 200 OK 응답(= 모임방 참여 OK 응답) 이 발생하는 것을 확인
- 마찬가지로 DB에 insert 된 room_participants 레코드의 숫자가 해당 rooms 레코드의 member_count 값보다 많은 것을 확인

2. 부하 테스트 스크립트
- 'per-vu-iterations(iterations : 1)' 시나리오를 설정하여, 수많은 사람들이 동시에 방 참여를 1번씩 요청하는 상황에 대하여 부하 테스트 진행
- 모든 요청에 대한 응답으로 200 OK(= 모임방 참여 성공), 400 Error(= 모임방 인원 수 초과) 응답이 와야 정상이지만, 다수의 500 Error 발생을 확인하였음(-> 콘솔 로그 확인 결과 deadlock 이슈로 인한 500 Error)

## 📸 스크린샷
<img width="505" height="158" alt="image" src="https://github.com/user-attachments/assets/80f319c7-72d8-4e68-b00d-af2f065ab6c0" />
-> 테스트 코드 결과

https://separate-snowplow-d8b.notion.site/API-1-29ab701eb0b880c79fd7ed9cfd744384?source=copy_link
-> 부하 테스트 결과와 데드락 원인에 대해 정리한 글

## 💬 리뷰 요구사항
- '방 참여 api' 의 개선 방향을
1. 서버의 응답 안정성 향상(= 500 error 발생 포인트 확인 및 해결 -> 방 참여 요청에 대해서는 '방 참여 OK' or '모임방 인원 수 초과' 의 응답만 발생하도록)
2. 서버의 응답 처리율 향상 -> 동시에 많은 요청이 몰리더라도, 응답 시간을 안정적으로 유지

로 설정하였습니다.

추후 새로 브랜치파서 위와 관련된 작업 진행해보겠습니다.

- 부하테스트 패키지를 프로젝트 최상위 디렉토리 하위에 위치시켰습니다. 혹시 다른 의견 있으시면 리뷰 부탁드립니다!
- 멀티스레드로 많은 요청을 보내는 테스트 코드는 CI 과정에서 제외하고 빌드되는게 맞는거 같아서 @Tag 어노테이션 활용 및 build.gradle 에서 test 설정 부분을 수정하였습니다! 이 부분 확인 부탁드립니다!

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  - 룸 동시 참여 기능에 대한 동시성 테스트 추가
  - 데이터베이스 플러시 작업 검증 테스트 추가

* **Chores**
  - 로드 테스트 스크립트 추가
  - CI 환경에서 동시성 관련 테스트 제외 설정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->