### PR TITLE
[fix] 모임방 참여 api 5xx 에러 발생 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,9 @@ dependencies {
 
 	// Spring AI - Google AI(Gemini) 연동
 	implementation 'org.springframework.ai:spring-ai-starter-model-openai:1.0.1'
+
+    // spring Retry
+    implementation 'org.springframework.retry:spring-retry'
 }
 
 def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile

--- a/loadtest/room_join_load_test.js
+++ b/loadtest/room_join_load_test.js
@@ -20,11 +20,13 @@ const http4xx     = new Counter('rooms_join_4xx');   // 4xx 개수
 const token_issue_failed                = new Counter('token_issue_failed');
 const fail_ROOM_MEMBER_COUNT_EXCEEDED   = new Counter('fail_ROOM_MEMBER_COUNT_EXCEEDED');
 const fail_USER_ALREADY_PARTICIPATE     = new Counter('fail_USER_ALREADY_PARTICIPATE');
+const fail_RESOURCE_LOCKED              = new Counter('fail_RESOURCE_LOCKED');  // 423 Locked error
 const fail_OTHER_4XX                    = new Counter('fail_OTHER_4XX');
 
 const ERR = {   // THIP error code
   ROOM_MEMBER_COUNT_EXCEEDED: 100006,
   USER_ALREADY_PARTICIPATE: 140005,
+  RESOURCE_LOCKED: 50200,
 };
 
 function parseError(res) {
@@ -132,6 +134,9 @@ export default function (data) {
         break;
       case ERR.USER_ALREADY_PARTICIPATE:
         fail_USER_ALREADY_PARTICIPATE.add(1);
+        break;
+      case ERR.RESOURCE_LOCKED:
+        fail_RESOURCE_LOCKED.add(1);
         break;
       default:
         fail_OTHER_4XX.add(1);

--- a/loadtest/room_join_load_test.js
+++ b/loadtest/room_join_load_test.js
@@ -14,35 +14,8 @@ const START_DELAY_S = 5;       // 테스트 시작 전 대기 (for 방 참여 �
 const joinLatency = new Trend('rooms_join_latency'); // 참여 API 지연(ms)
 const http5xx     = new Counter('rooms_join_5xx');   // 5xx 개수
 const http2xx     = new Counter('rooms_join_2xx');   // 2xx 개수
-const http4xx     = new Counter('rooms_join_4xx');   // 4xx 개수
-
-// 실패 원인 분포 파악용(응답 JSON의 code 필드 기준)
-const token_issue_failed                = new Counter('token_issue_failed');
-const fail_ROOM_MEMBER_COUNT_EXCEEDED   = new Counter('fail_ROOM_MEMBER_COUNT_EXCEEDED');
-const fail_USER_ALREADY_PARTICIPATE     = new Counter('fail_USER_ALREADY_PARTICIPATE');
-const fail_RESOURCE_LOCKED              = new Counter('fail_RESOURCE_LOCKED');  // 423 Locked error
-const fail_OTHER_4XX                    = new Counter('fail_OTHER_4XX');
-
-const ERR = {   // THIP error code
-  ROOM_MEMBER_COUNT_EXCEEDED: 100006,
-  USER_ALREADY_PARTICIPATE: 140005,
-  RESOURCE_LOCKED: 50200,
-};
-
-function parseError(res) {
-  try {
-    const j = JSON.parse(res.body || '{}'); // BaseResponse 구조
-    // BaseResponse: { isSuccess:boolean, code:number, message:string, requestId:string, data:any }
-    return {
-      code: Number(j.code),              // 정수 코드
-      message: j.message || '',
-      requestId: j.requestId || '',
-      isSuccess: !!j.isSuccess
-    };
-  } catch (e) {
-    return { code: NaN, message: '', requestId: '', isSuccess: false };
-  }
-}
+const http400     = new Counter('rooms_join_400');   // 400 개수
+const http423     = new Counter('rooms_join_423');   // 423 개수
 
 // ------------ 시나리오 ------------
 // [인기 작가가 만든 모임방에 THIP의 수많은 유저들이 '모임방 참여' 요청을 보내는 상황 가정]
@@ -59,6 +32,8 @@ export const options = {
   },
   thresholds: {
     rooms_join_5xx:     ['count==0'],     // 서버 오류는 0건이어야 함
+    rooms_join_423:     ['count>=0'],     // 기록용
+    rooms_join_400:     ['count>=0'],     // 기록용
     rooms_join_latency: ['p(95)<1000'],   // p95 < 1s
   },
 };
@@ -85,7 +60,6 @@ export function setup() {
       }
       else {
         tokens.push(''); // 실패한 자리도 인덱스 유지
-        token_issue_failed.add(1);
       }
     }
     sleep(BATCH_PAUSE_S);
@@ -126,24 +100,10 @@ export default function (data) {
   joinLatency.add(res.timings.duration);
   if (res.status >= 200 && res.status < 300) http2xx.add(1);
   else if (res.status >= 400 && res.status < 500) {
-    http4xx.add(1);
-    const err = parseError(res);
-    switch (err.code) {
-      case ERR.ROOM_MEMBER_COUNT_EXCEEDED:
-        fail_ROOM_MEMBER_COUNT_EXCEEDED.add(1);
-        break;
-      case ERR.USER_ALREADY_PARTICIPATE:
-        fail_USER_ALREADY_PARTICIPATE.add(1);
-        break;
-      case ERR.RESOURCE_LOCKED:
-        fail_RESOURCE_LOCKED.add(1);
-        break;
-      default:
-        fail_OTHER_4XX.add(1);
-    }
-  } else if (res.status >= 500) {
-    http5xx.add(1);
+    if (res.status === 400) http400.add(1);
+    else if (res.status === 423) http423.add(1);
   }
+  else if (res.status >= 500) http5xx.add(1);
 
   // === 검증 ===
   check(res, {

--- a/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
@@ -32,6 +32,8 @@ public enum ErrorCode implements ResponseCode {
 
     PERSISTENCE_TRANSACTION_REQUIRED(HttpStatus.INTERNAL_SERVER_ERROR, 50110, "@Transactional 컨텍스트가 필요합니다. 트랜잭션 범위 내에서만 사용할 수 있습니다."),
 
+    RESOURCE_LOCKED(HttpStatus.LOCKED, 50200, "자원이 잠겨 있어 요청을 처리할 수 없습니다."),
+
     /* 60000부터 비즈니스 예외 */
     /**
      * 60000 : alias error

--- a/src/main/java/konkuk/thip/config/RetryConfig.java
+++ b/src/main/java/konkuk/thip/config/RetryConfig.java
@@ -1,0 +1,9 @@
+package konkuk.thip.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry(proxyTargetClass = true)
+public class RetryConfig {
+}

--- a/src/main/java/konkuk/thip/room/adapter/out/jpa/RoomParticipantJpaEntity.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/jpa/RoomParticipantJpaEntity.java
@@ -10,7 +10,17 @@ import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 
 @Entity
-@Table(name = "room_participants")
+@Table(
+        name = "room_participants",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        // TODO : room_participant가 soft delete 된 경우에도 unique 제약조건은 여전히 유효
+                        // room_participant가 삭제된 방에 다시 참여하는 경우는 일단 고려 X
+                        name = "uk_room_participant_user_room",
+                        columnNames = {"user_id", "room_id"}
+                )
+        }
+)
 @Getter
 @SQLDelete(sql = "UPDATE room_participants SET status = 'INACTIVE' WHERE room_participant_id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -51,6 +61,11 @@ public class RoomParticipantJpaEntity extends BaseJpaEntity {
     @VisibleForTesting
     public void updateUserPercentage(double userPercentage) {
         this.userPercentage = userPercentage;
+    }
+
+    @VisibleForTesting
+    public void updateRoleToHost() {
+        this.roomParticipantRole = RoomParticipantRole.HOST;
     }
 
     public void updateFrom(RoomParticipant roomParticipant) {

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/RoomCommandPersistenceAdapter.java
@@ -35,6 +35,14 @@ public class RoomCommandPersistenceAdapter implements RoomCommandPort {
     }
 
     @Override
+    public Room getByIdForUpdate(Long id) {
+        RoomJpaEntity roomJpaEntity = roomJpaRepository.findByRoomIdForUpdate(id).orElseThrow(
+                () -> new EntityNotFoundException(ROOM_NOT_FOUND)
+        );
+        return roomMapper.toDomainEntity(roomJpaEntity);
+    }
+
+    @Override
     public Optional<Room> findById(Long id) {
         return roomJpaRepository.findByRoomId(id)
                 .map(roomMapper::toDomainEntity);

--- a/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomJpaRepository.java
+++ b/src/main/java/konkuk/thip/room/adapter/out/persistence/repository/RoomJpaRepository.java
@@ -1,9 +1,9 @@
 package konkuk.thip.room.adapter.out.persistence.repository;
 
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
@@ -15,6 +15,13 @@ public interface RoomJpaRepository extends JpaRepository<RoomJpaEntity, Long>, R
      * 소프트 딜리트 적용 대상 entity 단건 조회 메서드
      */
     Optional<RoomJpaEntity> findByRoomId(Long roomId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM RoomJpaEntity r WHERE r.roomId = :roomId")
+    @QueryHints(
+            @QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000")
+    )
+    Optional<RoomJpaEntity> findByRoomIdForUpdate(@Param("roomId") Long roomId);
 
     @Query("SELECT COUNT(r) FROM RoomJpaEntity r " +
             "WHERE r.bookJpaEntity.isbn = :isbn " +

--- a/src/main/java/konkuk/thip/room/application/port/out/RoomCommandPort.java
+++ b/src/main/java/konkuk/thip/room/application/port/out/RoomCommandPort.java
@@ -17,6 +17,8 @@ public interface RoomCommandPort {
                 .orElseThrow(() -> new EntityNotFoundException(ROOM_NOT_FOUND));
     }
 
+    Room getByIdForUpdate(Long id);
+
     Long save(Room room);
 
     void update(Room room);

--- a/src/main/java/konkuk/thip/room/application/service/RoomJoinService.java
+++ b/src/main/java/konkuk/thip/room/application/service/RoomJoinService.java
@@ -1,6 +1,7 @@
 package konkuk.thip.room.application.service;
 
 import konkuk.thip.common.exception.BusinessException;
+import konkuk.thip.common.exception.InvalidStateException;
 import konkuk.thip.common.exception.code.ErrorCode;
 import konkuk.thip.notification.application.port.in.RoomNotificationOrchestrator;
 import konkuk.thip.room.application.port.in.RoomJoinUseCase;
@@ -14,7 +15,11 @@ import konkuk.thip.room.domain.RoomParticipant;
 import konkuk.thip.user.application.port.out.UserCommandPort;
 import konkuk.thip.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
@@ -30,13 +35,21 @@ public class RoomJoinService implements RoomJoinUseCase {
     private final RoomNotificationOrchestrator roomNotificationOrchestrator;
 
     @Override
-    @Transactional
+    @Retryable(
+            noRetryFor = {InvalidStateException.class, BusinessException.class},  // 재시도 제외 예외
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100, multiplier = 2)
+    )
+    @Transactional(propagation = Propagation.REQUIRES_NEW)  // 재시도마다 새로운 트랜잭션
     public RoomJoinResult changeJoinState(RoomJoinCommand roomJoinCommand) {
         RoomJoinType type = roomJoinCommand.type();
 
         // 방이 존재하지 않거나 모집기간이 만료된 경우 예외 처리
-        Room room = roomCommandPort.findById(roomJoinCommand.roomId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_CANNOT_JOIN_OR_CANCEL));
+//        Room room = roomCommandPort.findById(roomJoinCommand.roomId())
+//                .orElseThrow(() -> new BusinessException(ErrorCode.USER_CANNOT_JOIN_OR_CANCEL));
+
+        /** 락 타잉아웃 발생 포인트 **/
+        Room room = roomCommandPort.getByIdForUpdate(roomJoinCommand.roomId());
 
         room.validateRoomRecruitExpired();
 
@@ -57,6 +70,11 @@ public class RoomJoinService implements RoomJoinUseCase {
         }
 
         return RoomJoinResult.of(room.getId(), type.getType());
+    }
+
+    @Recover
+    public RoomJoinResult recover(Exception e, RoomJoinCommand roomJoinCommand) {
+        throw new BusinessException(ErrorCode.RESOURCE_LOCKED);
     }
 
     private void sendNotifications(RoomJoinCommand roomJoinCommand, Room room) {

--- a/src/main/java/konkuk/thip/room/application/service/RoomJoinService.java
+++ b/src/main/java/konkuk/thip/room/application/service/RoomJoinService.java
@@ -1,5 +1,6 @@
 package konkuk.thip.room.application.service;
 
+import jakarta.persistence.LockTimeoutException;
 import konkuk.thip.common.exception.BusinessException;
 import konkuk.thip.common.exception.InvalidStateException;
 import konkuk.thip.common.exception.code.ErrorCode;
@@ -15,6 +16,7 @@ import konkuk.thip.room.domain.RoomParticipant;
 import konkuk.thip.user.application.port.out.UserCommandPort;
 import konkuk.thip.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
@@ -26,6 +28,7 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class RoomJoinService implements RoomJoinUseCase {
 
     private final RoomCommandPort roomCommandPort;
@@ -36,8 +39,13 @@ public class RoomJoinService implements RoomJoinUseCase {
 
     @Override
     @Retryable(
-            noRetryFor = {InvalidStateException.class, BusinessException.class},  // 재시도 제외 예외
-            maxAttempts = 3,
+            retryFor = {
+                    LockTimeoutException.class
+            },  // 재시도 대상 예외
+            noRetryFor = {
+                    InvalidStateException.class, BusinessException.class
+            },  // 제시도 제외 예외
+            maxAttempts = 2,
             backoff = @Backoff(delay = 100, multiplier = 2)
     )
     @Transactional(propagation = Propagation.REQUIRES_NEW)  // 재시도마다 새로운 트랜잭션
@@ -48,7 +56,7 @@ public class RoomJoinService implements RoomJoinUseCase {
 //        Room room = roomCommandPort.findById(roomJoinCommand.roomId())
 //                .orElseThrow(() -> new BusinessException(ErrorCode.USER_CANNOT_JOIN_OR_CANCEL));
 
-        /** 락 타잉아웃 발생 포인트 **/
+        /** x-lock 획득하여 room 조회 **/
         Room room = roomCommandPort.getByIdForUpdate(roomJoinCommand.roomId());
 
         room.validateRoomRecruitExpired();
@@ -73,8 +81,18 @@ public class RoomJoinService implements RoomJoinUseCase {
     }
 
     @Recover
-    public RoomJoinResult recover(Exception e, RoomJoinCommand roomJoinCommand) {
+    public RoomJoinResult recoverLockTimeout(LockTimeoutException e, RoomJoinCommand roomJoinCommand) {
         throw new BusinessException(ErrorCode.RESOURCE_LOCKED);
+    }
+
+    @Recover
+    public RoomJoinResult recoverInvalidStateException(InvalidStateException e, RoomJoinCommand roomJoinCommand) {
+        throw e;
+    }
+
+    @Recover
+    public RoomJoinResult recoverBusinessException(BusinessException e, RoomJoinCommand roomJoinCommand) {
+        throw e;
     }
 
     private void sendNotifications(RoomJoinCommand roomJoinCommand, Room room) {
@@ -117,6 +135,4 @@ public class RoomJoinService implements RoomJoinUseCase {
             throw new BusinessException(ErrorCode.HOST_CANNOT_CANCEL);
         }
     }
-
-
 }

--- a/src/main/resources/db/migration/V251229__Add_unique_room_participants.sql
+++ b/src/main/resources/db/migration/V251229__Add_unique_room_participants.sql
@@ -1,0 +1,4 @@
+-- (user_id, room_id) 조합 유니크 제약 추가
+ALTER TABLE room_participants
+    ADD CONSTRAINT uk_room_participant_user_room
+        UNIQUE (user_id, room_id);

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomJoinApiTest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomJoinApiTest.java
@@ -155,28 +155,22 @@ class RoomJoinApiTest {
         assertThat(room.getMemberCount()).isEqualTo(2); // 방 생성 시 1명 + 참여 1명
     }
 
-    /**
-     * 400 error 가 아니라 재시도 횟수 초과로 인해 423 error 발생
-     * H2 DB에서 select for update 패턴으로 락 획득할 시에 계속 예외 발생 -> 재시도 반복하여 테스트 의도대로 400 error 응답 X
-     * test yml에 LOCK_TIMEOUT 명시적으로 설정해도 해결 X
-     * 일단 주석 처리
-     */
-//    @Test
-//    @DisplayName("방 중복 참여 실패")
-//    void joinRoom_alreadyParticipated() throws Exception {
-//        // 이미 참여한 상태로 설정
-//        setUpWithParticipant();
-//
-//        Map<String, Object> request = new HashMap<>();
-//        request.put("type", JOIN.getType());
-//
-//        ResultActions result = mockMvc.perform(post("/rooms/" + room.getRoomId() + "/join")
-//                .requestAttr("userId", participant.getUserId())
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .content(objectMapper.writeValueAsString(request)));
-//
-//        result.andExpect(status().isBadRequest());
-//    }
+    @Test
+    @DisplayName("방 중복 참여 실패")
+    void joinRoom_alreadyParticipated() throws Exception {
+        // 이미 참여한 상태로 설정
+        setUpWithParticipant();
+
+        Map<String, Object> request = new HashMap<>();
+        request.put("type", JOIN.getType());
+
+        ResultActions result = mockMvc.perform(post("/rooms/" + room.getRoomId() + "/join")
+                .requestAttr("userId", participant.getUserId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpect(status().isBadRequest());
+    }
 
     @Test
     @DisplayName("방 참여 취소 성공 - 참여자 제거 및 인원수 감소 확인")
@@ -205,25 +199,19 @@ class RoomJoinApiTest {
         assertThat(room.getMemberCount()).isEqualTo(1); // 다시 원래 인원
     }
 
-    /**
-     * 400 error 가 아니라 재시도 횟수 초과로 인해 423 error 발생
-     * H2 DB에서 select for update 패턴으로 락 획득할 시에 계속 예외 발생 -> 재시도 반복하여 테스트 의도대로 400 error 응답 X
-     * test yml에 LOCK_TIMEOUT 명시적으로 설정해도 해결 X
-     * 일단 주석 처리
-     */
-//    @Test
-//    @DisplayName("방 미참여자 취소 실패")
-//    void cancelJoin_notParticipated() throws Exception {
-//        setUpWithOnlyHost();
-//
-//        Map<String, Object> request = new HashMap<>();
-//        request.put("type", CANCEL.getType());
-//
-//        ResultActions result = mockMvc.perform(post("/rooms/" + room.getRoomId() + "/join")
-//                .requestAttr("userId", participant.getUserId())
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .content(objectMapper.writeValueAsString(request)));
-//
-//        result.andExpect(status().isBadRequest());
-//    }
+    @Test
+    @DisplayName("방 미참여자 취소 실패")
+    void cancelJoin_notParticipated() throws Exception {
+        setUpWithOnlyHost();
+
+        Map<String, Object> request = new HashMap<>();
+        request.put("type", CANCEL.getType());
+
+        ResultActions result = mockMvc.perform(post("/rooms/" + room.getRoomId() + "/join")
+                .requestAttr("userId", participant.getUserId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpect(status().isBadRequest());
+    }
 }

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomJoinApiTest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomJoinApiTest.java
@@ -5,6 +5,7 @@ import jakarta.persistence.EntityManager;
 import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
 import konkuk.thip.book.adapter.out.persistence.repository.BookJpaRepository;
 import konkuk.thip.common.util.TestEntityFactory;
+import konkuk.thip.notification.application.port.in.RoomNotificationOrchestrator;
 import konkuk.thip.room.adapter.out.jpa.RoomJpaEntity;
 import konkuk.thip.room.adapter.out.jpa.RoomParticipantJpaEntity;
 import konkuk.thip.room.domain.value.RoomParticipantRole;
@@ -15,6 +16,8 @@ import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import konkuk.thip.user.domain.value.UserRole;
 import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
 import konkuk.thip.user.domain.value.Alias;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,9 +25,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.HashMap;
@@ -34,17 +37,21 @@ import static konkuk.thip.common.entity.StatusType.INACTIVE;
 import static konkuk.thip.room.application.port.in.dto.RoomJoinType.CANCEL;
 import static konkuk.thip.room.application.port.in.dto.RoomJoinType.JOIN;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @ActiveProfiles("test")
-@Transactional
+//@Transactional
 @AutoConfigureMockMvc(addFilters = false)
 @DisplayName("[통합] 방 참여/취소 API 통합 테스트")
 class RoomJoinApiTest {
 
     @Autowired private MockMvc mockMvc;
+    @MockitoBean private RoomNotificationOrchestrator roomNotificationOrchestrator;
     @Autowired private ObjectMapper objectMapper;
     @Autowired private RoomJpaRepository roomJpaRepository;
     @Autowired private RoomParticipantJpaRepository roomParticipantJpaRepository;
@@ -56,6 +63,20 @@ class RoomJoinApiTest {
     private UserJpaEntity host;
     private UserJpaEntity participant;
     private RoomParticipantJpaEntity memberParticipation;
+
+    @BeforeEach
+    void mockNotification() {   // 알림 서비스 모킹
+        doNothing().when(roomNotificationOrchestrator)
+                .notifyRoomJoinToHost(anyLong(), anyLong(), anyString(), anyLong(), anyString());
+    }
+
+    @AfterEach
+    void tearDown() {
+        roomParticipantJpaRepository.deleteAllInBatch();
+        roomJpaRepository.deleteAllInBatch();
+        bookJpaRepository.deleteAllInBatch();
+        userJpaRepository.deleteAllInBatch();
+    }
 
     private void setUpWithOnlyHost() {
         Alias alias = TestEntityFactory.createLiteratureAlias();
@@ -134,23 +155,28 @@ class RoomJoinApiTest {
         assertThat(room.getMemberCount()).isEqualTo(2); // 방 생성 시 1명 + 참여 1명
     }
 
-
-    @Test
-    @DisplayName("방 중복 참여 실패")
-    void joinRoom_alreadyParticipated() throws Exception {
-        // 이미 참여한 상태로 설정
-        setUpWithParticipant();
-
-        Map<String, Object> request = new HashMap<>();
-        request.put("type", JOIN.getType());
-
-        ResultActions result = mockMvc.perform(post("/rooms/" + room.getRoomId() + "/join")
-                .requestAttr("userId", participant.getUserId())
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)));
-
-        result.andExpect(status().isBadRequest());
-    }
+    /**
+     * 400 error 가 아니라 재시도 횟수 초과로 인해 423 error 발생
+     * H2 DB에서 select for update 패턴으로 락 획득할 시에 계속 예외 발생 -> 재시도 반복하여 테스트 의도대로 400 error 응답 X
+     * test yml에 LOCK_TIMEOUT 명시적으로 설정해도 해결 X
+     * 일단 주석 처리
+     */
+//    @Test
+//    @DisplayName("방 중복 참여 실패")
+//    void joinRoom_alreadyParticipated() throws Exception {
+//        // 이미 참여한 상태로 설정
+//        setUpWithParticipant();
+//
+//        Map<String, Object> request = new HashMap<>();
+//        request.put("type", JOIN.getType());
+//
+//        ResultActions result = mockMvc.perform(post("/rooms/" + room.getRoomId() + "/join")
+//                .requestAttr("userId", participant.getUserId())
+//                .contentType(MediaType.APPLICATION_JSON)
+//                .content(objectMapper.writeValueAsString(request)));
+//
+//        result.andExpect(status().isBadRequest());
+//    }
 
     @Test
     @DisplayName("방 참여 취소 성공 - 참여자 제거 및 인원수 감소 확인")
@@ -167,8 +193,8 @@ class RoomJoinApiTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
 
-        em.flush();
-        em.clear();
+//        em.flush();
+//        em.clear();
 
         // 참여자 삭제 확인
         RoomParticipantJpaEntity member = roomParticipantJpaRepository.findById(memberParticipation.getRoomParticipantId()).orElse(null);
@@ -179,19 +205,25 @@ class RoomJoinApiTest {
         assertThat(room.getMemberCount()).isEqualTo(1); // 다시 원래 인원
     }
 
-    @Test
-    @DisplayName("방 미참여자 취소 실패")
-    void cancelJoin_notParticipated() throws Exception {
-        setUpWithOnlyHost();
-
-        Map<String, Object> request = new HashMap<>();
-        request.put("type", CANCEL.getType());
-
-        ResultActions result = mockMvc.perform(post("/rooms/" + room.getRoomId() + "/join")
-                .requestAttr("userId", participant.getUserId())
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)));
-
-        result.andExpect(status().isBadRequest());
-    }
+    /**
+     * 400 error 가 아니라 재시도 횟수 초과로 인해 423 error 발생
+     * H2 DB에서 select for update 패턴으로 락 획득할 시에 계속 예외 발생 -> 재시도 반복하여 테스트 의도대로 400 error 응답 X
+     * test yml에 LOCK_TIMEOUT 명시적으로 설정해도 해결 X
+     * 일단 주석 처리
+     */
+//    @Test
+//    @DisplayName("방 미참여자 취소 실패")
+//    void cancelJoin_notParticipated() throws Exception {
+//        setUpWithOnlyHost();
+//
+//        Map<String, Object> request = new HashMap<>();
+//        request.put("type", CANCEL.getType());
+//
+//        ResultActions result = mockMvc.perform(post("/rooms/" + room.getRoomId() + "/join")
+//                .requestAttr("userId", participant.getUserId())
+//                .contentType(MediaType.APPLICATION_JSON)
+//                .content(objectMapper.writeValueAsString(request)));
+//
+//        result.andExpect(status().isBadRequest());
+//    }
 }

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomPlayingOrExpiredDetailViewApiTest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomPlayingOrExpiredDetailViewApiTest.java
@@ -1,5 +1,6 @@
 package konkuk.thip.room.adapter.in.web;
 
+import jakarta.persistence.EntityManager;
 import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
 import konkuk.thip.book.adapter.out.persistence.repository.BookJpaRepository;
 import konkuk.thip.common.util.DateUtil;
@@ -49,13 +50,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class RoomPlayingOrExpiredDetailViewApiTest {
 
     @Autowired private MockMvc mockMvc;
+    @Autowired private EntityManager em;
+
     @Autowired private UserJpaRepository userJpaRepository;
     @Autowired private BookJpaRepository bookJpaRepository;
     @Autowired private RoomJpaRepository roomJpaRepository;
     @Autowired private RoomParticipantJpaRepository roomParticipantJpaRepository;
     @Autowired private VoteJpaRepository voteJpaRepository;
     @Autowired private VoteItemJpaRepository voteItemJpaRepository;
-
 
     private RoomJpaEntity saveScienceRoom(String bookTitle, String isbn, String roomName, LocalDate startDate, RoomStatus roomStatus) {
         BookJpaEntity book = bookJpaRepository.save(BookJpaEntity.builder()
@@ -146,15 +148,12 @@ class RoomPlayingOrExpiredDetailViewApiTest {
         //given
         RoomJpaEntity room = saveScienceRoom("과학-책", "isbn1", "과학-방-지난달-활동시작", LocalDate.now().minusDays(31),EXPIRED);
         saveUsersToRoom(room, 4);
-        RoomParticipantJpaEntity roomParticipantJpaEntity = roomParticipantJpaRepository.findAllByRoomId(room.getRoomId()).get(0);
-        roomParticipantJpaRepository.delete(roomParticipantJpaEntity);
-        RoomParticipantJpaEntity joiningMember = roomParticipantJpaRepository.save(RoomParticipantJpaEntity.builder()
-                .userJpaEntity(roomParticipantJpaEntity.getUserJpaEntity())
-                .roomJpaEntity(roomParticipantJpaEntity.getRoomJpaEntity())
-                .roomParticipantRole(RoomParticipantRole.MEMBER)        // Member
-                .currentPage(50)        // 현재 member의 마지막 활동 page
-                .userPercentage(10.6)       // 현재 member의 활동 percentage
-                .build());
+
+        RoomParticipantJpaEntity joiningMember = roomParticipantJpaRepository.findAllByRoomId(room.getRoomId()).get(0);
+        joiningMember.updateCurrentPage(50);
+        joiningMember.updateUserPercentage(10.6);
+        roomParticipantJpaRepository.flush();
+        em.clear();
 
         createVoteToRoom(joiningMember.getUserJpaEntity(), room, 2);      // 2개의 투표 생성
 
@@ -194,15 +193,12 @@ class RoomPlayingOrExpiredDetailViewApiTest {
         //given
         RoomJpaEntity room = saveScienceRoom("과학-책", "isbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1),IN_PROGRESS);
         saveUsersToRoom(room, 4);
-        RoomParticipantJpaEntity roomParticipantJpaEntity = roomParticipantJpaRepository.findAllByRoomId(room.getRoomId()).get(0);
-        roomParticipantJpaRepository.delete(roomParticipantJpaEntity);
-        RoomParticipantJpaEntity joiningMember = roomParticipantJpaRepository.save(RoomParticipantJpaEntity.builder()
-                .userJpaEntity(roomParticipantJpaEntity.getUserJpaEntity())
-                .roomJpaEntity(roomParticipantJpaEntity.getRoomJpaEntity())
-                .roomParticipantRole(RoomParticipantRole.MEMBER)        // Member
-                .currentPage(50)        // 현재 member의 마지막 활동 page
-                .userPercentage(10.6)       // 현재 member의 활동 percentage
-                .build());
+
+        RoomParticipantJpaEntity joiningMember = roomParticipantJpaRepository.findAllByRoomId(room.getRoomId()).get(0);
+        joiningMember.updateCurrentPage(50);
+        joiningMember.updateUserPercentage(10.6);
+        roomParticipantJpaRepository.flush();
+        em.clear();
 
         createVoteToRoom(joiningMember.getUserJpaEntity(), room, 2);      // 2개의 투표 생성
 
@@ -242,15 +238,14 @@ class RoomPlayingOrExpiredDetailViewApiTest {
         //given
         RoomJpaEntity room = saveScienceRoom("과학-책", "isbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1),IN_PROGRESS);
         saveUsersToRoom(room, 4);
-        RoomParticipantJpaEntity roomParticipantJpaEntity = roomParticipantJpaRepository.findAllByRoomId(room.getRoomId()).get(0);
-        roomParticipantJpaRepository.delete(roomParticipantJpaEntity);
-        RoomParticipantJpaEntity roomHost = roomParticipantJpaRepository.save(RoomParticipantJpaEntity.builder()
-                .userJpaEntity(roomParticipantJpaEntity.getUserJpaEntity())
-                .roomJpaEntity(roomParticipantJpaEntity.getRoomJpaEntity())
-                .roomParticipantRole(RoomParticipantRole.HOST)        // HOST
-                .currentPage(50)        // 현재 member의 마지막 활동 page
-                .userPercentage(10.6)       // 현재 member의 활동 percentage
-                .build());
+
+        RoomParticipantJpaEntity roomHost = roomParticipantJpaRepository.findAllByRoomId(room.getRoomId()).get(0);
+        roomHost.updateRoleToHost();
+        roomHost.updateCurrentPage(50);
+        roomHost.updateUserPercentage(10.6);
+        roomParticipantJpaRepository.flush();
+        em.clear();
+
 
         createVoteToRoom(roomHost.getUserJpaEntity(), room, 2);      // 2개의 투표 생성
 
@@ -290,15 +285,12 @@ class RoomPlayingOrExpiredDetailViewApiTest {
         //given
         RoomJpaEntity room = saveScienceRoom("과학-책", "isbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1),IN_PROGRESS);
         saveUsersToRoom(room, 4);
-        RoomParticipantJpaEntity roomParticipantJpaEntity = roomParticipantJpaRepository.findAllByRoomId(room.getRoomId()).get(0);
-        roomParticipantJpaRepository.delete(roomParticipantJpaEntity);
-        RoomParticipantJpaEntity joiningMember = roomParticipantJpaRepository.save(RoomParticipantJpaEntity.builder()
-                .userJpaEntity(roomParticipantJpaEntity.getUserJpaEntity())
-                .roomJpaEntity(roomParticipantJpaEntity.getRoomJpaEntity())
-                .roomParticipantRole(RoomParticipantRole.MEMBER)        // Member
-                .currentPage(50)        // 현재 member의 마지막 활동 page
-                .userPercentage(10.6)       // 현재 member의 활동 percentage
-                .build());
+
+        RoomParticipantJpaEntity joiningMember = roomParticipantJpaRepository.findAllByRoomId(room.getRoomId()).get(0);
+        joiningMember.updateCurrentPage(50);
+        joiningMember.updateUserPercentage(10.6);
+        roomParticipantJpaRepository.flush();
+        em.clear();
 
         createVoteToRoom(joiningMember.getUserJpaEntity(), room, 2);      // 2개의 투표 생성
 
@@ -316,15 +308,12 @@ class RoomPlayingOrExpiredDetailViewApiTest {
         //given
         RoomJpaEntity room = saveScienceRoom("과학-책", "isbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1),IN_PROGRESS);
         saveUsersToRoom(room, 4);
-        RoomParticipantJpaEntity roomParticipantJpaEntity = roomParticipantJpaRepository.findAllByRoomId(room.getRoomId()).get(0);
-        roomParticipantJpaRepository.delete(roomParticipantJpaEntity);
-        RoomParticipantJpaEntity joiningMember = roomParticipantJpaRepository.save(RoomParticipantJpaEntity.builder()
-                .userJpaEntity(roomParticipantJpaEntity.getUserJpaEntity())
-                .roomJpaEntity(roomParticipantJpaEntity.getRoomJpaEntity())
-                .roomParticipantRole(RoomParticipantRole.MEMBER)        // Member
-                .currentPage(50)        // 현재 member의 마지막 활동 page
-                .userPercentage(10.6)       // 현재 member의 활동 percentage
-                .build());
+
+        RoomParticipantJpaEntity joiningMember = roomParticipantJpaRepository.findAllByRoomId(room.getRoomId()).get(0);
+        joiningMember.updateCurrentPage(50);
+        joiningMember.updateUserPercentage(10.6);
+        roomParticipantJpaRepository.flush();
+        em.clear();
 
         createVoteToRoom(joiningMember.getUserJpaEntity(), room, 6);      // 6개의 투표 생성
 
@@ -368,15 +357,12 @@ class RoomPlayingOrExpiredDetailViewApiTest {
         //given
         RoomJpaEntity room = saveScienceRoom("과학-책", "isbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1),IN_PROGRESS);
         saveUsersToRoom(room, 4);
-        RoomParticipantJpaEntity roomParticipantJpaEntity = roomParticipantJpaRepository.findAllByRoomId(room.getRoomId()).get(0);
-        roomParticipantJpaRepository.delete(roomParticipantJpaEntity);
-        RoomParticipantJpaEntity joiningMember = roomParticipantJpaRepository.save(RoomParticipantJpaEntity.builder()
-                .userJpaEntity(roomParticipantJpaEntity.getUserJpaEntity())
-                .roomJpaEntity(roomParticipantJpaEntity.getRoomJpaEntity())
-                .roomParticipantRole(RoomParticipantRole.MEMBER)        // Member
-                .currentPage(50)        // 현재 member의 마지막 활동 page
-                .userPercentage(10.6)       // 현재 member의 활동 percentage
-                .build());
+
+        RoomParticipantJpaEntity joiningMember = roomParticipantJpaRepository.findAllByRoomId(room.getRoomId()).get(0);
+        joiningMember.updateCurrentPage(50);
+        joiningMember.updateUserPercentage(10.6);
+        roomParticipantJpaRepository.flush();
+        em.clear();
 
         createVoteToRoom(joiningMember.getUserJpaEntity(), room, 0);      // 투표 생성 X
 

--- a/src/test/java/konkuk/thip/room/adapter/in/web/RoomRecruitingDetailViewApiTest.java
+++ b/src/test/java/konkuk/thip/room/adapter/in/web/RoomRecruitingDetailViewApiTest.java
@@ -185,13 +185,9 @@ class RoomRecruitingDetailViewApiTest {
         //given
         RoomJpaEntity targetRoom = saveScienceRoom("과학-책", "isbn1", "과학-방-1일뒤-활동시작", LocalDate.now().plusDays(1), 10, RoomStatus.RECRUITING);
         saveUsersToRoom(targetRoom, 4);
-        RoomParticipantJpaEntity firstMember = roomParticipantJpaRepository.findAllByRoomId(targetRoom.getRoomId()).get(1);
-        roomParticipantJpaRepository.delete(firstMember);
-        RoomParticipantJpaEntity roomCreator = roomParticipantJpaRepository.save(RoomParticipantJpaEntity.builder()
-                .userJpaEntity(firstMember.getUserJpaEntity())
-                .roomJpaEntity(firstMember.getRoomJpaEntity())
-                .roomParticipantRole(RoomParticipantRole.HOST)
-                .build());      // firstMember 을 MEMBER -> HOST 로 수정
+
+        RoomParticipantJpaEntity roomHost = roomParticipantJpaRepository.findAllByRoomId(targetRoom.getRoomId()).get(1);
+        roomHost.updateRoleToHost();
 
         RoomJpaEntity science_room_2 = saveScienceRoom("과학-책", "isbn2", "방이름입니다", LocalDate.now().plusDays(1), 10, RoomStatus.RECRUITING);
         saveUsersToRoom(science_room_2, 5);
@@ -210,7 +206,7 @@ class RoomRecruitingDetailViewApiTest {
 
         //when
         ResultActions result = mockMvc.perform(get("/rooms/{roomId}/recruiting", targetRoom.getRoomId())
-                .requestAttr("userId", roomCreator.getUserJpaEntity().getUserId()));
+                .requestAttr("userId", roomHost.getUserJpaEntity().getUserId()));
 
         //then
         result.andExpect(status().isOk())

--- a/src/test/java/konkuk/thip/room/application/service/RoomJoinServiceTest.java
+++ b/src/test/java/konkuk/thip/room/application/service/RoomJoinServiceTest.java
@@ -65,7 +65,8 @@ class RoomJoinServiceTest {
         void alreadyParticipated() {
             RoomJoinCommand command = new RoomJoinCommand(USER_ID, ROOM_ID, JOIN);
 
-            given(roomCommandPort.findById(ROOM_ID)).willReturn(Optional.of(room));
+//            given(roomCommandPort.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(roomCommandPort.getByIdForUpdate(ROOM_ID)).willReturn(room);
             given(roomParticipantCommandPort.findByUserIdAndRoomIdOptional(USER_ID, ROOM_ID))
                     .willReturn(Optional.of(RoomParticipant.memberWithoutId(USER_ID, ROOM_ID)));
 
@@ -79,7 +80,8 @@ class RoomJoinServiceTest {
         void successJoin() {
             RoomJoinCommand command = new RoomJoinCommand(USER_ID, ROOM_ID, JOIN);
 
-            given(roomCommandPort.findById(ROOM_ID)).willReturn(Optional.of(room));
+//            given(roomCommandPort.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(roomCommandPort.getByIdForUpdate(ROOM_ID)).willReturn(room);
             given(roomParticipantCommandPort.findByUserIdAndRoomIdOptional(USER_ID, ROOM_ID))
                     .willReturn(Optional.empty());
             given(roomParticipantCommandPort.findHostByRoomId(any()))
@@ -110,7 +112,8 @@ class RoomJoinServiceTest {
         void notParticipated() {
             RoomJoinCommand command = new RoomJoinCommand(USER_ID, ROOM_ID, CANCEL);
 
-            given(roomCommandPort.findById(ROOM_ID)).willReturn(Optional.of(room));
+//            given(roomCommandPort.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(roomCommandPort.getByIdForUpdate(ROOM_ID)).willReturn(room);
             given(roomParticipantCommandPort.findByUserIdAndRoomIdOptional(USER_ID, ROOM_ID))
                     .willReturn(Optional.empty());
 
@@ -125,7 +128,8 @@ class RoomJoinServiceTest {
             RoomJoinCommand command = new RoomJoinCommand(USER_ID, ROOM_ID, CANCEL);
             RoomParticipant participant = RoomParticipant.memberWithoutId(USER_ID, ROOM_ID);
 
-            given(roomCommandPort.findById(ROOM_ID)).willReturn(Optional.of(room));
+//            given(roomCommandPort.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(roomCommandPort.getByIdForUpdate(ROOM_ID)).willReturn(room);
             given(roomParticipantCommandPort.findByUserIdAndRoomIdOptional(USER_ID, ROOM_ID))
                     .willReturn(Optional.of(participant));
 

--- a/src/test/java/konkuk/thip/room/concurrency/RoomJoinConcurrencyTest.java
+++ b/src/test/java/konkuk/thip/room/concurrency/RoomJoinConcurrencyTest.java
@@ -53,7 +53,7 @@ public class RoomJoinConcurrencyTest {
         int requestUserCount = 500;
 
         BookJpaEntity book = bookJpaRepository.save(TestEntityFactory.createBook());
-        // 모집인원 10명 방 생성
+        // 모집인원 10명 방 생성 -> HOST 1명 + MEMBER 9명 가능
         RoomJpaEntity room = roomJpaRepository.save(TestEntityFactory.createCustomRoom(book, Category.LITERATURE, 10));
         List<Long> savedUserIds = createUsersRange(requestUserCount + 1);
 
@@ -132,11 +132,11 @@ public class RoomJoinConcurrencyTest {
          */
 
         // 1) participants가 recruitCount 보다 커질 수 있음
-        assertThat(participantRows).isGreaterThan(recruit);
+        assertThat(participantRows).isGreaterThanOrEqualTo(recruit);
 
         // 2) memberCount가 실제 participants 수보다 작을 수 있음
         // memberCount 값은 Room 도메인 규칙에 의해 recruitCount를 초과하여 증가하지 않음
-        assertThat(memberCountInRoom).isLessThan((int) participantRows);
+        assertThat(memberCountInRoom).isLessThanOrEqualTo((int) participantRows);
     }
 
     private List<Long> createUsersRange(long count) {

--- a/src/test/java/konkuk/thip/room/concurrency/RoomJoinConcurrencyTest.java
+++ b/src/test/java/konkuk/thip/room/concurrency/RoomJoinConcurrencyTest.java
@@ -85,7 +85,7 @@ public class RoomJoinConcurrencyTest {
                             .andExpect(status().isOk());
                     return 200;
                 } catch (AssertionError e) {
-                    return 400;
+                    return -1;  // 응답이 200이 아닌 경우 (4xx, 5xx error 모두)
                 } finally {
                     finish.countDown();
                 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #330 

## 📝 작업 내용
'모임방 참여 api' 에 비관적 락을 적용해, '인기 작가 모임방에 여러 유저들이 동시에 모임방 참여 요청을 보낼 경우' 를 재현한 테스트 코드와 부하 테스트에서의 5xx 에러 발생 이슈를 해결했습니다.

<주요 수정 부분>
- 최초 Room 엔티티 조회 시, select for update 패턴으로 x-lock 을 걸고 room 엔티티 조회하도록 코드 수정
- lock 대기 시간을 최대 5초로 설정 & 최대 3회 재시도 하도록 제한 (spring retry 활용)
- 재시도 횟수 초과한 요청에 대해서는 HTTP 423(Locked) error throw

<수정 결과>
- '모임방 참여' 에 대한 모든 쓰레드가 Room 엔티티의 x-lock 획득을 위해 대기하도록 하여 '동시성 이슈(= 데이터 정합성 안 맞음) 및 데드락으로 인한 5xx 에러 발생' 이슈를 해결
- But, x-lock 획득을 위한 대기 및 재시도로 인한 병목 발생으로 '서버의 요청 처리 시간' 이 길어지는 것 확인 (근거 : p(95) 지표, request duration 지표) 

## 📸 스크린샷
https://separate-snowplow-d8b.notion.site/API-2-2a3b701eb0b8809db7dbfafeda3596e0?source=copy_link
-> 정리한 노션 링크 입니다!

## 💬 리뷰 요구사항
- 서버의 처리율 개선을 위해, 모든 쓰레드가 Room 엔티티의 x-lock 획득을 위해 대기하는 구조를 개선하고자 합니다
- Room의 멤버 수를 update 하는 로직을 sql문으로 처리하면(-> 정원 초과 판단 & 멤버 수 update를 모두 하나의 sql문으로 처리), lock 없이 해결되겠지만, THIP 서버의 기반인 DDD 를 해친다고 판단했습니다
- 따라서 노션에 작성한 것처럼, '낙관적 락 기반의 Room 엔티티 update + 이벤트 기반의 RoomParticipant save' 구조로 모임방 참여 service 로직을 개선하려고 합니다
  - Redis를 활용해 '특정 room의 현재 멤버 수를 캐싱' 하는 방법도 생각했으나, '모임방 참여' 특성 상 Redis 자원 낭비 이슈가 더 크다고 판단했습니다

위 개선 방향에 대해 리뷰 달아주시면 감사하겠습니다!!

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 방 참여 시 잠금 충돌에 대한 자동 재시도 도입으로 일시적 동시성 문제 완화

* **개선 사항**
  * 리소스가 잠긴 경우 명확한 오류 응답(자원 잠김) 제공
  * 참가자 중복을 방지하는 데이터 제약 추가로 방 참여 무결성 향상

* **테스트/운영**
  * 동시성 관련 부하 테스트 및 통계 집계 간소화로 모니터링 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->