### PR TITLE
[chore] 운영 서버 종료 및 개발 서버 단일화

### DIFF
--- a/.github/workflows/cd-workflow-dev.yml
+++ b/.github/workflows/cd-workflow-dev.yml
@@ -31,7 +31,7 @@ jobs:
       - name: 🧾 Create application.yml from secret (base64)
         run: |
           mkdir -p ${{ env.RESOURCE_PATH }}
-          echo "${{ secrets.APPLICATION_YML_DEV }}" | base64 --decode > ${{ env.RESOURCE_PATH }}/application.yml
+          echo "${{ secrets.APPLICATION_YML_PROD }}" | base64 --decode > ${{ env.RESOURCE_PATH }}/application.yml
         shell: bash
 
       - name: 🔐 Create Firebase Key from secret (base64)
@@ -73,16 +73,11 @@ jobs:
           script: |
             echo "🗂️ Change Directory to Compose Path"
             cd ${{ env.COMPOSE_PATH }}
-            
-            echo "✋🏻Stopping existing container and Cleaning up old images"
-            sudo docker-compose stop ${{ secrets.DOCKER_IMAGE }}
-            sudo docker rm -f ${{ secrets.DOCKER_IMAGE }}
-            
+
             sudo docker ps -a
-            
+
             echo "🥳 Pulling new image"
             sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_IMAGE }}
-            
-            echo "🌱 Starting new container"
-            sudo docker-compose up -d
-            sudo docker image prune -a -f
+
+            echo "🚀 Run Blue-Green Deploy Script"
+            sudo bash deploy.sh


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #이슈번호

## 📝 작업 내용
운영 서버를 종료하고 개발 서버 하나로 통합
도메인을 변경하고, 개발 서버에 블루그린 무중단 배포를 적용

### 변경 사항
- cd-workflow-dev.yml: APPLICATION_YML_DEV → APPLICATION_YML_PROD로 변경
- cd-workflow-dev.yml: docker-compose up 단순 배포 → deploy.sh 블루그린 배포로 변경

### EC2 직접 작업 내역
- docker-compose.yml: 단일 컨테이너 → green/blue 2개로 변경
- deploy.sh 생성 (블루그린 배포 스크립트)
- nginx 설정:SSL 인증서 발급 및 설정
- 보안 그룹 80/443 포트 오픈

## 📸 스크린샷

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 배포 방식이 개선되어 서비스 업데이트 시 중단 시간이 줄어들 수 있습니다.
* **버그 수정**
  * 배포 과정에서 기존 방식보다 더 안정적으로 새 버전을 반영하도록 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->