### PR TITLE
[FEAT]  iOS FCM 푸시 알림 지원 추가

### DIFF
--- a/src/main/java/konkuk/thip/message/application/service/FeedNotificationDispatchService.java
+++ b/src/main/java/konkuk/thip/message/application/service/FeedNotificationDispatchService.java
@@ -1,5 +1,7 @@
 package konkuk.thip.message.application.service;
 
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 import konkuk.thip.message.application.port.in.FeedNotificationDispatchUseCase;
@@ -74,6 +76,7 @@ public class FeedNotificationDispatchService implements FeedNotificationDispatch
                     .putData("category", NotificationCategory.FEED.getDisplay())
                     .putData("action", "OPEN_NOTIFICATION") // FE는 이 액션으로 알림 상세/라우팅을 BE api 요청으로 처리
                     .putData("notificationId", String.valueOf(notificationId))
+                    .setApnsConfig(buildApnsConfig())
                     .build();
 
             msgs.add(m);
@@ -86,5 +89,11 @@ public class FeedNotificationDispatchService implements FeedNotificationDispatch
 
     private Notification buildFcmNotification(final String title, final String body) {
         return Notification.builder().setTitle(title).setBody(body).build();
+    }
+
+    private ApnsConfig buildApnsConfig() {
+        return ApnsConfig.builder()
+                .setAps(Aps.builder().setSound("default").build())
+                .build();
     }
 }

--- a/src/main/java/konkuk/thip/message/application/service/RoomNotificationDispatchService.java
+++ b/src/main/java/konkuk/thip/message/application/service/RoomNotificationDispatchService.java
@@ -1,5 +1,7 @@
 package konkuk.thip.message.application.service;
 
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 import konkuk.thip.message.application.port.in.RoomNotificationDispatchUseCase;
@@ -86,6 +88,7 @@ public class RoomNotificationDispatchService implements RoomNotificationDispatch
                     .putData("category", NotificationCategory.ROOM.getDisplay())
                     .putData("action", "OPEN_NOTIFICATION") // FE는 이 액션으로 알림 상세/라우팅을 BE api 요청으로 처리
                     .putData("notificationId", String.valueOf(notificationId))
+                    .setApnsConfig(buildApnsConfig())
                     .build();
             msgs.add(m); tk.add(t.getFcmToken()); dev.add(t.getDeviceId());
         }
@@ -97,6 +100,12 @@ public class RoomNotificationDispatchService implements RoomNotificationDispatch
         return Notification.builder()
                 .setTitle(title)
                 .setBody(body)
+                .build();
+    }
+
+    private ApnsConfig buildApnsConfig() {
+        return ApnsConfig.builder()
+                .setAps(Aps.builder().setSound("default").build())
                 .build();
     }
 }

--- a/src/main/java/konkuk/thip/notification/adapter/in/web/request/FcmTokenRegisterRequest.java
+++ b/src/main/java/konkuk/thip/notification/adapter/in/web/request/FcmTokenRegisterRequest.java
@@ -16,7 +16,7 @@ public record FcmTokenRegisterRequest(
         String fcmToken,
 
         @NotBlank(message = "플랫폼 타입은 필수입니다.")
-        @Schema(description = "플랫폼 타입 (ANDROID 또는 WEB)", example = "ANDROID")
+        @Schema(description = "플랫폼 타입 (ANDROID, WEB 또는 IOS)", example = "ANDROID")
         String platformType
 ) {
     public FcmTokenRegisterCommand toCommand(Long userId) {

--- a/src/main/java/konkuk/thip/notification/domain/value/PlatformType.java
+++ b/src/main/java/konkuk/thip/notification/domain/value/PlatformType.java
@@ -10,7 +10,8 @@ import static konkuk.thip.common.exception.code.ErrorCode.INVALID_FE_PLATFORM;
 @RequiredArgsConstructor
 public enum PlatformType {
     ANDROID("ANDROID"),
-    WEB("WEB");
+    WEB("WEB"),
+    IOS("IOS");
 
     private final String value;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #363

## 📝 작업 내용

- `PlatformType`에 `IOS` 추가
- FCM 메시지 빌드 시 `ApnsConfig(sound: default)` 적용하여 iOS 알림 소리 지원
- Android/Web 토큰은 FCM이 `ApnsConfig` 무시하므로 분기 처리 불필요


## 📸 스크린샷

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * iOS 플랫폼을 알림 대상에 추가했습니다.
  * iOS 푸시 알림에서 기본 알림음이 재생됩니다.

* **문서**
  * 플랫폼 유형 안내에 iOS가 포함되도록 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->