### PR TITLE
[fix] @Validated 컨트롤러 파라미터 검증 실패 시 500 에러 반환 버그 수정

### DIFF
--- a/src/main/java/konkuk/thip/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/konkuk/thip/common/exception/handler/GlobalExceptionHandler.java
@@ -14,10 +14,12 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static konkuk.thip.common.exception.code.ErrorCode.*;
 import static konkuk.thip.common.logging.LoggingConstant.REQUEST_ID;
@@ -141,6 +143,21 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(API_SERVER_ERROR.getHttpStatus())
                 .body(ErrorResponse.of(API_SERVER_ERROR));
+    }
+
+    // Spring 6.1+ @Validated 컨트롤러 파라미터 검증 실패 예외처리
+    @ExceptionHandler(HandlerMethodValidationException.class)
+    public ResponseEntity<ErrorResponse> handlerMethodValidationExceptionHandler(HandlerMethodValidationException e) {
+        log.warn("[HandlerMethodValidationExceptionHandler] {}", e.getMessage());
+        String errorMessage = Stream.concat(e.getBeanResults().stream(), e.getValueResults().stream())
+                .flatMap(result -> result.getResolvableErrors().stream())
+                .findFirst()
+                .map(error -> error.getDefaultMessage())
+                .orElse("유효성 검사에 실패했습니다.");
+
+        return ResponseEntity
+                .status(API_INVALID_PARAM.getHttpStatus())
+                .body(ErrorResponse.of(API_INVALID_PARAM, errorMessage));
     }
 
     // @validation 예외처리


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

**문제**
Spring Boot 3.x (Spring Framework 6.1+)에서 @Validated 컨트롤러의
@PathVariable @Pattern 검증 실패 시 HandlerMethodValidationException이 발생하지만
GlobalExceptionHandler에 해당 핸들러가 없어 handleServerErrors(RuntimeException)로
떨어져 500을 반환하던 문제

**원인**
Spring 6.1+에서 컨트롤러 메서드 파라미터 검증 실패 시
기존 ConstraintViolationException 대신 HandlerMethodValidationException을 던지도록 변경됨
기존 핸들러는 ConstraintViolationException만 처리하고 있었음

--> HandlerMethodValidationException 전용 핸들러 추가 → 400 반환

## 📸 스크린샷

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 요청 파라미터 검증 실패 시 더 명확하고 일관된 오류 메시지를 제공하도록 개선했습니다. 이제 검증 오류 발생 시 사용자가 더 쉽게 문제를 파악할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->