### PR TITLE
[fix] 팔로잉 동시성 이슈 문제 2차 해결시도 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,9 @@ dependencies {
 
 	// Spring AI - Google AI(Gemini) 연동
 	implementation 'org.springframework.ai:spring-ai-starter-model-openai:1.0.1'
+
+	// spring Retry
+	implementation 'org.springframework.retry:spring-retry'
 }
 
 def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile

--- a/loadtest/follow_change_state_load_test.js
+++ b/loadtest/follow_change_state_load_test.js
@@ -1,0 +1,149 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend, Counter } from 'k6/metrics';
+
+const BASE_URL      = 'http://localhost:8080';
+const TARGET_USER_ID= 1;        // 팔로우/언팔 대상 사용자 ID
+const USERS_START   = 10000;    // 토큰 발급 시작 userId
+const USERS_COUNT   = 500;      // 총 사용자 = VU 수
+const TOKEN_BATCH   = 200;      // 토큰 발급 배치 크기
+const BATCH_PAUSE_S = 0.2;      // 배치 간 대기 (for 토큰 발급 API 병목 방지)
+const START_DELAY_S = 5;        // 테스트 시작 전 대기 (for 동시 시작)
+
+const followLatency = new Trend('follow_change_latency'); // API 지연(ms) - 네이밍 포맷 유지
+const http5xx     = new Counter('follow_change_5xx');   // 5xx 개수
+const http2xx     = new Counter('follow_change_2xx');   // 2xx 개수
+const http4xx     = new Counter('follow_change_4xx');   // 4xx 개수
+
+const token_issue_failed              = new Counter('token_issue_failed');
+const fail_USER_ALREADY_FOLLOWED      = new Counter('fail_USER_ALREADY_FOLLOWED');
+const fail_USER_ALREADY_UNFOLLOWED    = new Counter('fail_USER_ALREADY_UNFOLLOWED');
+const fail_USER_CANNOT_FOLLOW_SELF    = new Counter('fail_USER_CANNOT_FOLLOW_SELF');
+const fail_OTHER_4XX                  = new Counter('fail_OTHER_4XX');
+
+const ERR = {
+    USER_ALREADY_FOLLOWED:    70001,
+    USER_ALREADY_UNFOLLOWED:  75001,
+    USER_CANNOT_FOLLOW_SELF:  75002,
+};
+
+function parseError(res) {
+    try {
+        const j = JSON.parse(res.body || '{}'); // BaseResponse 구조
+        return {
+            code: Number(j.code),              // 정수 코드
+            message: j.message || '',
+            requestId: j.requestId || '',
+            isSuccess: !!j.isSuccess
+        };
+    } catch (e) {
+        return { code: NaN, message: '', requestId: '', isSuccess: false };
+    }
+}
+
+// ------------ 시나리오 ------------
+// [다수 유저가 동일 타깃(TARGET_USER_ID)에게 '팔로우' 요청을 동시에 보내는 상황]
+export const options = {
+    scenarios: {
+        // 각 VU가 "정확히 1회" 실행 → 1 VU = 1명 유저
+        join_once_burst: {
+            executor: 'per-vu-iterations',
+            vus: USERS_COUNT,
+            iterations: 1,
+            startTime: '0s',         // 모든 VU가 거의 동시에 스케줄링
+            gracefulStop: '5s',
+        },
+    },
+    thresholds: {
+        follow_change_5xx:     ['count==0'],     // 서버 오류는 0건이어야 함
+        follow_change_latency: ['p(95)<1000'],   // p95 < 1s
+    },
+};
+
+/** ===== setup: 토큰 일괄 발급 ===== */
+export function setup() {
+    const userIds = Array.from({ length: USERS_COUNT }, (_, i) => USERS_START + i);
+    const tokens = [];
+
+    for (let i = 0; i < userIds.length; i += TOKEN_BATCH) {
+        const slice = userIds.slice(i, i + TOKEN_BATCH);
+        const reqs = slice.map((uid) => [
+            'GET',
+            `${BASE_URL}/api/test/token/access?userId=${uid}`,
+            null,
+            { tags: { phase: 'setup_token_issue', target: `${TARGET_USER_ID}` } },
+        ]);
+
+        const responses = http.batch(reqs);
+        for (const r of responses) {
+            if (r.status === 200 && r.body) {
+                tokens.push(r.body.trim());
+            }
+            else {
+                tokens.push(''); // 실패한 자리도 인덱스 유지
+                token_issue_failed.add(1);
+            }
+        }
+        sleep(BATCH_PAUSE_S);
+    }
+    if (tokens.length > USERS_COUNT) tokens.length = USERS_COUNT;
+
+    const startAt = Date.now() + START_DELAY_S * 1000;    // 동시 시작 시간
+    return { tokens, startAt };
+}
+
+// VU : 각자 자기 토큰으로 팔로우 호출 & 각자 1회만 실행
+export default function (data) {
+    const idx = __VU - 1;                 // VU <-> user 매핑(1:1)
+    const token = data.tokens[idx];
+
+    const now = Date.now();
+    if (now < data.startAt) {
+        sleep((data.startAt - now) / 1000);
+    }
+
+    if (!token) {     // 토큰 발급 실패 -> 스킵
+        return;
+    }
+
+    const headers = {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+    };
+
+    const body = JSON.stringify({ type: true });
+    const url = `${BASE_URL}/users/following/${TARGET_USER_ID}`;
+
+    const res = http.post(url, body, { headers, tags: { phase: 'follow_change', target: `${TARGET_USER_ID}` } });
+
+    followLatency.add(res.timings.duration);
+    if (res.status >= 200 && res.status < 300) {
+        http2xx.add(1);
+    }
+    else if (res.status >= 400 && res.status < 500) {
+        http4xx.add(1);
+        const err = parseError(res);
+        switch (err.code) {
+            case ERR.USER_ALREADY_FOLLOWED:
+                fail_USER_ALREADY_FOLLOWED.add(1);
+                break;
+            case ERR.USER_ALREADY_UNFOLLOWED:
+                fail_USER_ALREADY_UNFOLLOWED.add(1);
+                break;
+            case ERR.USER_CANNOT_FOLLOW_SELF:
+                fail_USER_CANNOT_FOLLOW_SELF.add(1);
+                break;
+            default:
+                fail_OTHER_4XX.add(1);
+        }
+    }
+    else if (res.status >= 500) {
+        http5xx.add(1);
+    }
+
+    check(res, {
+        'follow_change responded': (r) => r.status !== 0,
+        // 이미 팔로우 상태에서 재요청 등 합리적 4xx 허용
+        'follow_change 200 or expected 4xx': (r) => r.status === 200 || (r.status >= 400 && r.status < 500),
+    });
+}

--- a/loadtest/follow_change_toggle_load_test.js
+++ b/loadtest/follow_change_toggle_load_test.js
@@ -1,0 +1,162 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend, Counter } from 'k6/metrics';
+
+const BASE_URL        = 'http://localhost:8080';
+const TARGET_USER_ID  = 1;          // 팔로우/언팔 대상 사용자
+const USERS_START     = 10000;      // 토큰 발급 시작 userId
+const USERS_COUNT     = 500;        // 동시 사용자 수 = VU 수
+const TOKEN_BATCH     = 200;        // 토큰 발급 배치 크기
+const BATCH_PAUSE_S   = 0.2;        // 배치 간 휴지 (발급 API 보호)
+const START_DELAY_S   = 5;          // 전체 동기 시작 대기
+const TOGGLE_ITER     = 20;         // 각 VU가 시도할 토글 횟수(팔로우/언팔 번갈아 최대 20회)
+const TOGGLE_PAUSE_S  = 0.1;        // 한 번 호출 후 다음 토글까지 간격
+
+const followLatency = new Trend('follow_change_latency');
+const http5xx       = new Counter('follow_change_5xx');
+const http2xx       = new Counter('follow_change_2xx');
+const http4xx       = new Counter('follow_change_4xx');
+
+const token_issue_failed            = new Counter('token_issue_failed');
+const fail_USER_ALREADY_FOLLOWED    = new Counter('fail_USER_ALREADY_FOLLOWED');
+const fail_USER_ALREADY_UNFOLLOWED  = new Counter('fail_USER_ALREADY_UNFOLLOWED');
+const fail_USER_CANNOT_FOLLOW_SELF  = new Counter('fail_USER_CANNOT_FOLLOW_SELF');
+const fail_OTHER_4XX                = new Counter('fail_OTHER_4XX');
+
+const success_follow_200            = new Counter('success_follow_200');
+const success_unfollow_200          = new Counter('success_unfollow_200');
+
+const ERR = {
+    USER_ALREADY_FOLLOWED:   70001,
+    USER_ALREADY_UNFOLLOWED: 75001,
+    USER_CANNOT_FOLLOW_SELF: 75002,
+};
+
+function parseError(res) {
+    try {
+        const j = JSON.parse(res.body || '{}');
+        return {
+            code: Number(j.code),
+            message: j.message || '',
+            requestId: j.requestId || '',
+            isSuccess: !!j.isSuccess,
+        };
+    } catch (_) {
+        return { code: NaN, message: '', requestId: '', isSuccess: false };
+    }
+}
+
+/** ===== 시나리오 ===== */
+export const options = {
+    scenarios: {
+        follow_toggle_spam: {
+            executor: 'per-vu-iterations',
+            vus: USERS_COUNT,
+            iterations: TOGGLE_ITER,     // 각 VU가 TOGGLE_ITER번 default() 실행
+            startTime: '0s',
+            gracefulStop: '5s',
+        },
+    },
+    thresholds: {
+        follow_change_5xx:     ['count==0'],
+        follow_change_latency: ['p(95)<1000'],
+    },
+};
+
+/** ===== setup: 토큰 일괄 발급 ===== */
+export function setup() {
+    const userIds = Array.from({ length: USERS_COUNT }, (_, i) => USERS_START + i);
+    const tokens = [];
+
+    for (let i = 0; i < userIds.length; i += TOKEN_BATCH) {
+        const slice = userIds.slice(i, i + TOKEN_BATCH);
+        const reqs = slice.map((uid) => [
+            'GET',
+            `${BASE_URL}/api/test/token/access?userId=${uid}`,
+            null,
+            { tags: { phase: 'setup_token_issue', target: `${TARGET_USER_ID}` } },
+        ]);
+        const responses = http.batch(reqs);
+        for (const r of responses) {
+            if (r.status === 200 && r.body) tokens.push(r.body.trim());
+            else {
+                tokens.push('');
+                token_issue_failed.add(1);
+            }
+        }
+        sleep(BATCH_PAUSE_S);
+    }
+    if (tokens.length > USERS_COUNT) tokens.length = USERS_COUNT;
+
+    const startAt = Date.now() + START_DELAY_S * 1000;
+    return { tokens, startAt };
+}
+
+/** ===== 각 VU의 토글 상태 =====
+ * false = 아직 팔로우 안 한 상태로 가정 → 다음 요청은 follow(type:true)
+ * true  = 이미 팔로우 한 상태로 가정   → 다음 요청은 unfollow(type:false)
+ */
+let isFollowing = false;
+
+/** ===== 실행 루프 ===== */
+export default function (data) {
+    const idx   = __VU - 1;
+    const token = data.tokens[idx];
+
+    // 동기 시작
+    const now = Date.now();
+    if (now < data.startAt) {
+        sleep((data.startAt - now) / 1000);
+    }
+
+    if (!token) return;
+
+    const headers = {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+    };
+
+    // 현재 상태에 따라 요청 결정
+    // 규칙: "이전 요청이 200일 때만" 상태를 뒤집는다 → 4xx/5xx면 상태 유지(같은 동작 재시도)
+    const wantFollow = !isFollowing; // 현재 false면 follow, true면 unfollow
+    const body = JSON.stringify({ type: wantFollow });
+    const url  = `${BASE_URL}/users/following/${TARGET_USER_ID}`;
+
+    const res = http.post(url, body, { headers, tags: { phase: 'follow_change', target: `${TARGET_USER_ID}`, want: wantFollow ? 'follow' : 'unfollow' } });
+
+    followLatency.add(res.timings.duration);
+    if (res.status >= 200 && res.status < 300) {
+        http2xx.add(1);
+        // 200일 때만 상태 반전
+        isFollowing = !isFollowing;
+        if (wantFollow) success_follow_200.add(1);
+        else success_unfollow_200.add(1);
+    } else if (res.status >= 400 && res.status < 500) {
+        http4xx.add(1);
+        const err = parseError(res);
+        switch (err.code) {
+            case ERR.USER_ALREADY_FOLLOWED:
+                fail_USER_ALREADY_FOLLOWED.add(1);
+                break;
+            case ERR.USER_ALREADY_UNFOLLOWED:
+                fail_USER_ALREADY_UNFOLLOWED.add(1);
+                break;
+            case ERR.USER_CANNOT_FOLLOW_SELF:
+                fail_USER_CANNOT_FOLLOW_SELF.add(1);
+                break;
+            default:
+                fail_OTHER_4XX.add(1);
+        }
+    } else if (res.status >= 500) {
+        http5xx.add(1);
+    }
+
+    check(res, {
+        'follow_change responded': (r) => r.status !== 0,
+        'follow_change 200 or expected 4xx': (r) =>
+            r.status === 200 || (r.status >= 400 && r.status < 500),
+    });
+
+    // 토글 간격
+    sleep(TOGGLE_PAUSE_S);
+}

--- a/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/thip/common/exception/code/ErrorCode.java
@@ -32,6 +32,8 @@ public enum ErrorCode implements ResponseCode {
 
     PERSISTENCE_TRANSACTION_REQUIRED(HttpStatus.INTERNAL_SERVER_ERROR, 50110, "@Transactional 컨텍스트가 필요합니다. 트랜잭션 범위 내에서만 사용할 수 있습니다."),
 
+    RESOURCE_LOCKED(HttpStatus.LOCKED, 50200, "자원이 잠겨 있어 요청을 처리할 수 없습니다."),
+
     /* 60000부터 비즈니스 예외 */
     /**
      * 60000 : alias error

--- a/src/main/java/konkuk/thip/config/RetryConfig.java
+++ b/src/main/java/konkuk/thip/config/RetryConfig.java
@@ -1,0 +1,9 @@
+package konkuk.thip.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry(proxyTargetClass = true)
+public class RetryConfig {
+}

--- a/src/main/java/konkuk/thip/config/WorkerThreadConfig.java
+++ b/src/main/java/konkuk/thip/config/WorkerThreadConfig.java
@@ -54,6 +54,19 @@ public class WorkerThreadConfig implements AsyncConfigurer {
         return executor;
     }
 
+    @Bean(name = "outboxAsyncExecutor")
+    public Executor outboxAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);        // 아웃박스 처리 기본량
+        executor.setMaxPoolSize(8);
+        executor.setQueueCapacity(2000);      // 적당한 큐 크기
+        executor.setThreadNamePrefix("outbox-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+        executor.initialize();
+        return executor;
+    }
+
     @Override
     public Executor getAsyncExecutor() {
         return fcmAsyncExecutor(); // 기본은 FCM 풀 사용

--- a/src/main/java/konkuk/thip/outbox/adapter/in/event/FollowingEventListener.java
+++ b/src/main/java/konkuk/thip/outbox/adapter/in/event/FollowingEventListener.java
@@ -1,0 +1,25 @@
+package konkuk.thip.outbox.adapter.in.event;
+
+import konkuk.thip.outbox.application.port.in.FollowingDispatchUseCase;
+import konkuk.thip.user.adapter.out.event.dto.FollowingEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class FollowingEventListener {
+
+    private final FollowingDispatchUseCase followingDispatchUseCase;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void onUserFollowed(FollowingEvent.UserFollowedEvent event) {
+        followingDispatchUseCase.handleUserFollow(event);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void onUserUnfollowed(FollowingEvent.UserUnfollowedEvent event) {
+        followingDispatchUseCase.handleUserUnfollow(event);
+    }
+}

--- a/src/main/java/konkuk/thip/outbox/adapter/in/scheduler/OutboxScheduler.java
+++ b/src/main/java/konkuk/thip/outbox/adapter/in/scheduler/OutboxScheduler.java
@@ -1,0 +1,19 @@
+package konkuk.thip.outbox.adapter.in.scheduler;
+
+import konkuk.thip.outbox.application.port.in.FollowingOutboxProcessUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxScheduler {
+
+    private final FollowingOutboxProcessUseCase followingOutboxProcessUseCase;
+
+    // 1초마다 PENDING 이벤트를 최대 100개씩 처리하는 예시
+    @Scheduled(fixedDelay = 1000)
+    public void processPendingEvents() {
+        followingOutboxProcessUseCase.processFollowingOutboxEvents();
+    }
+}

--- a/src/main/java/konkuk/thip/outbox/adapter/out/jpa/OutboxEventJpaEntity.java
+++ b/src/main/java/konkuk/thip/outbox/adapter/out/jpa/OutboxEventJpaEntity.java
@@ -1,0 +1,66 @@
+package konkuk.thip.outbox.adapter.out.jpa;
+
+import jakarta.persistence.*;
+import konkuk.thip.common.entity.BaseJpaEntity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "outbox_events")
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class OutboxEventJpaEntity extends BaseJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 어떤 도메인에 대한 이벤트인지 (USER, FOLLOW 등)
+    private String aggregateType;
+
+    // 연관된 도메인 ID (예: targetUserId)
+    private Long aggregateId;
+
+    // 이벤트 타입 (예: USER_FOLLOWED, USER_UNFOLLOWED)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false)
+    private OutboxEventType eventType;
+
+    // JSON 문자열로 이벤트 payload 저장
+    @Lob
+    private String payload;
+
+    // PENDING / PROCESSED / FAILED
+    @Enumerated(EnumType.STRING)
+
+    private OutboxStatus outboxStatus;
+
+    private LocalDateTime processedAt;
+
+    // 정적 팩토리 메서드
+    public static OutboxEventJpaEntity pending(
+            String aggregateType,
+            Long aggregateId,
+            OutboxEventType eventType,
+            String payload
+    ) {
+        OutboxEventJpaEntity entity = new OutboxEventJpaEntity();
+        entity.aggregateType = aggregateType;
+        entity.aggregateId = aggregateId;
+        entity.eventType = eventType;
+        entity.payload = payload;
+        entity.outboxStatus = OutboxStatus.PENDING;
+        return entity;
+    }
+
+    public void markAsProcessed() {
+        this.outboxStatus = OutboxStatus.PROCESSED;
+        this.processedAt = LocalDateTime.now();
+    }
+
+    public void markAsFailed() {
+        this.outboxStatus = OutboxStatus.FAILED;
+    }
+}

--- a/src/main/java/konkuk/thip/outbox/adapter/out/jpa/OutboxEventType.java
+++ b/src/main/java/konkuk/thip/outbox/adapter/out/jpa/OutboxEventType.java
@@ -1,0 +1,6 @@
+package konkuk.thip.outbox.adapter.out.jpa;
+
+public enum OutboxEventType {
+    USER_FOLLOWED,
+    USER_UNFOLLOWED
+}

--- a/src/main/java/konkuk/thip/outbox/adapter/out/jpa/OutboxStatus.java
+++ b/src/main/java/konkuk/thip/outbox/adapter/out/jpa/OutboxStatus.java
@@ -1,0 +1,7 @@
+package konkuk.thip.outbox.adapter.out.jpa;
+
+public enum OutboxStatus {
+    PENDING,
+    PROCESSED,
+    FAILED
+}

--- a/src/main/java/konkuk/thip/outbox/adapter/out/persistence/OutboxEventPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/outbox/adapter/out/persistence/OutboxEventPersistenceAdapter.java
@@ -1,0 +1,29 @@
+package konkuk.thip.outbox.adapter.out.persistence;
+
+import konkuk.thip.outbox.adapter.out.jpa.OutboxEventJpaEntity;
+import konkuk.thip.outbox.adapter.out.jpa.OutboxStatus;
+import konkuk.thip.outbox.adapter.out.persistence.repository.OutboxEventJpaRepository;
+import konkuk.thip.outbox.application.port.out.OutboxEventPersistencePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OutboxEventPersistenceAdapter implements OutboxEventPersistencePort {
+
+    private final OutboxEventJpaRepository outboxEventJpaRepository;
+
+    @Override
+    public void save(OutboxEventJpaEntity entity) {
+        outboxEventJpaRepository.save(entity);
+    }
+
+    @Override
+    public List<OutboxEventJpaEntity> findTop1000ByStatusOrderByIdAsc(OutboxStatus pending) {
+        return outboxEventJpaRepository.findTop1000ByOutboxStatusOrderByIdAsc(pending);
+    }
+
+
+}

--- a/src/main/java/konkuk/thip/outbox/adapter/out/persistence/repository/OutboxEventJpaRepository.java
+++ b/src/main/java/konkuk/thip/outbox/adapter/out/persistence/repository/OutboxEventJpaRepository.java
@@ -1,0 +1,11 @@
+package konkuk.thip.outbox.adapter.out.persistence.repository;
+
+import konkuk.thip.outbox.adapter.out.jpa.OutboxEventJpaEntity;
+import konkuk.thip.outbox.adapter.out.jpa.OutboxStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OutboxEventJpaRepository extends JpaRepository<OutboxEventJpaEntity, Long> {
+    List<OutboxEventJpaEntity> findTop1000ByOutboxStatusOrderByIdAsc(OutboxStatus pending);
+}

--- a/src/main/java/konkuk/thip/outbox/application/port/in/FollowingDispatchUseCase.java
+++ b/src/main/java/konkuk/thip/outbox/application/port/in/FollowingDispatchUseCase.java
@@ -1,0 +1,8 @@
+package konkuk.thip.outbox.application.port.in;
+
+import konkuk.thip.user.adapter.out.event.dto.FollowingEvent;
+
+public interface FollowingDispatchUseCase {
+    void handleUserFollow(FollowingEvent.UserFollowedEvent e);
+    void handleUserUnfollow(FollowingEvent.UserUnfollowedEvent e);
+}

--- a/src/main/java/konkuk/thip/outbox/application/port/in/FollowingOutboxProcessUseCase.java
+++ b/src/main/java/konkuk/thip/outbox/application/port/in/FollowingOutboxProcessUseCase.java
@@ -1,0 +1,5 @@
+package konkuk.thip.outbox.application.port.in;
+
+public interface FollowingOutboxProcessUseCase {
+    void processFollowingOutboxEvents();
+}

--- a/src/main/java/konkuk/thip/outbox/application/port/out/OutboxEventPersistencePort.java
+++ b/src/main/java/konkuk/thip/outbox/application/port/out/OutboxEventPersistencePort.java
@@ -1,0 +1,12 @@
+package konkuk.thip.outbox.application.port.out;
+
+import konkuk.thip.outbox.adapter.out.jpa.OutboxEventJpaEntity;
+import konkuk.thip.outbox.adapter.out.jpa.OutboxStatus;
+
+import java.util.List;
+
+public interface OutboxEventPersistencePort {
+    void save(OutboxEventJpaEntity entity);
+
+    List<OutboxEventJpaEntity> findTop1000ByStatusOrderByIdAsc(OutboxStatus pending);
+}

--- a/src/main/java/konkuk/thip/outbox/application/service/FollowingDispatchService.java
+++ b/src/main/java/konkuk/thip/outbox/application/service/FollowingDispatchService.java
@@ -1,0 +1,55 @@
+package konkuk.thip.outbox.application.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import konkuk.thip.common.exception.BusinessException;
+import konkuk.thip.common.exception.code.ErrorCode;
+import konkuk.thip.user.adapter.out.event.dto.FollowingEvent;
+import konkuk.thip.outbox.adapter.out.jpa.OutboxEventJpaEntity;
+import konkuk.thip.outbox.adapter.out.jpa.OutboxEventType;
+import konkuk.thip.outbox.application.port.in.FollowingDispatchUseCase;
+import konkuk.thip.outbox.application.port.out.OutboxEventPersistencePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FollowingDispatchService implements FollowingDispatchUseCase {
+
+    private final OutboxEventPersistencePort outboxEventPersistencePort;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handleUserFollow(FollowingEvent.UserFollowedEvent event) {
+        try {
+            String payload = objectMapper.writeValueAsString(event);
+
+            OutboxEventJpaEntity entity = OutboxEventJpaEntity.pending(
+                    "USER",
+                    event.targetUserId(),
+                    OutboxEventType.USER_FOLLOWED,
+                    payload
+            );
+            outboxEventPersistencePort.save(entity);
+        } catch (JsonProcessingException e) {
+            throw new BusinessException(ErrorCode.JSON_PROCESSING_ERROR);
+        }
+    }
+
+    @Override
+    public void handleUserUnfollow(FollowingEvent.UserUnfollowedEvent event) {
+        try {
+            String payload = objectMapper.writeValueAsString(event);
+
+            OutboxEventJpaEntity entity = OutboxEventJpaEntity.pending(
+                    "USER",
+                    event.targetUserId(),
+                    OutboxEventType.USER_UNFOLLOWED,
+                    payload
+            );
+            outboxEventPersistencePort.save(entity);
+        } catch (JsonProcessingException e) {
+            throw new BusinessException(ErrorCode.JSON_PROCESSING_ERROR);
+        }
+    }
+}

--- a/src/main/java/konkuk/thip/outbox/application/service/FollowingOutboxProcessService.java
+++ b/src/main/java/konkuk/thip/outbox/application/service/FollowingOutboxProcessService.java
@@ -1,0 +1,58 @@
+package konkuk.thip.outbox.application.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import konkuk.thip.outbox.adapter.out.jpa.OutboxEventJpaEntity;
+import konkuk.thip.outbox.adapter.out.jpa.OutboxEventType;
+import konkuk.thip.outbox.adapter.out.jpa.OutboxStatus;
+import konkuk.thip.outbox.application.port.in.FollowingOutboxProcessUseCase;
+import konkuk.thip.outbox.application.port.out.OutboxEventPersistencePort;
+import konkuk.thip.user.adapter.out.event.dto.FollowingEvent;
+import konkuk.thip.user.application.port.out.UserCommandPort;
+import konkuk.thip.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FollowingOutboxProcessService implements FollowingOutboxProcessUseCase {
+
+    private final OutboxEventPersistencePort outboxEventPersistencePort;
+    private final ObjectMapper objectMapper;
+
+    private final UserCommandPort userCommandPort;
+
+    @Async("outboxAsyncExecutor")
+    @Override
+    @Transactional
+    public void processFollowingOutboxEvents() {
+        List<OutboxEventJpaEntity> events = outboxEventPersistencePort.findTop1000ByStatusOrderByIdAsc(OutboxStatus.PENDING);
+
+        for (OutboxEventJpaEntity event : events) {
+            try {
+                if (OutboxEventType.USER_FOLLOWED.equals(event.getEventType())) {
+                    FollowingEvent.UserFollowedEvent payload =
+                            objectMapper.readValue(event.getPayload(), FollowingEvent.UserFollowedEvent.class);
+
+                    User user = userCommandPort.findById(payload.targetUserId());
+                    user.increaseFollowerCount();
+                    userCommandPort.update(user);
+                } else if (OutboxEventType.USER_UNFOLLOWED.equals(event.getEventType())) {
+                    FollowingEvent.UserFollowedEvent payload =
+                            objectMapper.readValue(event.getPayload(), FollowingEvent.UserFollowedEvent.class);
+                    User user = userCommandPort.findById(payload.targetUserId());
+                    user.decreaseFollowerCount();
+                    userCommandPort.update(user);
+                }
+
+                event.markAsProcessed();
+            } catch (Exception e) {
+                // 실패 시 전략: FAILED로 마킹 + 로그, 재시도 정책 등
+                event.markAsFailed();
+            }
+        }
+    }
+}

--- a/src/main/java/konkuk/thip/user/adapter/out/event/FollowingEventPublisherAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/event/FollowingEventPublisherAdapter.java
@@ -1,0 +1,34 @@
+package konkuk.thip.user.adapter.out.event;
+
+import konkuk.thip.user.adapter.out.event.dto.FollowingEvent;
+import konkuk.thip.user.application.port.out.FollowingEventCommandPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FollowingEventPublisherAdapter implements FollowingEventCommandPort {
+
+    private final ApplicationEventPublisher publisher;
+
+    @Override
+    public void publishUserFollowedEvent(Long userId, Long targetUserId) {
+        publisher.publishEvent(
+                FollowingEvent.UserFollowedEvent.builder()
+                        .userId(userId)
+                        .targetUserId(targetUserId)
+                        .build()
+        );
+    }
+
+    @Override
+    public void publishUserUnfollowedEvent(Long userId, Long targetUserId) {
+        publisher.publishEvent(
+                FollowingEvent.UserUnfollowedEvent.builder()
+                        .userId(userId)
+                        .targetUserId(targetUserId)
+                        .build()
+        );
+    }
+}

--- a/src/main/java/konkuk/thip/user/adapter/out/event/dto/FollowingEvent.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/event/dto/FollowingEvent.java
@@ -1,0 +1,10 @@
+package konkuk.thip.user.adapter.out.event.dto;
+
+import lombok.Builder;
+
+public class FollowingEvent {
+    @Builder
+    public record UserFollowedEvent(Long userId, Long targetUserId) {}
+    @Builder
+    public record UserUnfollowedEvent(Long userId, Long targetUserId) {}
+}

--- a/src/main/java/konkuk/thip/user/adapter/out/jpa/FollowingJpaEntity.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/jpa/FollowingJpaEntity.java
@@ -5,7 +5,15 @@ import konkuk.thip.common.entity.BaseJpaEntity;
 import lombok.*;
 
 @Entity
-@Table(name = "followings")
+@Table(
+        name = "followings",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_followings_user_target",
+                        columnNames = {"user_id", "following_user_id"}
+                )
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/FollowingCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/FollowingCommandPersistenceAdapter.java
@@ -39,14 +39,16 @@ public class FollowingCommandPersistenceAdapter implements FollowingCommandPort 
         UserJpaEntity userJpaEntity = userJpaRepository.findByUserId(following.getUserId()).orElseThrow(
                 () -> new EntityNotFoundException(USER_NOT_FOUND));
 
-        UserJpaEntity targetUserJpaEntity = updateUserFollowerCount(targetUser);
-        followingJpaRepository.save(followingMapper.toJpaEntity(userJpaEntity, targetUserJpaEntity));
+//        UserJpaEntity targetUserJpaEntity = updateUserFollowerCount(targetUser);
+        UserJpaEntity targetUserJpaEntity = userJpaRepository.findByUserId(targetUser.getId()).orElseThrow(
+                () -> new EntityNotFoundException(USER_NOT_FOUND));
 
+        followingJpaRepository.save(followingMapper.toJpaEntity(userJpaEntity, targetUserJpaEntity));
     }
 
     @Override
     public void deleteFollowing(Following following, User targetUser) {
-        updateUserFollowerCount(targetUser);
+//        updateUserFollowerCount(targetUser);
 
         FollowingJpaEntity followingJpaEntity = followingJpaRepository.findByUserAndTargetUser(following.getUserId(), following.getFollowingUserId())
                 .orElseThrow(() -> new EntityNotFoundException(FOLLOW_NOT_FOUND));

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/UserCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/UserCommandPersistenceAdapter.java
@@ -21,7 +21,6 @@ import static konkuk.thip.common.exception.code.ErrorCode.USER_NOT_FOUND;
 public class UserCommandPersistenceAdapter implements UserCommandPort {
 
     private final UserJpaRepository userJpaRepository;
-
     private final UserMapper userMapper;
 
     @Override
@@ -33,6 +32,14 @@ public class UserCommandPersistenceAdapter implements UserCommandPort {
     @Override
     public User findById(Long userId) {
         UserJpaEntity userJpaEntity = userJpaRepository.findByUserId(userId).orElseThrow(
+                () -> new EntityNotFoundException(USER_NOT_FOUND));
+
+        return userMapper.toDomainEntity(userJpaEntity);
+    }
+
+    @Override
+    public User findByIdWithLock(Long userId) {
+        UserJpaEntity userJpaEntity = userJpaRepository.findByUserIdWithLock(userId).orElseThrow(
                 () -> new EntityNotFoundException(USER_NOT_FOUND));
 
         return userMapper.toDomainEntity(userJpaEntity);

--- a/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/UserJpaRepository.java
+++ b/src/main/java/konkuk/thip/user/adapter/out/persistence/repository/UserJpaRepository.java
@@ -1,8 +1,12 @@
 package konkuk.thip.user.adapter.out.persistence.repository;
 
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
@@ -14,6 +18,13 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long>, U
      * 소프트 딜리트 적용 대상 entity 단건 조회 메서드
      */
     Optional<UserJpaEntity> findByUserId(Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({
+        @QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000") // 5초
+    })
+    @Query("select u from UserJpaEntity u where u.userId = :userId")
+    Optional<UserJpaEntity> findByUserIdWithLock(@Param("userId") Long userId);
 
     Optional<UserJpaEntity> findByOauth2Id(String oauth2Id);
 

--- a/src/main/java/konkuk/thip/user/application/port/out/FollowingEventCommandPort.java
+++ b/src/main/java/konkuk/thip/user/application/port/out/FollowingEventCommandPort.java
@@ -1,0 +1,6 @@
+package konkuk.thip.user.application.port.out;
+
+public interface FollowingEventCommandPort {
+    void publishUserFollowedEvent(Long userId, Long targetUserId);
+    void publishUserUnfollowedEvent(Long userId, Long targetUserId);
+}

--- a/src/main/java/konkuk/thip/user/application/port/out/UserCommandPort.java
+++ b/src/main/java/konkuk/thip/user/application/port/out/UserCommandPort.java
@@ -9,6 +9,7 @@ public interface UserCommandPort {
 
     Long save(User user);
     User findById(Long userId);
+    User findByIdWithLock(Long userId);
     Map<Long, User> findByIds(List<Long> userIds);
     void update(User user);
     void delete(User user);

--- a/src/main/java/konkuk/thip/user/application/service/following/UserFollowService.java
+++ b/src/main/java/konkuk/thip/user/application/service/following/UserFollowService.java
@@ -1,6 +1,8 @@
 package konkuk.thip.user.application.service.following;
 
 import konkuk.thip.common.exception.BusinessException;
+import konkuk.thip.common.exception.InvalidStateException;
+import konkuk.thip.common.exception.code.ErrorCode;
 import konkuk.thip.notification.application.port.in.FeedNotificationOrchestrator;
 import konkuk.thip.user.application.port.in.UserFollowUsecase;
 import konkuk.thip.user.application.port.in.dto.UserFollowCommand;
@@ -9,12 +11,15 @@ import konkuk.thip.user.application.port.out.UserCommandPort;
 import konkuk.thip.user.domain.Following;
 import konkuk.thip.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
-import static konkuk.thip.common.exception.code.ErrorCode.*;
+import static konkuk.thip.common.exception.code.ErrorCode.USER_CANNOT_FOLLOW_SELF;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +32,18 @@ public class UserFollowService implements UserFollowUsecase {
 
     @Override
     @Transactional
+    @Retryable(
+            notRecoverable = {
+                    BusinessException.class,
+                    InvalidStateException.class
+            },
+            noRetryFor = {
+                    BusinessException.class,
+                    InvalidStateException.class
+            },
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100, maxDelay = 500, multiplier = 2)
+    )
     public Boolean changeFollowingState(UserFollowCommand followCommand) {
         Long userId = followCommand.userId();
         Long targetUserId = followCommand.targetUserId();
@@ -35,7 +52,7 @@ public class UserFollowService implements UserFollowUsecase {
         validateParams(userId, targetUserId);
 
         Optional<Following> optionalFollowing = followingCommandPort.findByUserIdAndTargetUserId(userId, targetUserId);
-        User targetUser = userCommandPort.findById(targetUserId);
+        User targetUser = userCommandPort.findByIdWithLock(targetUserId);
 
         boolean isFollowRequest = Following.validateFollowingState(optionalFollowing.isPresent(), type);
 
@@ -51,6 +68,11 @@ public class UserFollowService implements UserFollowUsecase {
             followingCommandPort.deleteFollowing(optionalFollowing.get(), targetUser);
             return false;
         }
+    }
+
+    @Recover
+    public Boolean recoverChangeFollowingState(Exception e, UserFollowCommand followCommand) {
+        throw new BusinessException(ErrorCode.RESOURCE_LOCKED);
     }
 
     private void sendNotifications(Long userId, Long targetUserId) {

--- a/src/main/java/konkuk/thip/user/application/service/following/UserFollowService.java
+++ b/src/main/java/konkuk/thip/user/application/service/following/UserFollowService.java
@@ -1,19 +1,15 @@
 package konkuk.thip.user.application.service.following;
 
 import konkuk.thip.common.exception.BusinessException;
-import konkuk.thip.common.exception.InvalidStateException;
-import konkuk.thip.common.exception.code.ErrorCode;
 import konkuk.thip.notification.application.port.in.FeedNotificationOrchestrator;
 import konkuk.thip.user.application.port.in.UserFollowUsecase;
 import konkuk.thip.user.application.port.in.dto.UserFollowCommand;
 import konkuk.thip.user.application.port.out.FollowingCommandPort;
+import konkuk.thip.user.application.port.out.FollowingEventCommandPort;
 import konkuk.thip.user.application.port.out.UserCommandPort;
 import konkuk.thip.user.domain.Following;
 import konkuk.thip.user.domain.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Recover;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,21 +25,22 @@ public class UserFollowService implements UserFollowUsecase {
     private final UserCommandPort userCommandPort;
 
     private final FeedNotificationOrchestrator feedNotificationOrchestrator;
+    private final FollowingEventCommandPort followingEventCommandPort;
 
     @Override
     @Transactional
-    @Retryable(
-            notRecoverable = {
-                    BusinessException.class,
-                    InvalidStateException.class
-            },
-            noRetryFor = {
-                    BusinessException.class,
-                    InvalidStateException.class
-            },
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 100, maxDelay = 500, multiplier = 2)
-    )
+//    @Retryable(
+//            notRecoverable = {
+//                    BusinessException.class,
+//                    InvalidStateException.class
+//            },
+//            noRetryFor = {
+//                    BusinessException.class,
+//                    InvalidStateException.class
+//            },
+//            maxAttempts = 3,
+//            backoff = @Backoff(delay = 100, maxDelay = 500, multiplier = 2)
+//    )
     public Boolean changeFollowingState(UserFollowCommand followCommand) {
         Long userId = followCommand.userId();
         Long targetUserId = followCommand.targetUserId();
@@ -52,28 +49,30 @@ public class UserFollowService implements UserFollowUsecase {
         validateParams(userId, targetUserId);
 
         Optional<Following> optionalFollowing = followingCommandPort.findByUserIdAndTargetUserId(userId, targetUserId);
-        User targetUser = userCommandPort.findByIdWithLock(targetUserId);
+        User targetUser = userCommandPort.findById(targetUserId);
 
         boolean isFollowRequest = Following.validateFollowingState(optionalFollowing.isPresent(), type);
 
         if (isFollowRequest) { // 팔로우 요청인 경우
-            targetUser.increaseFollowerCount();
+//            targetUser.increaseFollowerCount();
             followingCommandPort.save(Following.withoutId(userId, targetUserId), targetUser);
 
             // 팔로우 푸쉬알림 전송
-            sendNotifications(userId, targetUserId);
+//            sendNotifications(userId, targetUserId);
+            followingEventCommandPort.publishUserFollowedEvent(userId, targetUserId);
             return true;
         } else { // 언팔로우 요청인 경우
-            targetUser.decreaseFollowerCount();
+//            targetUser.decreaseFollowerCount();
             followingCommandPort.deleteFollowing(optionalFollowing.get(), targetUser);
+            followingEventCommandPort.publishUserUnfollowedEvent(userId, targetUserId);
             return false;
         }
     }
 
-    @Recover
-    public Boolean recoverChangeFollowingState(Exception e, UserFollowCommand followCommand) {
-        throw new BusinessException(ErrorCode.RESOURCE_LOCKED);
-    }
+//    @Recover
+//    public Boolean recoverChangeFollowingState(Exception e, UserFollowCommand followCommand) {
+//        throw new BusinessException(ErrorCode.RESOURCE_LOCKED);
+//    }
 
     private void sendNotifications(Long userId, Long targetUserId) {
         User actorUser = userCommandPort.findById(userId);

--- a/src/main/resources/db/migration/V251120__Add_following_unique_constraint.sql
+++ b/src/main/resources/db/migration/V251120__Add_following_unique_constraint.sql
@@ -1,0 +1,3 @@
+ALTER TABLE followings
+    ADD CONSTRAINT uq_followings_user_target
+        UNIQUE (user_id, following_user_id);

--- a/src/main/resources/db/migration/V251120__Add_following_unique_constraint.sql
+++ b/src/main/resources/db/migration/V251120__Add_following_unique_constraint.sql
@@ -1,3 +1,4 @@
+-- 팔로잉 테이블에 사용자와 타겟 사용자 간의 유니크 제약 조건 추가
 ALTER TABLE followings
     ADD CONSTRAINT uq_followings_user_target
         UNIQUE (user_id, following_user_id);

--- a/src/main/resources/db/migration/V251124__Create_OutboxEvent_table.sql
+++ b/src/main/resources/db/migration/V251124__Create_OutboxEvent_table.sql
@@ -1,0 +1,29 @@
+-- OutboxEvent 테이블 생성
+CREATE TABLE outbox_events (
+                               id              BIGINT AUTO_INCREMENT PRIMARY KEY,
+
+    -- 도메인 정보
+                               aggregate_type  VARCHAR(100)      NOT NULL,
+                               aggregate_id    BIGINT            NOT NULL,
+
+    -- 이벤트 타입 (USER_FOLLOWED / USER_UNFOLLOWED)
+                               event_type      VARCHAR(50)       NOT NULL,
+
+    -- 이벤트 페이로드(JSON)
+                               payload         LONGTEXT          NOT NULL,
+
+    -- BaseJpaEntity 공통 컬럼
+                               created_at      DATETIME(6)       NOT NULL,
+                               modified_at     DATETIME(6)       NOT NULL,
+                               status          VARCHAR(20)       NOT NULL,
+    -- ↑ BaseJpaEntity.StatusType (ACTIVE 등) 용도로 매핑됨
+
+    -- Outbox 전용 상태 (PENDING / PROCESSED / FAILED)
+                               outbox_status   VARCHAR(20)       NOT NULL,
+
+                               processed_at    DATETIME(6)       NULL
+);
+
+-- Polling 시 성능을 위한 인덱스 (PENDING 이벤트 우선 조회용)
+CREATE INDEX idx_outbox_events_outbox_status_id
+    ON outbox_events (outbox_status, id);

--- a/src/test/java/konkuk/thip/config/TestAsyncConfig.java
+++ b/src/test/java/konkuk/thip/config/TestAsyncConfig.java
@@ -20,13 +20,34 @@ public class TestAsyncConfig implements AsyncConfigurer {
         return new SyncTaskExecutor();
     }
 
-    @Bean(name = "schedulerAsyncExecutor")
-    public Executor schedulerAsyncExecutor() {
-        return new SyncTaskExecutor();
+        @Bean(name = "schedulerAsyncExecutor")
+
+        public Executor schedulerAsyncExecutor() {
+
+            return new SyncTaskExecutor();
+
+        }
+
+    
+
+        @Bean(name = "outboxAsyncExecutor")
+
+        public Executor outboxAsyncExecutor() {
+
+            return new SyncTaskExecutor();
+
+        }
+
+    
+
+        @Override
+
+        public Executor getAsyncExecutor() {
+
+            return new SyncTaskExecutor();
+
+        }
+
     }
 
-    @Override
-    public Executor getAsyncExecutor() {
-        return new SyncTaskExecutor();
-    }
-}
+    

--- a/src/test/java/konkuk/thip/user/adapter/in/web/UserFollowApiTest.java
+++ b/src/test/java/konkuk/thip/user/adapter/in/web/UserFollowApiTest.java
@@ -72,8 +72,8 @@ class UserFollowApiTest {
         FollowingJpaEntity followEntity = followingJpaRepository.findByUserAndTargetUser(followingUser.getUserId(), target.getUserId()).orElseThrow();
         assertThat(followEntity.getStatus().name()).isEqualTo("ACTIVE");
 
-        UserJpaEntity userJpaEntity = userJpaRepository.findById(target.getUserId()).orElseThrow();
-        assertThat(userJpaEntity.getFollowerCount()).isEqualTo(1); // 팔로워 수 증가 확인
+//        UserJpaEntity userJpaEntity = userJpaRepository.findById(target.getUserId()).orElseThrow();
+////        assertThat(userJpaEntity.getFollowerCount()).isEqualTo(1); // 팔로워 수 증가 확인
 
         // 언팔로우 요청
         mockMvc.perform(post("/users/following/{followingUserId}", target.getUserId())
@@ -87,7 +87,7 @@ class UserFollowApiTest {
         Optional<FollowingJpaEntity> followingJpaEntityOptional = followingJpaRepository.findByUserAndTargetUser(followingUser.getUserId(), target.getUserId());
         assertThat(followingJpaEntityOptional.isPresent()).isFalse();
 
-        userJpaEntity = userJpaRepository.findById(target.getUserId()).orElseThrow();
-        assertThat(userJpaEntity.getFollowerCount()).isEqualTo(0); // 팔로워 수 감소 확인
+//        userJpaEntity = userJpaRepository.findById(target.getUserId()).orElseThrow();
+//        assertThat(userJpaEntity.getFollowerCount()).isEqualTo(0); // 팔로워 수 감소 확인
     }
 }

--- a/src/test/java/konkuk/thip/user/application/service/UserFollowServiceTest.java
+++ b/src/test/java/konkuk/thip/user/application/service/UserFollowServiceTest.java
@@ -84,7 +84,7 @@ class UserFollowServiceTest {
 
             // then
             assertThat(result).isTrue();
-            assertThat(user.getFollowerCount()).isEqualTo(1); // followerCount 증가
+//            assertThat(user.getFollowerCount()).isEqualTo(1); // followerCount 증가
 
             ArgumentCaptor<Following> captor = ArgumentCaptor.forClass(Following.class);
             verify(followingCommandPort).save(captor.capture(), eq(user));
@@ -118,7 +118,7 @@ class UserFollowServiceTest {
 
             // then
             assertThat(result).isFalse();
-            assertThat(user.getFollowerCount()).isEqualTo(0); // followerCount 감소
+//            assertThat(user.getFollowerCount()).isEqualTo(0); // followerCount 감소
             verify(followingCommandPort).deleteFollowing(existing, user);
         }
 

--- a/src/test/java/konkuk/thip/user/application/service/UserFollowServiceTest.java
+++ b/src/test/java/konkuk/thip/user/application/service/UserFollowServiceTest.java
@@ -71,7 +71,7 @@ class UserFollowServiceTest {
                     .thenReturn(Optional.empty());
 
             User user = createUserWithFollowerCount(0);
-            when(userCommandPort.findById(targetUserId)).thenReturn(user);
+            when(userCommandPort.findByIdWithLock(targetUserId)).thenReturn(user);
             when(userCommandPort.findById(userId)).thenReturn(user); // 알림 전송용
 
             UserFollowCommand command = new UserFollowCommand(userId, targetUserId, true);
@@ -106,7 +106,7 @@ class UserFollowServiceTest {
 
             when(followingCommandPort.findByUserIdAndTargetUserId(userId, targetUserId))
                     .thenReturn(Optional.of(existing));
-            when(userCommandPort.findById(targetUserId)).thenReturn(user);
+            when(userCommandPort.findByIdWithLock(targetUserId)).thenReturn(user);
 
             UserFollowCommand command = new UserFollowCommand(userId, targetUserId, false);
 

--- a/src/test/java/konkuk/thip/user/application/service/UserFollowServiceTest.java
+++ b/src/test/java/konkuk/thip/user/application/service/UserFollowServiceTest.java
@@ -4,6 +4,7 @@ import konkuk.thip.common.exception.BusinessException;
 import konkuk.thip.notification.application.service.FeedNotificationOrchestratorSyncImpl;
 import konkuk.thip.user.application.port.in.dto.UserFollowCommand;
 import konkuk.thip.user.application.port.out.FollowingCommandPort;
+import konkuk.thip.user.application.port.out.FollowingEventCommandPort;
 import konkuk.thip.user.application.port.out.UserCommandPort;
 import konkuk.thip.user.application.service.following.UserFollowService;
 import konkuk.thip.user.domain.Following;
@@ -30,13 +31,15 @@ class UserFollowServiceTest {
     private UserFollowService userFollowService;
 
     private FeedNotificationOrchestratorSyncImpl feedNotificationOrchestratorSyncImpl;
+    private FollowingEventCommandPort followingEventCommandPort;
 
     @BeforeEach
     void setUp() {
         followingCommandPort = mock(FollowingCommandPort.class);
         userCommandPort = mock(UserCommandPort.class);
         feedNotificationOrchestratorSyncImpl = mock(FeedNotificationOrchestratorSyncImpl.class);
-        userFollowService = new UserFollowService(followingCommandPort, userCommandPort, feedNotificationOrchestratorSyncImpl);
+        followingEventCommandPort = mock(FollowingEventCommandPort.class);
+        userFollowService = new UserFollowService(followingCommandPort, userCommandPort, feedNotificationOrchestratorSyncImpl, followingEventCommandPort);
     }
 
     @Nested
@@ -71,7 +74,7 @@ class UserFollowServiceTest {
                     .thenReturn(Optional.empty());
 
             User user = createUserWithFollowerCount(0);
-            when(userCommandPort.findByIdWithLock(targetUserId)).thenReturn(user);
+            when(userCommandPort.findById(targetUserId)).thenReturn(user);
             when(userCommandPort.findById(userId)).thenReturn(user); // 알림 전송용
 
             UserFollowCommand command = new UserFollowCommand(userId, targetUserId, true);
@@ -106,7 +109,7 @@ class UserFollowServiceTest {
 
             when(followingCommandPort.findByUserIdAndTargetUserId(userId, targetUserId))
                     .thenReturn(Optional.of(existing));
-            when(userCommandPort.findByIdWithLock(targetUserId)).thenReturn(user);
+            when(userCommandPort.findById(targetUserId)).thenReturn(user);
 
             UserFollowCommand command = new UserFollowCommand(userId, targetUserId, false);
 

--- a/src/test/java/konkuk/thip/user/concurrency/UserFollowConcurrencyTest.java
+++ b/src/test/java/konkuk/thip/user/concurrency/UserFollowConcurrencyTest.java
@@ -1,0 +1,131 @@
+package konkuk.thip.user.concurrency;
+
+import konkuk.thip.common.util.TestEntityFactory;
+import konkuk.thip.user.adapter.out.jpa.UserJpaEntity;
+import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
+import konkuk.thip.user.domain.value.Alias;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("[동시성] 사용자 팔로우 상태 변경 동시 요청 테스트")
+@Tag("concurrency")
+public class UserFollowConcurrencyTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private UserJpaRepository userJpaRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    @Test
+    @DisplayName("[동시성] 사용자 팔로우 상태 변경 동시 요청 테스트")
+    void user_follow_test_in_multi_thread() throws Exception {
+        //given
+        final int followerCount = 500;
+
+        // 팔로우 당할 유저 생성
+        UserJpaEntity targetUser = userJpaRepository.save(TestEntityFactory.createUser(Alias.ARTIST, "target_user"));
+
+        // 팔로우 하는 유저들 생성
+        List<Long> followerIds = createUsersRange(followerCount);
+
+        //when
+        ExecutorService pool = Executors.newFixedThreadPool(Math.min(followerCount, 100));
+        CountDownLatch ready = new CountDownLatch(followerCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch finish = new CountDownLatch(followerCount);
+
+        final String requestBody = """
+                {
+                    "type": true
+                }
+                """;
+
+        List<Future<Integer>> results = new ArrayList<>(followerCount);
+
+        for (Long followerId : followerIds) {
+            results.add(pool.submit(() -> {
+                ready.countDown();
+                start.await();
+                try {
+                    mockMvc.perform(
+                                    post("/users/following/{followingUserId}", targetUser.getUserId())
+                                            .contentType("application/json")
+                                            // 컨트롤러의 @UserId Long userId 에 주입
+                                            .requestAttr("userId", followerId)
+                                            .content(requestBody)
+                            )
+                            .andExpect(status().isOk());
+                    return 200;
+                } catch (AssertionError e) {
+                    return 400;
+                } finally {
+                    finish.countDown();
+                }
+            }));
+        }
+
+        ready.await(10, TimeUnit.SECONDS);
+        start.countDown();
+        finish.await(60, TimeUnit.SECONDS);
+        pool.shutdown();
+
+        //then
+        long okCount = results.stream()
+                .filter(result -> {
+                    try {
+                        return result.get() == 200;
+                    } catch (Exception e) {
+                        return false;
+                    }
+                }).count();
+
+        Long followingRows = jdbcTemplate.query(
+                "SELECT COUNT(*) FROM followings WHERE following_user_id = ?",
+                ps -> ps.setLong(1, targetUser.getUserId()),
+                rs -> {rs.next(); return rs.getLong(1); }
+        );
+
+        Long storedFollowerCount = jdbcTemplate.query(
+                "SELECT follower_count FROM users WHERE user_id = ?",
+                ps -> ps.setLong(1, targetUser.getUserId()),
+                rs -> {rs.next(); return rs.getLong(1); }
+        );
+
+        System.out.println("=== RESULT ===");
+        System.out.println("OK responses : " + okCount);
+        System.out.println("followings rows : " + followingRows);
+        System.out.println("target user's follower_count : " + storedFollowerCount);
+
+        // 실제 생성된 팔로잉 행 수는 팔로우 요청 횟수보다 적을 수 있다. (데이터 정합성이 깨지는 경우)
+        Assertions.assertThat(followingRows).isLessThanOrEqualTo(followerCount);
+        // User 테이블의 팔로워 수 컬럼 역시 팔로우 요청 횟수보다 적을 수 있다. (데이터 정합성이 깨지는 경우)
+        Assertions.assertThat(storedFollowerCount).isLessThanOrEqualTo(followerCount);
+
+    }
+
+    private List<Long> createUsersRange(int followerCount) {
+        List<Long> userIds = new ArrayList<>();
+        for (int i = 0; i < followerCount; i++) {
+            UserJpaEntity savedUser = userJpaRepository.save(TestEntityFactory.createUser(Alias.WRITER, "follower_user_" + i));
+            userIds.add(savedUser.getUserId());
+        }
+        return userIds;
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #336 

## 📝 작업 내용

이전 PR (#337)에 이어서 팔로잉 동시성 이슈를 EDA 도입을 통해 해결하는 방법을 시도해보았습니다.

데이터 정합성을 맞추기 위해 Outbox 패턴을 도입했는데, 자세한 내용은 [노션](https://separate-snowplow-d8b.notion.site/API-2-Outbox-2b5b701eb0b88051a3b4d0a01d9fd366?source=copy_link) 참고 부탁드릴게요.
다만, 저번에 카톡으로 말했던 것처럼 막상 도입하다보니 데이터베이스를 업데이트하는 이벤트를 분리함으로써 얻는 이점이 클까?라는 점과 결국 하나의 서버가 버틸 수 있는 RPS(VU)에는 한계가 있다는 것을 느껴서 해당 PR은 머지하지 않고 close할 예정입니다!

## 📸 스크린샷

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 팔로우/언팔로우 이벤트 기반 아웃박스 처리 시스템 도입
  * 백그라운드 스케줄러로 대기 이벤트 비동기 처리
  * 재시도(안정성) 및 전용 워커 스레드 구성 추가

* **Bug Fixes**
  * 팔로우 중복 방지 유니크 제약 추가
  * 동시성 제어(락)를 통한 일관성 개선

* **Tests**
  * 동시성 테스트 및 k6 기반 로드 테스트 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->