### PR TITLE
[Refactor] External Api Isolation in 방 생성

### DIFF
--- a/src/main/java/konkuk/thip/book/adapter/out/api/CompositeBookApiAdapter.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/api/CompositeBookApiAdapter.java
@@ -6,15 +6,19 @@ import konkuk.thip.book.adapter.out.api.dto.NaverDetailBookParseResult;
 import konkuk.thip.book.adapter.out.api.naver.NaverApiClient;
 import konkuk.thip.book.application.port.out.BookApiQueryPort;
 import konkuk.thip.book.domain.Book;
+import konkuk.thip.common.discord.DiscordClient;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class CompositeBookApiAdapter implements BookApiQueryPort {
 
     private final NaverApiClient naverApiClient;
     private final AladinApiClient aladinApiClient;
+    private final DiscordClient discordClient;
 
     @Override
     public NaverBookParseResult findBooksByKeyword(String keyword, int start) {
@@ -26,29 +30,36 @@ public class CompositeBookApiAdapter implements BookApiQueryPort {
         return naverApiClient.findDetailBookByIsbn(isbn);
     }
 
+    // 알라딘 API 실패 시 Discord 알림 전송 후 null 반환 (방 생성은 계속 진행)
     @Override
     public Integer findPageCountByIsbn(String isbn) {
-        return aladinApiClient.findPageCountByIsbn(isbn);
+        try {
+            return aladinApiClient.findPageCountByIsbn(isbn);
+        } catch (Exception e) {
+            log.error("[Aladin API] pageCount 획득 실패 - isbn: {}, error: {}", isbn, e.getMessage());
+            discordClient.sendAladinApiFailureAlert(isbn, e);
+            return null;
+        }
     }
 
     @Override
     public Book loadBookWithPageByIsbn(String isbn) {
-        // 1. naver 상세정보 조회 api 로 책 상세정보(without page) load
-        NaverDetailBookParseResult detailBookByKeyword = findDetailBookByIsbn(isbn);
+        // 1. Naver API - 실패 시 예외 전파 (방 생성 실패)
+        NaverDetailBookParseResult detailBook = findDetailBookByIsbn(isbn);
 
-        // 2. 알라딘으로부터 책 page 정보 load
+        // 2. Aladin API - 실패 시 null 반환 (Discord 알림은 findPageCountByIsbn 내부에서 처리)
         Integer pageCount = findPageCountByIsbn(isbn);
 
-        // 3. pageCount 정보를 포함한 Book 반환
+        // 3. pageCount가 null이어도 Book 반환 (방 생성 계속 진행)
         return Book.withoutId(
-                detailBookByKeyword.title(),
+                detailBook.title(),
                 isbn,
-                detailBookByKeyword.author(),
+                detailBook.author(),
                 false,      // TODO : 추후 BestSeller 도입되면 고려해야함
-                detailBookByKeyword.publisher(),
-                detailBookByKeyword.imageUrl(),
+                detailBook.publisher(),
+                detailBook.imageUrl(),
                 pageCount,
-                detailBookByKeyword.description()
+                detailBook.description()
         );
     }
 }

--- a/src/main/java/konkuk/thip/book/adapter/out/api/naver/NaverApiUtil.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/api/naver/NaverApiUtil.java
@@ -30,6 +30,8 @@ public class NaverApiUtil {
     private String bookDetailSearchUrl;
 
     public static final int PAGE_SIZE = 10;
+    private static final int CONNECT_TIMEOUT_MS = 3_000;
+    private static final int READ_TIMEOUT_MS = 5_000;
 
     public String searchBook(String keyword, int start) {
         return callNaverApi(keyword, start, false);
@@ -50,13 +52,12 @@ public class NaverApiUtil {
         return get(url, requestHeaders);
     }
 
-
-    private String buildSearchApiUrl(String query,Integer start) {
-        return bookSearchUrl+query+"&display="+PAGE_SIZE+"&start="+start;
+    private String buildSearchApiUrl(String query, Integer start) {
+        return bookSearchUrl + query + "&display=" + PAGE_SIZE + "&start=" + start;
     }
 
     private String buildDetailSearchApiUrl(String query) {
-        return bookDetailSearchUrl+query;
+        return bookDetailSearchUrl + query;
     }
 
     private String keywordToEncoding(String keyword) {
@@ -69,12 +70,13 @@ public class NaverApiUtil {
         return text;
     }
 
-
-    String get(String apiUrl, Map<String, String> requestHeaders){
+    String get(String apiUrl, Map<String, String> requestHeaders) {
         HttpURLConnection con = connect(apiUrl);
         try {
+            con.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            con.setReadTimeout(READ_TIMEOUT_MS);
             con.setRequestMethod("GET");
-            for(Map.Entry<String, String> header :requestHeaders.entrySet()) {
+            for (Map.Entry<String, String> header : requestHeaders.entrySet()) {
                 con.setRequestProperty(header.getKey(), header.getValue());
             }
 
@@ -91,11 +93,10 @@ public class NaverApiUtil {
         }
     }
 
-
-    private HttpURLConnection connect(String apiUrl){
+    private HttpURLConnection connect(String apiUrl) {
         try {
             URL url = new URL(apiUrl);
-            return (HttpURLConnection)url.openConnection();
+            return (HttpURLConnection) url.openConnection();
         } catch (MalformedURLException e) {
             throw new InternalServerException(BOOK_NAVER_API_URL_ERROR);
         } catch (IOException e) {
@@ -103,8 +104,7 @@ public class NaverApiUtil {
         }
     }
 
-
-    private String readBody(InputStream body){
+    private String readBody(InputStream body) {
         InputStreamReader streamReader = new InputStreamReader(body);
 
         try (BufferedReader lineReader = new BufferedReader(streamReader)) {
@@ -120,5 +120,4 @@ public class NaverApiUtil {
             throw new ExternalApiException(BOOK_NAVER_API_RESPONSE_ERROR);
         }
     }
-
 }

--- a/src/main/java/konkuk/thip/book/adapter/out/jpa/BookJpaEntity.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/jpa/BookJpaEntity.java
@@ -39,7 +39,14 @@ public class BookJpaEntity extends BaseJpaEntity {
     @Column(length = 3000)
     private String description;
 
+    @Column(name = "page_count_unfindable", nullable = false)
+    private boolean pageCountUnfindable;
+
     public void changePageCount(Integer pageCount) {
         this.pageCount = pageCount;
+    }
+
+    public void markAsUnfindable() {
+        this.pageCountUnfindable = true;
     }
 }

--- a/src/main/java/konkuk/thip/book/adapter/out/mapper/BookMapper.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/mapper/BookMapper.java
@@ -17,6 +17,7 @@ public class BookMapper {
                 .imageUrl(book.getImageUrl())
                 .pageCount(book.getPageCount())
                 .description(book.getDescription())
+                .pageCountUnfindable(book.isPageCountUnfindable())
                 .build();
     }
 
@@ -31,6 +32,7 @@ public class BookMapper {
                 .imageUrl(bookJpaEntity.getImageUrl())
                 .pageCount(bookJpaEntity.getPageCount())
                 .description(bookJpaEntity.getDescription())
+                .pageCountUnfindable(bookJpaEntity.isPageCountUnfindable())
                 .createdAt(bookJpaEntity.getCreatedAt())
                 .modifiedAt(bookJpaEntity.getModifiedAt())
                 .status(bookJpaEntity.getStatus())

--- a/src/main/java/konkuk/thip/book/adapter/out/persistence/BookCommandPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/persistence/BookCommandPersistenceAdapter.java
@@ -97,4 +97,13 @@ public class BookCommandPersistenceAdapter implements BookCommandPort {
     public void deleteAllSavedBookByUserId(Long userId) {
         savedBookJpaRepository.deleteAllByUserId(userId);
     }
+
+    @Override
+    public void updateForUnfindable(Book book) {
+        BookJpaEntity bookJpaEntity = bookJpaRepository.findById(book.getId()).orElseThrow(
+                () -> new EntityNotFoundException(BOOK_NOT_FOUND)
+        );
+        bookJpaEntity.markAsUnfindable();
+        bookJpaRepository.save(bookJpaEntity);
+    }
 }

--- a/src/main/java/konkuk/thip/book/adapter/out/persistence/BookQueryPersistenceAdapter.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/persistence/BookQueryPersistenceAdapter.java
@@ -5,6 +5,7 @@ import konkuk.thip.book.adapter.out.persistence.repository.BookJpaRepository;
 import konkuk.thip.book.adapter.out.persistence.repository.SavedBookJpaRepository;
 import konkuk.thip.book.application.port.out.BookQueryPort;
 import konkuk.thip.book.application.port.out.dto.BookQueryDto;
+import konkuk.thip.book.domain.Book;
 import konkuk.thip.common.util.Cursor;
 import konkuk.thip.common.util.CursorBasedList;
 import konkuk.thip.user.adapter.out.persistence.repository.UserJpaRepository;
@@ -67,5 +68,14 @@ public class BookQueryPersistenceAdapter implements BookQueryPort {
     @Override
     public Set<Long> findUnusedBookIds() {
         return bookJpaRepository.findUnusedBookIds();
+    }
+
+    @Override
+    public List<Book> findBooksWithNullPageCountLinkedToRooms() {
+        return bookJpaRepository
+                .findBooksWithNullPageCountLinkedToRooms()
+                .stream()
+                .map(bookMapper::toDomainEntity)
+                .toList();
     }
 }

--- a/src/main/java/konkuk/thip/book/adapter/out/persistence/repository/BookJpaRepository.java
+++ b/src/main/java/konkuk/thip/book/adapter/out/persistence/repository/BookJpaRepository.java
@@ -4,6 +4,7 @@ import konkuk.thip.book.adapter.out.jpa.BookJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -30,4 +31,12 @@ public interface BookJpaRepository extends JpaRepository<BookJpaEntity, Long>, B
             ")"
     )
     Set<Long> findUnusedBookIds();
+
+    @Query(
+            "SELECT b FROM BookJpaEntity b " +
+            "WHERE b.pageCount IS NULL AND b.pageCountUnfindable = false " +
+            "AND EXISTS (SELECT r FROM RoomJpaEntity r WHERE r.bookJpaEntity = b) " +
+            "ORDER BY b.bookId ASC"
+    )
+    List<BookJpaEntity> findBooksWithNullPageCountLinkedToRooms();
 }

--- a/src/main/java/konkuk/thip/book/application/port/in/BookPageCountFillUseCase.java
+++ b/src/main/java/konkuk/thip/book/application/port/in/BookPageCountFillUseCase.java
@@ -1,0 +1,6 @@
+package konkuk.thip.book.application.port.in;
+
+public interface BookPageCountFillUseCase {
+
+    void fillNullPageCounts();
+}

--- a/src/main/java/konkuk/thip/book/application/port/out/BookCommandPort.java
+++ b/src/main/java/konkuk/thip/book/application/port/out/BookCommandPort.java
@@ -31,4 +31,7 @@ public interface BookCommandPort {
     void deleteAllByIdInBatch(Set<Long> unusedBookIds);
 
     void deleteAllSavedBookByUserId(Long userId);
+
+    // 알라딘 미등록 book 영구 제외 처리 (스케줄러용)
+    void updateForUnfindable(Book book);
 }

--- a/src/main/java/konkuk/thip/book/application/port/out/BookQueryPort.java
+++ b/src/main/java/konkuk/thip/book/application/port/out/BookQueryPort.java
@@ -1,9 +1,11 @@
 package konkuk.thip.book.application.port.out;
 
 import konkuk.thip.book.application.port.out.dto.BookQueryDto;
+import konkuk.thip.book.domain.Book;
 import konkuk.thip.common.util.Cursor;
 import konkuk.thip.common.util.CursorBasedList;
 
+import java.util.List;
 import java.util.Set;
 
 public interface BookQueryPort {
@@ -17,4 +19,7 @@ public interface BookQueryPort {
     CursorBasedList<BookQueryDto> findJoiningRoomsBooksByRoomPercentage(Long userId, Cursor cursor);
 
     Set<Long> findUnusedBookIds();
+
+    // room과 연관된 book 중 pageCount가 null이고 아직 포기하지 않은 book 전체 조회 (스케줄러용)
+    List<Book> findBooksWithNullPageCountLinkedToRooms();
 }

--- a/src/main/java/konkuk/thip/book/application/service/BookPageCountFillService.java
+++ b/src/main/java/konkuk/thip/book/application/service/BookPageCountFillService.java
@@ -47,6 +47,10 @@ public class BookPageCountFillService implements BookPageCountFillUseCase {
         int transientFailCount = 0;
 
         for (Book book : books) {
+            // TODO: 알라딘 API 연속 실패 시 Circuit Breaker 패턴 적용 필요
+            // 현재: API 장애 상태에서도 전체 건수에 대해 호출 시도 → 타임아웃 × 건수만큼 스케줄러 점유
+            // 개선: 연속 실패 N회 초과 시 조기 종료 + Discord 알림
+
             try {
                 Integer pageCount = aladinApiClient.findPageCountByIsbn(book.getIsbn());
                 book.changePageCount(pageCount);

--- a/src/main/java/konkuk/thip/book/application/service/BookPageCountFillService.java
+++ b/src/main/java/konkuk/thip/book/application/service/BookPageCountFillService.java
@@ -1,0 +1,89 @@
+package konkuk.thip.book.application.service;
+
+import konkuk.thip.book.adapter.out.api.aladin.AladinApiClient;
+import konkuk.thip.book.application.port.in.BookPageCountFillUseCase;
+import konkuk.thip.book.application.port.out.BookCommandPort;
+import konkuk.thip.book.application.port.out.BookQueryPort;
+import konkuk.thip.book.domain.Book;
+import konkuk.thip.common.discord.DiscordClient;
+import konkuk.thip.common.exception.ExternalApiException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static konkuk.thip.common.exception.code.ErrorCode.BOOK_ALADIN_API_ISBN_NOT_FOUND;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BookPageCountFillService implements BookPageCountFillUseCase {
+
+    @Value("${scheduler.throttle-ms:500}") // 초당 2건 → 알라딘 API 과부하 방지
+    private long throttleMs;
+
+    private final BookQueryPort bookQueryPort;
+    private final BookCommandPort bookCommandPort;
+    private final AladinApiClient aladinApiClient;
+    private final DiscordClient discordClient;
+
+    // @Transactional 미적용 - 의도적 설계
+    // 각 book의 pageCount 업데이트는 독립적인 작업이므로, 일부 실패 시 나머지 성공 건은 유지되어야 함
+    // 전체를 하나의 트랜잭션으로 묶으면 하나의 실패가 전체 롤백을 유발하고,
+    // 수백~수천 건 처리 중 DB 커넥션을 장시간 점유하게 되어 비효율적
+    @Override
+    public void fillNullPageCounts() {
+        List<Book> books = bookQueryPort.findBooksWithNullPageCountLinkedToRooms();
+
+        if (books.isEmpty()) {
+            log.info("[스케줄러] pageCount 업데이트 대상 없음");
+            return;
+        }
+
+        int successCount = 0;
+        int unfindableCount = 0;
+        int transientFailCount = 0;
+
+        for (Book book : books) {
+            try {
+                Integer pageCount = aladinApiClient.findPageCountByIsbn(book.getIsbn());
+                book.changePageCount(pageCount);
+                bookCommandPort.updateForPageCount(book);
+                successCount++;
+                log.info("[스케줄러] pageCount 업데이트 완료 - isbn: {}, pageCount: {}", book.getIsbn(), pageCount);
+            } catch (ExternalApiException e) {
+                if (e.getErrorCode() == BOOK_ALADIN_API_ISBN_NOT_FOUND) {
+                    // 영구 실패: 알라딘에 미등록된 책 → 재시도 불필요
+                    book.markAsUnfindable();
+                    bookCommandPort.updateForUnfindable(book);
+                    unfindableCount++;
+                    log.info("[스케줄러] 알라딘 미등록 book 처리 완료 - isbn: {}", book.getIsbn());
+                } else {
+                    // 파싱 오류 등 그 외 ExternalApiException → 일시 장애로 간주, 다음 실행에서 재시도
+                    transientFailCount++;
+                    log.warn("[스케줄러] 알라딘 API 오류 (재시도 예정) - isbn: {}, error: {}", book.getIsbn(), e.getMessage());
+                }
+            } catch (Exception e) {
+                // 타임아웃(ResourceAccessException) 등 일시 장애 → 다음 실행에서 재시도
+                transientFailCount++;
+                log.warn("[스케줄러] 일시 장애 (재시도 예정) - isbn: {}, error: {}", book.getIsbn(), e.getMessage());
+            }
+
+            throttle();
+        }
+
+        log.info("[스케줄러] 실행 완료 - 대상: {}건 / 성공: {}건 / 미등록: {}건 / 일시실패: {}건",
+                books.size(), successCount, unfindableCount, transientFailCount);
+        discordClient.sendPageCountFillResult(books.size(), successCount, unfindableCount, transientFailCount);
+    }
+
+    private void throttle() {
+        try {
+            Thread.sleep(throttleMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/main/java/konkuk/thip/book/domain/Book.java
+++ b/src/main/java/konkuk/thip/book/domain/Book.java
@@ -28,6 +28,8 @@ public class Book extends BaseDomainEntity {
 
     private String description;
 
+    private boolean pageCountUnfindable;
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -61,5 +63,9 @@ public class Book extends BaseDomainEntity {
 
     public void changePageCount(Integer newPageCount) {
         this.pageCount = newPageCount;
+    }
+
+    public void markAsUnfindable() {
+        this.pageCountUnfindable = true;
     }
 }

--- a/src/main/java/konkuk/thip/common/discord/DiscordClient.java
+++ b/src/main/java/konkuk/thip/common/discord/DiscordClient.java
@@ -1,5 +1,7 @@
 package konkuk.thip.common.discord;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -11,8 +13,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @Component
+@RequiredArgsConstructor
 public class DiscordClient {
+
+    private final WebClient webClient;
 
     @Value("${discord.env}")
     private String env;
@@ -21,9 +27,7 @@ public class DiscordClient {
     private String webhookUrl;
 
     public void sendErrorMessage(String message, String stackTrace, String requestId, String userId) {
-        if("test".equals(env)) return;
-
-        WebClient webClient = WebClient.create();
+        if ("test".equals(env)) return;
 
         Map<String, Object> embedData = new HashMap<>();
         embedData.put("title", "THIP 서버 500 에러 발생");
@@ -53,12 +57,89 @@ public class DiscordClient {
         Map<String, Object> payload = new HashMap<>();
         payload.put("embeds", new Object[]{embedData});
 
+        sendSync(payload, "서버 500 에러");
+    }
+
+    public void sendAladinApiFailureAlert(String isbn, Exception e) {
+        if ("test".equals(env)) return;
+
+        Map<String, Object> embedData = new HashMap<>();
+        embedData.put("title", "알라딘 API 페이지 정보 획득 실패");
+
+        Map<String, String> field1 = new HashMap<>();
+        field1.put("name", "발생시각");
+        field1.put("value", LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+
+        Map<String, String> field2 = new HashMap<>();
+        field2.put("name", "ISBN");
+        field2.put("value", isbn);
+
+        Map<String, String> field3 = new HashMap<>();
+        field3.put("name", "에러 메시지");
+        field3.put("value", e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+
+        embedData.put("fields", List.of(field1, field2, field3));
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("embeds", new Object[]{embedData});
+
+        sendAsync(payload, "알라딘 API 실패 알림 (isbn: " + isbn + ")");
+    }
+
+    public void sendPageCountFillResult(int total, int successCount, int unfindableCount, int transientFailCount) {
+        if ("test".equals(env)) return;
+
+        Map<String, Object> embedData = new HashMap<>();
+        embedData.put("title", "[스케줄러] pageCount 업데이트 실행 완료");
+
+        Map<String, String> field1 = new HashMap<>();
+        field1.put("name", "처리 대상");
+        field1.put("value", total + "건");
+
+        Map<String, String> field2 = new HashMap<>();
+        field2.put("name", "pageCount 업데이트 성공");
+        field2.put("value", successCount + "건");
+
+        Map<String, String> field3 = new HashMap<>();
+        field3.put("name", "알라딘 미등록 (unfindable 처리)");
+        field3.put("value", unfindableCount + "건");
+
+        Map<String, String> field4 = new HashMap<>();
+        field4.put("name", "일시 실패 (다음 실행 재시도)");
+        field4.put("value", transientFailCount + "건");
+
+        embedData.put("fields", List.of(field1, field2, field3, field4));
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("embeds", new Object[]{embedData});
+
+        sendSync(payload, "pageCount 스케줄러 결과");
+    }
+
+    private void sendSync(Map<String, Object> payload, String alertDescription) {
+        try {
+            webClient.post()
+                    .uri(webhookUrl)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(payload)
+                    .retrieve()
+                    .bodyToMono(Void.class)
+                    .block();
+        } catch (Exception ex) {
+            log.warn("[Discord] 알림 전송 실패 - {}: {}", alertDescription, ex.getMessage());
+        }
+    }
+
+    private void sendAsync(Map<String, Object> payload, String alertDescription) {
         webClient.post()
                 .uri(webhookUrl)
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(payload)
                 .retrieve()
                 .bodyToMono(Void.class)
-                .block();
+                .subscribe(
+                        null,
+                        ex -> log.warn("[Discord] 알림 전송 실패 - {}: {}", alertDescription, ex.getMessage())
+                );
     }
 }

--- a/src/main/java/konkuk/thip/common/exception/ExternalApiException.java
+++ b/src/main/java/konkuk/thip/common/exception/ExternalApiException.java
@@ -1,7 +1,9 @@
 package konkuk.thip.common.exception;
 
 import konkuk.thip.common.exception.code.ErrorCode;
+import lombok.Getter;
 
+@Getter
 public class ExternalApiException extends RuntimeException {
 
     private final ErrorCode errorCode;

--- a/src/main/java/konkuk/thip/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/konkuk/thip/common/exception/handler/GlobalExceptionHandler.java
@@ -132,11 +132,7 @@ public class GlobalExceptionHandler {
         String userId = MDC.get(USER_ID.getValue());
 
         // Discord 웹훅 전송
-        try {
-            discordClient.sendErrorMessage(combinedMessage, stackSummary, requestId, userId);
-        } catch (Exception sendException) {
-            log.error("[ServerErrorHandler] -> [Discord] 전송 실패", sendException);
-        }
+        discordClient.sendErrorMessage(combinedMessage, stackSummary, requestId, userId);
 
         return ResponseEntity
                 .status(API_SERVER_ERROR.getHttpStatus())

--- a/src/main/java/konkuk/thip/common/scheduler/BookPageCountFillScheduler.java
+++ b/src/main/java/konkuk/thip/common/scheduler/BookPageCountFillScheduler.java
@@ -1,0 +1,23 @@
+package konkuk.thip.common.scheduler;
+
+import konkuk.thip.book.application.port.in.BookPageCountFillUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BookPageCountFillScheduler {
+
+    private final BookPageCountFillUseCase bookPageCountFillUseCase;
+
+    // 매일 새벽 3시 실행 (BookDeleteScheduler(4시)보다 먼저 수행)
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
+    public void fillNullPageCounts() {
+        log.info("[스케줄러] pageCount 업데이트 시작");
+        bookPageCountFillUseCase.fillNullPageCounts();
+        log.info("[스케줄러] pageCount 업데이트 종료");
+    }
+}

--- a/src/main/java/konkuk/thip/config/AppConfig.java
+++ b/src/main/java/konkuk/thip/config/AppConfig.java
@@ -1,4 +1,15 @@
 package konkuk.thip.config;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Configuration
 public class AppConfig {
+
+    @Bean
+    public TransactionTemplate transactionTemplate(PlatformTransactionManager transactionManager) {
+        return new TransactionTemplate(transactionManager);
+    }
 }

--- a/src/main/java/konkuk/thip/config/RestTemplateConfig.java
+++ b/src/main/java/konkuk/thip/config/RestTemplateConfig.java
@@ -2,13 +2,20 @@ package konkuk.thip.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class RestTemplateConfig {
 
+    private static final int CONNECT_TIMEOUT_MS = 3_000;
+    private static final int READ_TIMEOUT_MS = 5_000;
+
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        factory.setReadTimeout(READ_TIMEOUT_MS);
+        return new RestTemplate(factory);
     }
 }

--- a/src/main/java/konkuk/thip/config/WebClientConfig.java
+++ b/src/main/java/konkuk/thip/config/WebClientConfig.java
@@ -1,0 +1,24 @@
+package konkuk.thip.config;
+
+import io.netty.channel.ChannelOption;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 3_000)
+                .responseTimeout(Duration.ofSeconds(5));
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+}

--- a/src/main/java/konkuk/thip/room/application/service/RoomCreateService.java
+++ b/src/main/java/konkuk/thip/room/application/service/RoomCreateService.java
@@ -11,8 +11,9 @@ import konkuk.thip.room.domain.value.Category;
 import konkuk.thip.room.domain.Room;
 import konkuk.thip.room.domain.RoomParticipant;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 @RequiredArgsConstructor
@@ -22,35 +23,36 @@ public class RoomCreateService implements RoomCreateUseCase {
     private final RoomParticipantCommandPort roomParticipantCommandPort;
     private final BookCommandPort bookCommandPort;
     private final BookApiQueryPort bookApiQueryPort;
+    private final TransactionTemplate transactionTemplate;
 
     @Override
-    @Transactional
     public Long createRoom(RoomCreateCommand command, Long userId) {
         // 1. Category 생성
         Category category = Category.from(command.category());
 
-        // 2. Book 찾기, 없으면 Book 로드 및 저장
+        // 2. Book 찾기, 없으면 외부 API로 로드 및 저장 (트랜잭션 밖에서 수행)
         Long bookId = resolveBookAndEnsurePage(command.isbn());
 
-        // 3. Room 생성 및 저장
-        Room room = Room.withoutId(
-                command.roomName(),
-                command.description(),
-                command.isPublic(),
-                command.password(),
-                command.progressStartDate(),
-                command.progressEndDate(),
-                command.recruitCount(),
-                bookId,
-                category
-        );
-        Long savedRoomId = roomCommandPort.save(room);
+        // 3. Room + RoomParticipant 저장 (단일 트랜잭션으로 원자성 보장)
+        return transactionTemplate.execute(status -> {
+            Room room = Room.withoutId(
+                    command.roomName(),
+                    command.description(),
+                    command.isPublic(),
+                    command.password(),
+                    command.progressStartDate(),
+                    command.progressEndDate(),
+                    command.recruitCount(),
+                    bookId,
+                    category
+            );
+            Long savedRoomId = roomCommandPort.save(room);
 
-        // 4. 방장 RoomParticipant 생성 및 DB save
-        RoomParticipant roomParticipant = RoomParticipant.hostWithoutId(userId, savedRoomId);
-        roomParticipantCommandPort.save(roomParticipant);
+            RoomParticipant roomParticipant = RoomParticipant.hostWithoutId(userId, savedRoomId);
+            roomParticipantCommandPort.save(roomParticipant);
 
-        return savedRoomId;
+            return savedRoomId;
+        });
     }
 
     private Long resolveBookAndEnsurePage(String isbn) {
@@ -65,13 +67,23 @@ public class RoomCreateService implements RoomCreateUseCase {
     }
 
     private void updateBookPageCount(Book book) {
+        // 알라딘 API 실패 시 null 반환 (Discord 알림은 어댑터에서 처리)
         Integer pageCount = bookApiQueryPort.findPageCountByIsbn(book.getIsbn());
+        if (pageCount == null) return;
+
         book.changePageCount(pageCount);
         bookCommandPort.updateForPageCount(book);
     }
 
     private Long saveNewBookWithPageCount(String isbn) {
         Book loaded = bookApiQueryPort.loadBookWithPageByIsbn(isbn);
-        return bookCommandPort.save(loaded);
+        try {
+            return bookCommandPort.save(loaded);
+        } catch (DataIntegrityViolationException e) {
+            // 동일 ISBN 동시 요청으로 이미 저장된 경우 → 기존 Book ID 반환
+            return bookCommandPort.findByIsbn(isbn)
+                    .map(Book::getId)
+                    .orElseThrow(() -> e);
+        }
     }
 }

--- a/src/main/resources/db/migration/V260302__Add_page_count_unfindable_and_scheduler_index_to_book.sql
+++ b/src/main/resources/db/migration/V260302__Add_page_count_unfindable_and_scheduler_index_to_book.sql
@@ -1,0 +1,10 @@
+-- pageCount를 알라딘 API로 조회했으나 영구적으로 찾을 수 없는 책을 표시하는 플래그
+-- true : 알라딘 미등록 → 스케줄러 조회 대상에서 영구 제외
+-- false(기본값) : 아직 포기하지 않음 → 스케줄러가 pageCount 채우기 시도
+ALTER TABLE books
+    ADD COLUMN page_count_unfindable TINYINT(1) NOT NULL DEFAULT 0;
+
+-- 스케줄러 쿼리 최적화 인덱스
+-- 대상 조건: page_count IS NULL AND page_count_unfindable = false
+-- page_count를 선두 컬럼으로 설정 → 스테디 스테이트에서 IS NULL 선택도가 높아 효과적
+CREATE INDEX idx_books_scheduler ON books (page_count, page_count_unfindable);

--- a/src/test/java/konkuk/thip/book/adapter/out/api/AladinApiDiscordAlertIntegrationTest.java
+++ b/src/test/java/konkuk/thip/book/adapter/out/api/AladinApiDiscordAlertIntegrationTest.java
@@ -1,0 +1,60 @@
+package konkuk.thip.book.adapter.out.api;
+
+import konkuk.thip.book.adapter.out.api.aladin.AladinApiClient;
+import konkuk.thip.book.adapter.out.api.naver.NaverApiClient;
+import konkuk.thip.config.WebClientConfig;
+import konkuk.thip.common.discord.DiscordClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.client.ResourceAccessException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * [수동 검증용] 알라딘 API 타임아웃 시 실제 Discord 웹훅으로 알림이 전송되는지 검증하는 통합 테스트.
+ *
+ * - 알라딘/네이버 API: @MockitoBean으로 타임아웃 상황 재현 (실제 서버 연결 불필요)
+ * - DiscordClient: application-test.yml의 webhook-url을 자동 주입받아 실제 Discord로 전송
+ * - discord.env를 @TestPropertySource로 "local" 오버라이드
+ *   → DiscordClient 내부의 조기 반환(if "test".equals(env) return)을 우회하여 실제 전송 활성화
+ *
+ * 테스트 실행 후 Discord 채널에서 "알라딘 API 페이지 정보 획득 실패" 알림 수신 여부를 직접 확인한다.
+ */
+@SpringBootTest(classes = {WebClientConfig.class, DiscordClient.class, CompositeBookApiAdapter.class})
+@ActiveProfiles("test")
+//@TestPropertySource(properties = "discord.env=local")
+@DisplayName("[수동 검증] 알라딘 API 타임아웃 → 실제 Discord 알림 전송 통합 테스트")
+class AladinApiDiscordAlertIntegrationTest {
+
+    private static final String ISBN = "9791168342941";
+
+    @MockitoBean AladinApiClient aladinApiClient;
+    @MockitoBean NaverApiClient naverApiClient;
+
+    @Autowired CompositeBookApiAdapter adapter;
+
+    @Test
+    @DisplayName("알라딘 API 타임아웃 시 실제 Discord 웹훅으로 알림이 전송되고 null이 반환된다")
+    void findPageCountByIsbn_timeout_sendsRealDiscordAlert() throws InterruptedException {
+        // given: RestTemplate read timeout → ResourceAccessException (SocketTimeoutException 래핑)
+        given(aladinApiClient.findPageCountByIsbn(anyString()))
+                .willThrow(new ResourceAccessException("Read timed out"));
+
+        // when
+        Integer result = adapter.findPageCountByIsbn(ISBN);
+
+        // then: null 반환 → 방 생성은 계속 진행됨
+        assertThat(result).isNull();
+
+        // sendAladinApiFailureAlert()는 subscribe() 기반 비동기(fire-and-forget)로 동작하므로
+        // 테스트 종료 전 HTTP 요청이 완료될 수 있도록 대기 후 Discord 채널에서 직접 확인
+        Thread.sleep(2_000);
+    }
+}

--- a/src/test/java/konkuk/thip/book/adapter/out/api/CompositeBookApiAdapterTest.java
+++ b/src/test/java/konkuk/thip/book/adapter/out/api/CompositeBookApiAdapterTest.java
@@ -1,0 +1,129 @@
+package konkuk.thip.book.adapter.out.api;
+
+import konkuk.thip.book.adapter.out.api.aladin.AladinApiClient;
+import konkuk.thip.book.adapter.out.api.naver.NaverApiClient;
+import konkuk.thip.common.discord.DiscordClient;
+import konkuk.thip.common.exception.ExternalApiException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.ResourceAccessException;
+
+import static konkuk.thip.common.exception.code.ErrorCode.BOOK_ALADIN_API_ISBN_NOT_FOUND;
+import static konkuk.thip.common.exception.code.ErrorCode.BOOK_NAVER_API_REQUEST_ERROR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("[단위] CompositeBookApiAdapter - 외부 API 실패 처리 검증")
+class CompositeBookApiAdapterTest {
+
+    private static final String ISBN = "9791168342941";
+
+    private NaverApiClient naverApiClient;
+    private AladinApiClient aladinApiClient;
+    private DiscordClient discordClient;
+    private CompositeBookApiAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        naverApiClient = mock(NaverApiClient.class);
+        aladinApiClient = mock(AladinApiClient.class);
+        discordClient = mock(DiscordClient.class);
+        adapter = new CompositeBookApiAdapter(naverApiClient, aladinApiClient, discordClient);
+    }
+
+    @Nested
+    @DisplayName("알라딘 API 성공")
+    class Success {
+
+        @Test
+        @DisplayName("pageCount가 반환되고 Discord 알림이 전송되지 않는다")
+        void findPageCountByIsbn_aladinSuccess_noDiscordAlert() {
+            // given
+            given(aladinApiClient.findPageCountByIsbn(ISBN)).willReturn(296);
+
+            // when
+            Integer pageCount = adapter.findPageCountByIsbn(ISBN);
+
+            // then
+            assertThat(pageCount).isEqualTo(296);
+            then(discordClient).should(never()).sendAladinApiFailureAlert(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("알라딘 API 실패")
+    class Failure {
+
+        @Test
+        @DisplayName("비즈니스 예외(ISBN 미존재) 발생 시 Discord 알림이 전송되고 null이 반환된다")
+        void findPageCountByIsbn_businessException_sendsDiscordAlertAndReturnsNull() {
+            // given
+            ExternalApiException cause = new ExternalApiException(BOOK_ALADIN_API_ISBN_NOT_FOUND);
+            given(aladinApiClient.findPageCountByIsbn(ISBN)).willThrow(cause);
+
+            // when
+            Integer pageCount = adapter.findPageCountByIsbn(ISBN);
+
+            // then: 방 생성은 계속 진행 (null 반환)
+            assertThat(pageCount).isNull();
+            // Discord 알림은 정확한 isbn과 예외 객체로 호출되어야 한다
+            then(discordClient).should().sendAladinApiFailureAlert(eq(ISBN), eq(cause));
+        }
+
+        @Test
+        @DisplayName("읽기 타임아웃(ResourceAccessException) 발생 시 Discord 알림이 전송되고 null이 반환된다")
+        void findPageCountByIsbn_readTimeout_sendsDiscordAlertAndReturnsNull() {
+            // given: RestTemplate read timeout → ResourceAccessException
+            ResourceAccessException timeoutEx = new ResourceAccessException("Read timed out");
+            given(aladinApiClient.findPageCountByIsbn(ISBN)).willThrow(timeoutEx);
+
+            // when
+            Integer pageCount = adapter.findPageCountByIsbn(ISBN);
+
+            // then: 알라딘 타임아웃도 Discord 알림 후 null 반환 → 방 생성 계속 진행
+            assertThat(pageCount).isNull();
+            then(discordClient).should().sendAladinApiFailureAlert(eq(ISBN), eq(timeoutEx));
+        }
+
+        @Test
+        @DisplayName("예상치 못한 런타임 예외 발생 시에도 Discord 알림이 전송되고 null이 반환된다")
+        void findPageCountByIsbn_unexpectedException_sendsDiscordAlertAndReturnsNull() {
+            // given
+            RuntimeException cause = new RuntimeException("Unexpected error");
+            given(aladinApiClient.findPageCountByIsbn(ISBN)).willThrow(cause);
+
+            // when
+            Integer pageCount = adapter.findPageCountByIsbn(ISBN);
+
+            // then
+            assertThat(pageCount).isNull();
+            then(discordClient).should().sendAladinApiFailureAlert(eq(ISBN), eq(cause));
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────────
+    // 네이버 API 실패: 알라딘과 달리 예외가 그대로 전파됨 (방 생성 실패)
+    // ────────────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("네이버 API 실패")
+    class NaverFailure {
+
+        @Test
+        @DisplayName("네이버 API 예외 발생 시 예외가 그대로 전파되고 Discord 알림은 전송되지 않는다")
+        void loadBookWithPageByIsbn_naverFails_exceptionPropagates_noDiscordAlert() {
+            // given: 네이버 타임아웃/에러 발생 (HttpURLConnection IOException → ExternalApiException)
+            ExternalApiException naverEx = new ExternalApiException(BOOK_NAVER_API_REQUEST_ERROR);
+            given(naverApiClient.findDetailBookByIsbn(ISBN)).willThrow(naverEx);
+
+            // when & then: 알라딘과 달리 catch 없이 예외 전파 → 방 생성 실패
+            assertThatThrownBy(() -> adapter.loadBookWithPageByIsbn(ISBN))
+                    .isInstanceOf(ExternalApiException.class);
+
+            // 네이버 실패는 Discord 알림 대상이 아님 (알라딘 실패만 알림)
+            then(discordClient).should(never()).sendAladinApiFailureAlert(any(), any());
+        }
+    }
+}

--- a/src/test/java/konkuk/thip/book/adapter/out/api/naver/NaverApiUtilTest.java
+++ b/src/test/java/konkuk/thip/book/adapter/out/api/naver/NaverApiUtilTest.java
@@ -1,11 +1,13 @@
 package konkuk.thip.book.adapter.out.api.naver;
 
 import konkuk.thip.common.exception.BusinessException;
+import konkuk.thip.common.exception.ExternalApiException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
+import java.net.ServerSocket;
 
 import static konkuk.thip.common.exception.code.ErrorCode.BOOK_NAVER_API_REQUEST_ERROR;
 import static org.assertj.core.api.Assertions.*;
@@ -67,5 +69,36 @@ class NaverApiUtilTest {
         assertThatThrownBy(() -> naverApiUtil.searchBook("테스트", 1))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(BOOK_NAVER_API_REQUEST_ERROR.getMessage());
+    }
+
+    @Test
+    @DisplayName("네트워크 IOException 발생 시 ExternalApiException으로 변환된다 - 타임아웃 설정 동작 확인")
+    void get_ioException_throwsExternalApiException() throws Exception {
+        // given: 연결 수락 후 즉시 닫는 서버
+        // SocketTimeoutException(타임아웃)과 SocketException(연결 끊김) 모두 IOException을 상속하므로
+        // get() 내부의 catch (IOException e) → ExternalApiException 변환 경로가 동일함
+        try (ServerSocket server = new ServerSocket(0)) {
+            new Thread(() -> {
+                try { server.accept().close(); } catch (Exception ignored) {}
+            }).start();
+
+            // spy 없이 실제 get()을 실행하여 내부 catch 블록까지 동작 검증
+            NaverApiUtil util = new NaverApiUtil();
+            Field urlField = NaverApiUtil.class.getDeclaredField("bookSearchUrl");
+            urlField.setAccessible(true);
+            urlField.set(util, "http://localhost:" + server.getLocalPort() + "/?query=");
+
+            Field clientIdField = NaverApiUtil.class.getDeclaredField("clientId");
+            clientIdField.setAccessible(true);
+            clientIdField.set(util, "dummy");
+
+            Field clientSecretField = NaverApiUtil.class.getDeclaredField("clientSecret");
+            clientSecretField.setAccessible(true);
+            clientSecretField.set(util, "dummy");
+
+            // when & then: IOException → catch → ExternalApiException(BOOK_NAVER_API_REQUEST_ERROR)
+            assertThatThrownBy(() -> util.searchBook("테스트", 1))
+                    .isInstanceOf(ExternalApiException.class);
+        }
     }
 }

--- a/src/test/java/konkuk/thip/book/application/service/BookPageCountFillServiceTest.java
+++ b/src/test/java/konkuk/thip/book/application/service/BookPageCountFillServiceTest.java
@@ -1,0 +1,163 @@
+package konkuk.thip.book.application.service;
+
+import konkuk.thip.book.adapter.out.api.aladin.AladinApiClient;
+import konkuk.thip.book.application.port.out.BookCommandPort;
+import konkuk.thip.book.application.port.out.BookQueryPort;
+import konkuk.thip.book.domain.Book;
+import konkuk.thip.common.discord.DiscordClient;
+import konkuk.thip.common.exception.ExternalApiException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.ResourceAccessException;
+
+import java.util.List;
+
+import static konkuk.thip.common.exception.code.ErrorCode.BOOK_ALADIN_API_ISBN_NOT_FOUND;
+import static konkuk.thip.common.exception.code.ErrorCode.BOOK_ALADIN_API_PARSING_ERROR;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class BookPageCountFillServiceTest {
+
+    // throttleMs는 @Value로 주입되며, Mockito 환경에서는 Spring이 주입하지 않으므로
+    // long 기본값 0L이 적용됨 → Thread.sleep(0) → 테스트 지연 없음
+
+    @Mock BookQueryPort bookQueryPort;
+    @Mock BookCommandPort bookCommandPort;
+    @Mock AladinApiClient aladinApiClient;
+    @Mock DiscordClient discordClient;
+
+    @InjectMocks BookPageCountFillService sut;
+
+    private Book bookWithIsbn(String isbn) {
+        return Book.builder()
+                .isbn(isbn)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("업데이트 대상 없음")
+    class WhenNoBooksToUpdate {
+
+        @Test
+        @DisplayName("조회된 book이 없으면 API 호출 없이 조기 종료한다")
+        void fillNullPageCounts_emptyList_noApiCallsNorDiscordAlert() {
+            given(bookQueryPort.findBooksWithNullPageCountLinkedToRooms()).willReturn(List.of());
+
+            sut.fillNullPageCounts();
+
+            then(aladinApiClient).shouldHaveNoInteractions();
+            then(discordClient).shouldHaveNoInteractions();
+            then(bookCommandPort).shouldHaveNoInteractions();
+        }
+    }
+
+    @Nested
+    @DisplayName("알라딘 API 성공")
+    class WhenAladinApiSucceeds {
+
+        @Test
+        @DisplayName("pageCount를 정상 수신하면 book을 업데이트하고 Discord 성공 알림을 보낸다")
+        void fillNullPageCounts_success_updatesPageCountAndNotifiesDiscord() {
+            Book book = bookWithIsbn("9788966261024");
+            given(bookQueryPort.findBooksWithNullPageCountLinkedToRooms()).willReturn(List.of(book));
+            given(aladinApiClient.findPageCountByIsbn("9788966261024")).willReturn(300);
+
+            sut.fillNullPageCounts();
+
+            then(bookCommandPort).should().updateForPageCount(book);
+            then(bookCommandPort).should(never()).updateForUnfindable(any());
+            then(discordClient).should().sendPageCountFillResult(1, 1, 0, 0);
+        }
+    }
+
+    @Nested
+    @DisplayName("알라딘 API 영구 실패 (ISBN 미등록)")
+    class WhenIsbnNotFound {
+
+        @Test
+        @DisplayName("ISBN_NOT_FOUND면 unfindable 처리하고 Discord 미등록 알림을 보낸다")
+        void fillNullPageCounts_isbnNotFound_marksAsUnfindableAndNotifiesDiscord() {
+            Book book = bookWithIsbn("0000000000000");
+            given(bookQueryPort.findBooksWithNullPageCountLinkedToRooms()).willReturn(List.of(book));
+            given(aladinApiClient.findPageCountByIsbn("0000000000000"))
+                    .willThrow(new ExternalApiException(BOOK_ALADIN_API_ISBN_NOT_FOUND));
+
+            sut.fillNullPageCounts();
+
+            then(bookCommandPort).should().updateForUnfindable(book);
+            then(bookCommandPort).should(never()).updateForPageCount(any());
+            then(discordClient).should().sendPageCountFillResult(1, 0, 1, 0);
+        }
+    }
+
+    @Nested
+    @DisplayName("알라딘 API 일시 장애 (재시도 예정)")
+    class WhenTransientFailure {
+
+        @Test
+        @DisplayName("파싱 오류(ExternalApiException)면 DB 업데이트 없이 Discord 일시실패 알림을 보낸다")
+        void fillNullPageCounts_parsingError_skipsDbUpdateAndNotifiesDiscord() {
+            Book book = bookWithIsbn("9788966261024");
+            given(bookQueryPort.findBooksWithNullPageCountLinkedToRooms()).willReturn(List.of(book));
+            given(aladinApiClient.findPageCountByIsbn("9788966261024"))
+                    .willThrow(new ExternalApiException(BOOK_ALADIN_API_PARSING_ERROR));
+
+            sut.fillNullPageCounts();
+
+            then(bookCommandPort).shouldHaveNoInteractions();
+            then(discordClient).should().sendPageCountFillResult(1, 0, 0, 1);
+        }
+
+        @Test
+        @DisplayName("네트워크 타임아웃(ResourceAccessException)이면 DB 업데이트 없이 Discord 일시실패 알림을 보낸다")
+        void fillNullPageCounts_networkTimeout_skipsDbUpdateAndNotifiesDiscord() {
+            Book book = bookWithIsbn("9788966261024");
+            given(bookQueryPort.findBooksWithNullPageCountLinkedToRooms()).willReturn(List.of(book));
+            given(aladinApiClient.findPageCountByIsbn("9788966261024"))
+                    .willThrow(new ResourceAccessException("Read timed out"));
+
+            sut.fillNullPageCounts();
+
+            then(bookCommandPort).shouldHaveNoInteractions();
+            then(discordClient).should().sendPageCountFillResult(1, 0, 0, 1);
+        }
+    }
+
+    @Nested
+    @DisplayName("혼합 케이스")
+    class WhenMixedResults {
+
+        @Test
+        @DisplayName("성공/미등록/일시실패가 섞이면 Discord에 각 케이스별 정확한 카운트를 전달한다")
+        void fillNullPageCounts_mixedResults_discordReceivesCorrectCounts() {
+            Book successBook = bookWithIsbn("1111111111111");
+            Book unfindableBook = bookWithIsbn("2222222222222");
+            Book transientBook = bookWithIsbn("3333333333333");
+
+            given(bookQueryPort.findBooksWithNullPageCountLinkedToRooms())
+                    .willReturn(List.of(successBook, unfindableBook, transientBook));
+            given(aladinApiClient.findPageCountByIsbn("1111111111111")).willReturn(250);
+            given(aladinApiClient.findPageCountByIsbn("2222222222222"))
+                    .willThrow(new ExternalApiException(BOOK_ALADIN_API_ISBN_NOT_FOUND));
+            given(aladinApiClient.findPageCountByIsbn("3333333333333"))
+                    .willThrow(new ResourceAccessException("Read timed out"));
+
+            sut.fillNullPageCounts();
+
+            then(bookCommandPort).should().updateForPageCount(successBook);
+            then(bookCommandPort).should().updateForUnfindable(unfindableBook);
+            then(bookCommandPort).should(never()).updateForPageCount(unfindableBook);
+            then(bookCommandPort).should(never()).updateForUnfindable(transientBook);
+            then(discordClient).should().sendPageCountFillResult(3, 1, 1, 1);
+        }
+    }
+}

--- a/src/test/java/konkuk/thip/room/application/service/RoomCreateServiceTest.java
+++ b/src/test/java/konkuk/thip/room/application/service/RoomCreateServiceTest.java
@@ -1,0 +1,234 @@
+package konkuk.thip.room.application.service;
+
+import konkuk.thip.book.application.port.out.BookApiQueryPort;
+import konkuk.thip.book.application.port.out.BookCommandPort;
+import konkuk.thip.book.domain.Book;
+import konkuk.thip.common.exception.ExternalApiException;
+import konkuk.thip.room.application.port.in.dto.RoomCreateCommand;
+import konkuk.thip.room.application.port.out.RoomCommandPort;
+import konkuk.thip.room.application.port.out.RoomParticipantCommandPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static konkuk.thip.common.exception.code.ErrorCode.BOOK_NAVER_API_REQUEST_ERROR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("[단위] 방 생성 서비스 단위 테스트")
+class RoomCreateServiceTest {
+
+    private RoomCommandPort roomCommandPort;
+    private RoomParticipantCommandPort roomParticipantCommandPort;
+    private BookCommandPort bookCommandPort;
+    private BookApiQueryPort bookApiQueryPort;
+    private TransactionTemplate transactionTemplate;
+    private RoomCreateService roomCreateService;
+
+    private static final Long USER_ID = 1L;
+    private static final Long BOOK_ID = 10L;
+    private static final Long ROOM_ID = 100L;
+    private static final String ISBN = "9791168342941";
+
+    @BeforeEach
+    void setUp() {
+        roomCommandPort = mock(RoomCommandPort.class);
+        roomParticipantCommandPort = mock(RoomParticipantCommandPort.class);
+        bookCommandPort = mock(BookCommandPort.class);
+        bookApiQueryPort = mock(BookApiQueryPort.class);
+        transactionTemplate = mock(TransactionTemplate.class);
+
+        roomCreateService = new RoomCreateService(
+                roomCommandPort,
+                roomParticipantCommandPort,
+                bookCommandPort,
+                bookApiQueryPort,
+                transactionTemplate
+        );
+
+        // TransactionTemplate mock: 콜백을 직접 실행
+        given(transactionTemplate.execute(any())).willAnswer(invocation -> {
+            TransactionCallback<?> callback = invocation.getArgument(0);
+            return callback.doInTransaction(null);
+        });
+
+        given(roomCommandPort.save(any())).willReturn(ROOM_ID);
+    }
+
+    private RoomCreateCommand createCommand() {
+        return new RoomCreateCommand(
+                ISBN, "문학", "방이름", "방설명",
+                LocalDate.now().plusDays(1),
+                LocalDate.now().plusDays(10),
+                3, null, true
+        );
+    }
+
+    private Book bookWithPage() {
+        return Book.builder()
+                .id(BOOK_ID).title("제목").isbn(ISBN).authorName("저자")
+                .bestSeller(false).publisher("출판사").imageUrl("img.jpg")
+                .pageCount(296).description("설명").build();
+    }
+
+    private Book bookWithoutPage() {
+        return Book.builder()
+                .id(BOOK_ID).title("제목").isbn(ISBN).authorName("저자")
+                .bestSeller(false).publisher("출판사").imageUrl("img.jpg")
+                .pageCount(null).description("설명").build();
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────────
+    // Case A: DB에 pageCount 있는 Book 존재
+    // ────────────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("DB에 pageCount가 있는 Book이 존재하는 경우")
+    class CaseA {
+
+        @Test
+        @DisplayName("외부 API 호출 없이 방이 생성된다")
+        void createRoom_bookWithPageExists_noApiCall() {
+            // given
+            given(bookCommandPort.findByIsbn(ISBN)).willReturn(Optional.of(bookWithPage()));
+
+            // when
+            Long roomId = roomCreateService.createRoom(createCommand(), USER_ID);
+
+            // then
+            assertThat(roomId).isEqualTo(ROOM_ID);
+            then(bookApiQueryPort).should(never()).findPageCountByIsbn(any());
+            then(bookApiQueryPort).should(never()).loadBookWithPageByIsbn(any());
+            then(roomCommandPort).should().save(any());
+            then(roomParticipantCommandPort).should().save(any());
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────────
+    // Case B: DB에 pageCount 없는 Book 존재
+    // ────────────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("DB에 pageCount가 없는 Book이 존재하는 경우")
+    class CaseB {
+
+        @Test
+        @DisplayName("알라딘 API 성공 시 pageCount가 업데이트되고 방이 생성된다")
+        void createRoom_aladinSuccess_pageCountUpdated() {
+            // given
+            given(bookCommandPort.findByIsbn(ISBN)).willReturn(Optional.of(bookWithoutPage()));
+            given(bookApiQueryPort.findPageCountByIsbn(ISBN)).willReturn(296);
+
+            // when
+            Long roomId = roomCreateService.createRoom(createCommand(), USER_ID);
+
+            // then
+            assertThat(roomId).isEqualTo(ROOM_ID);
+            then(bookCommandPort).should().updateForPageCount(any());
+            then(roomCommandPort).should().save(any());
+        }
+
+        @Test
+        @DisplayName("알라딘 API 실패(null 반환) 시 pageCount 업데이트 없이 방이 생성된다")
+        void createRoom_aladinFail_roomCreatedWithNullPage() {
+            // given
+            given(bookCommandPort.findByIsbn(ISBN)).willReturn(Optional.of(bookWithoutPage()));
+            given(bookApiQueryPort.findPageCountByIsbn(ISBN)).willReturn(null); // 알라딘 실패
+
+            // when
+            Long roomId = roomCreateService.createRoom(createCommand(), USER_ID);
+
+            // then: pageCount 업데이트 없이 방 생성 계속 진행
+            assertThat(roomId).isEqualTo(ROOM_ID);
+            then(bookCommandPort).should(never()).updateForPageCount(any());
+            then(roomCommandPort).should().save(any());
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────────
+    // Case C: DB에 Book 없음
+    // ────────────────────────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("DB에 Book이 없는 경우")
+    class CaseC {
+
+        @Test
+        @DisplayName("네이버 + 알라딘 API 성공 시 Book이 저장되고 방이 생성된다")
+        void createRoom_bookNotExist_savedAndRoomCreated() {
+            // given
+            given(bookCommandPort.findByIsbn(ISBN)).willReturn(Optional.empty());
+            given(bookApiQueryPort.loadBookWithPageByIsbn(ISBN)).willReturn(bookWithPage());
+            given(bookCommandPort.save(any())).willReturn(BOOK_ID);
+            given(roomCommandPort.save(any())).willReturn(ROOM_ID);
+
+            // when
+            Long roomId = roomCreateService.createRoom(createCommand(), USER_ID);
+
+            // then
+            assertThat(roomId).isEqualTo(ROOM_ID);
+            then(bookCommandPort).should().save(any());
+            then(roomCommandPort).should().save(any());
+        }
+
+        @Test
+        @DisplayName("알라딘 API 실패 시 pageCount=null인 Book이 저장되고 방이 생성된다")
+        void createRoom_aladinFail_bookSavedWithNullPageAndRoomCreated() {
+            // given
+            Book bookNullPage = Book.withoutId("제목", ISBN, "저자", false, "출판사", "img.jpg", null, "설명");
+            given(bookCommandPort.findByIsbn(ISBN)).willReturn(Optional.empty());
+            given(bookApiQueryPort.loadBookWithPageByIsbn(ISBN)).willReturn(bookNullPage); // 알라딘 실패 → null pageCount
+            given(bookCommandPort.save(any())).willReturn(BOOK_ID);
+            given(roomCommandPort.save(any())).willReturn(ROOM_ID);
+
+            // when
+            Long roomId = roomCreateService.createRoom(createCommand(), USER_ID);
+
+            // then: Book은 저장되고 방 생성도 계속 진행
+            assertThat(roomId).isEqualTo(ROOM_ID);
+            then(bookCommandPort).should().save(any());
+            then(roomCommandPort).should().save(any());
+        }
+
+        @Test
+        @DisplayName("네이버 API 장애 시 방 생성이 실패한다")
+        void createRoom_naverFail_throwsException() {
+            // given
+            given(bookCommandPort.findByIsbn(ISBN)).willReturn(Optional.empty());
+            given(bookApiQueryPort.loadBookWithPageByIsbn(ISBN))
+                    .willThrow(new ExternalApiException(BOOK_NAVER_API_REQUEST_ERROR));
+
+            // when & then: 예외 전파 → 방 생성 실패
+            assertThatThrownBy(() -> roomCreateService.createRoom(createCommand(), USER_ID))
+                    .isInstanceOf(ExternalApiException.class);
+
+            then(bookCommandPort).should(never()).save(any());
+            then(roomCommandPort).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("동일 ISBN 동시 요청으로 저장 충돌 시 기존 Book을 재사용해 방이 생성된다")
+        void createRoom_concurrentSameIsbn_reuseExistingBook() {
+            // given
+            given(bookCommandPort.findByIsbn(ISBN)).willReturn(Optional.empty());
+            given(bookApiQueryPort.loadBookWithPageByIsbn(ISBN)).willReturn(bookWithPage());
+            // 첫 번째 save: 동시 요청으로 이미 저장된 Book → DataIntegrityViolationException
+            given(bookCommandPort.save(any())).willThrow(new DataIntegrityViolationException("duplicate key"));
+            // 재조회 시 이미 저장된 Book 반환
+            given(bookCommandPort.findByIsbn(ISBN)).willReturn(Optional.empty(), Optional.of(bookWithPage()));
+            given(roomCommandPort.save(any())).willReturn(ROOM_ID);
+
+            // when
+            Long roomId = roomCreateService.createRoom(createCommand(), USER_ID);
+
+            // then: 예외 없이 방 생성 성공
+            assertThat(roomId).isEqualTo(ROOM_ID);
+            then(roomCommandPort).should().save(any());
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #294 

## 📝 작업 내용
외부 API(Naver, Aladin) 지연이 내부 시스템 자원(DB 커넥션, 톰캣 쓰레드) 고갈로 이어지는 연쇄 장애(Cascading Failure)를 차단하고, 방 생성 도메인의 가용성을 확보하기 위해 아키텍처를 개선했습니다.

### 트랜잭션 경계 분리 및 타임아웃 적용
* `@Transactional`을 제거하고 `TransactionTemplate`을 도입하여 외부 API 호출 구간을 DB 트랜잭션 밖으로 분리
* `RestTemplate` 및 `WebClient`에 명시적 Timeout(Connect 3s, Read 5s) 설정

### 도메인 특성을 반영한 장애 격리 (Fault Isolation)
* 부가 정보인 Aladin API 장애 시 예외를 전파하지 않고 `pageCount = null`로 격리하여 방 생성 속행(Fail-soft)
* Aladin API 실패 내역은 방 생성 지연을 막기 위해 Discord 비동기(`subscribe()`) 알림 전송

### 최종적 일관성(Eventual Consistency) 보장
* 매일 03:00 실행되는 `BookPageCountFillScheduler` 도입으로 누락된 `pageCount` 복구 (외부 API 쓰로틀링 적용)
* 알라딘 미등록 도서(`ISBN_NOT_FOUND`)는 `pageCountUnfindable = true` 플래그로 업데이트하여 무의미한 API 반복 호출(좀비 프로세스) 영구 차단

### 동시성 예외 제어
* 동일 ISBN 동시 요청 시 발생하는 `DataIntegrityViolationException` 예외를 캐치하여 기존 데이터 재조회로 처리

## 📸 스크린샷
<img width="672" height="375" alt="image" src="https://github.com/user-attachments/assets/04041530-5d20-4ded-b3ee-9ef555bb5fa8" />

## 💬 리뷰 요구사항
- `TransactionTemplate` 내부로 묶인 DB 쓰기 작업의 트랜잭션 경계가 적절히 최소화되었는지 검토 바랍니다.
- pageCount = null 인 데이터를 백그라운드에서 업데이트하는 스케줄러가 적절히 구현되었는지 검토 바랍니다.
- Discord 에러 알림이 동기(500 에러)와 비동기(알라딘 장애)로 목적에 맞게 분리되었는지, 쓰레드 블로킹 우려는 없는지 확인 바랍니다.

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 매일 오전 3시에 자동으로 누락된 책의 페이지 수를 채우는 스케줄러 추가
  * API 오류 발생 시 실시간 알림 시스템 강화

* **버그 수정**
  * API 요청 타임아웃 설정 추가 (응답 제한시간 5초)
  * 찾을 수 없는 책에 대한 체계적인 처리 개선
  * 동시 다중 요청으로 인한 중복 생성 문제 해결
  * 일시적 API 오류 재시도 로직 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->